### PR TITLE
ci(release): port client release steps from monorepo (CLI build secrets, nx manifest, sync_gosum PR)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,9 +55,20 @@ jobs:
           git tag "toolbox-api-client-go/$VERSION"
           git tag "sdk-go/$VERSION"
           git push origin "api-client-go/$VERSION" "toolbox-api-client-go/$VERSION" "sdk-go/$VERSION"
+      - name: Write dummy manifest for nx release
+        run: |
+          mkdir -p dist
+          printf '{ "name": "clients", "version": "0.0.0" }\n' > dist/package.json
       - name: Create release
         run: yarn nx release "$VERSION" --skip-publish --verbose
       - name: Build CLI
+        env:
+          DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
+          DAYTONA_AUTH0_DOMAIN: ${{ secrets.DAYTONA_AUTH0_DOMAIN }}
+          DAYTONA_AUTH0_CLIENT_ID: ${{ secrets.DAYTONA_AUTH0_CLIENT_ID }}
+          DAYTONA_AUTH0_CLIENT_SECRET: ${{ secrets.DAYTONA_AUTH0_CLIENT_SECRET }}
+          DAYTONA_AUTH0_CALLBACK_PORT: ${{ secrets.DAYTONA_AUTH0_CALLBACK_PORT }}
+          DAYTONA_AUTH0_AUDIENCE: ${{ secrets.DAYTONA_AUTH0_AUDIENCE }}
         run: |
           cd ./cli
           GOOS=linux GOARCH=amd64 ./hack/build.sh --skip-env-file
@@ -82,6 +93,56 @@ jobs:
           tar -czf "sdk-docs-${VERSION}.tar.gz" -C artifacts sdk-docs
       - name: Upload SDK docs to release assets
         run: gh release upload "$VERSION" "sdk-docs-${VERSION}.tar.gz" --clobber
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          git config --global --fixed-value --unset-all user.name "Daytona Release Bot" 2>/dev/null || true
+          git config --global --fixed-value --unset-all user.email "daytona-release@users.noreply.github.com" 2>/dev/null || true
+          git config --global --fixed-value --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true
+
+  sync_gosum:
+    needs: release
+    if: github.repository == 'daytona/clients'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: go.work
+      - uses: ./.github/actions/install-gh-cli
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global user.name "Daytona Release Bot"
+          git config --global user.email "daytona-release@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
+      - name: Sync go.sum and create PR
+        run: |
+          git checkout -b "sync-gosum-$VERSION"
+          GONOSUMDB=go.daytona.io go work sync
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No go workspace changes detected; skipping commit and PR creation."
+          else
+            git commit -s -m "chore: sync go.sum for $VERSION"
+            git push origin "sync-gosum-$VERSION"
+            gh pr create \
+              --title "chore: sync go.sum for $VERSION" \
+              --body "Automated PR to sync go.sum after release $VERSION" \
+              --base main \
+              --head "sync-gosum-$VERSION"
+          fi
       - name: Cleanup credentials
         if: always()
         run: |


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytona/codesmith/clients/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785021676&installation_id=142518896&pr_number=12&repository=daytona%2Fclients&return_to=https%3A%2F%2Fgithub.com%2Fdaytona%2Fclients%2Fpull%2F12&signature=05fed501c61cc8cd8d942a5988c8acf3c3c23b45f550dbd62fe58fc474292383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the release pipeline with the monorepo by adding CLI build support, generating an `nx` manifest, and auto-syncing `go.sum` with a follow-up PR when needed.

- New Features
  - Injects CLI build secrets (`DAYTONA_API_URL`, `DAYTONA_AUTH0_*`) into the release job.
  - Generates a minimal `dist/package.json` (name `clients`, version `0.0.0`) so `nx release` can run.
  - Adds a `sync_gosum` job that runs `go work sync` post-release and opens a PR if any `go.sum` files change.
  - Configures git credential setup and cleanup for safe, automated pushes.

<sup>Written for commit 769556c3766851f5bdbb832db3eb38b1b1ca65e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

