### PR TITLE
chore: align package license metadata with repo dual-license

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daytona",
   "version": "0.0.0-dev",
-  "license": "UNLICENSED",
+  "license": "SEE LICENSE IN LICENSE",
   "private": true,
   "scripts": {
     "postinstall": "is-ci || husky",

--- a/sdk-ruby/daytona.gemspec
+++ b/sdk-ruby/daytona.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = 'Ruby SDK for Daytona'
   spec.description = 'High-level Ruby SDK for Daytona: sandboxes, git, filesystem, LSP, process, and object storage.'
   spec.homepage = 'https://github.com/daytona/clients'
+  spec.license = 'Apache-2.0'
   spec.required_ruby_version = '>= 3.2.0'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'


### PR DESCRIPTION
## What

Align package-manifest license metadata with the repository's actual dual-license (`cli/` = AGPL-3.0, everything else = Apache-2.0).

- **Root `package.json`**: `"UNLICENSED"` -> `"SEE LICENSE IN LICENSE"`. The npm `UNLICENSED` token reads as "proprietary," which is inaccurate for a public, open-source repo. The root workspace stays `"private": true`, so there is no change to publish behavior; this is a metadata-accuracy fix only.
- **`sdk-ruby/daytona.gemspec`**: add `spec.license = 'Apache-2.0'`. The gem sets `allowed_push_host = rubygems.org` (it is published) but declared no license. The other SDKs (`sdk-typescript`, `sdk-python`) already declare Apache-2.0.

## Why

Metadata consistency. No code, SPDX headers, or LICENSE files change; the headers and `LICENSE` / `cli/LICENSE` / `LICENSES/` are already correct and consistent. GitHub will continue to show the repo license as "Other" (expected for a custom per-directory dual-license).

## Scope

Two lines, metadata only. No functional impact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytona/codesmith/clients/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785570832&installation_id=142518896&pr_number=31&repository=daytona%2Fclients&return_to=https%3A%2F%2Fgithub.com%2Fdaytona%2Fclients%2Fpull%2F31&signature=c153c0438ccf5a4e559282c52456a9e125abf4977a8353a6a170b72a8ceeb820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align license metadata with the repo’s dual-license by changing the root `package.json` license to `SEE LICENSE IN LICENSE` and adding `Apache-2.0` to `sdk-ruby/daytona.gemspec`. Metadata-only; no code or publish behavior changes.

<sup>Written for commit a479bb7a890c7c9f6c7982f3659859bd9c6b46d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

