### PR TITLE
chore: changelog automaticFromRef for releases without a reachable base tag

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -170,6 +170,7 @@
   "release": {
     "projects": ["sdk-typescript", "sdk-python", "api-client", "toolbox-api-client", "analytics-api-client"],
     "changelog": {
+      "automaticFromRef": true,
       "workspaceChangelog": {
         "file": false,
         "createRelease": "github"


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytona/codesmith/clients/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785088281&installation_id=142518896&pr_number=17&repository=daytona%2Fclients&return_to=https%3A%2F%2Fgithub.com%2Fdaytona%2Fclients%2Fpull%2F17&signature=c195022f36297af000ddfeced51c84b02d679e15402549426c27a3acafdfa126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `nx` release changelog `automaticFromRef` in `nx.json` so release notes generate when the base tag isn’t reachable. Uses the current ref as the base to prevent empty or failed changelogs in CI and shallow clones.

<sup>Written for commit 25bcfebbc12afff16c34e47cf495e191cfb16bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

