### PR TITLE
fix(release): fall back to disk version + make Go tagging idempotent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,10 +51,14 @@ jobs:
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
       - name: Tag Go modules
         run: |
-          git tag "api-client-go/$VERSION"
-          git tag "toolbox-api-client-go/$VERSION"
-          git tag "sdk-go/$VERSION"
-          git push origin "api-client-go/$VERSION" "toolbox-api-client-go/$VERSION" "sdk-go/$VERSION"
+          for mod in api-client-go toolbox-api-client-go sdk-go; do
+            if git ls-remote --exit-code --tags origin "refs/tags/$mod/$VERSION" >/dev/null 2>&1; then
+              echo "Tag $mod/$VERSION already exists on origin; skipping."
+            else
+              git tag "$mod/$VERSION"
+              git push origin "$mod/$VERSION"
+            fi
+          done
       - name: Write dummy manifest for nx release
         run: |
           mkdir -p dist

--- a/nx.json
+++ b/nx.json
@@ -177,7 +177,8 @@
     },
     "version": {
       "manifestRootsToUpdate": ["dist"],
-      "conventionalCommits": true
+      "conventionalCommits": true,
+      "fallbackCurrentVersionResolver": "disk"
     },
     "conventionalCommits": {
       "types": {


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytona/codesmith/clients/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785087685&installation_id=142518896&pr_number=16&repository=daytona%2Fclients&return_to=https%3A%2F%2Fgithub.com%2Fdaytona%2Fclients%2Fpull%2F16&signature=cd552d7936c35ee80c09a4937b70fe0736d8394d25031412d9b6e729e5487c8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the release pipeline more resilient by making Go module tagging idempotent and using a disk-based version fallback for `nx release`. This reduces failures on re-runs and in shallow clone CI.

- **Bug Fixes**
  - Tagging for `api-client-go`, `toolbox-api-client-go`, and `sdk-go` now checks origin with `git ls-remote` and only creates/pushes missing tags.
  - Set `nx` `fallbackCurrentVersionResolver` to `disk` so versioning works without git tags or history.

<sup>Written for commit bd29a94266442efb664f4e3408bfd0f174a172fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

