### PR TITLE
fix(cli): normalize Auth0 issuer in release builds

### DIFF
--- a/cli/hack/build.sh
+++ b/cli/hack/build.sh
@@ -83,6 +83,12 @@ if [ ${#MISSING_VARS[@]} -ne 0 ]; then
     exit 1
 fi
 
+# Auth0's discovery issuer ends in a single trailing slash, and go-oidc compares
+# the configured issuer against it exactly. Collapse any trailing slashes to one
+# so a value entered with none or several still matches.
+shopt -s extglob
+DAYTONA_AUTH0_DOMAIN="${DAYTONA_AUTH0_DOMAIN%%+(/)}/"
+
 # Create build directory if it doesn't exist
 mkdir -p "${DIST_DIR}/dist/cli"
 


### PR DESCRIPTION
## Description

Normalize the Auth0 issuer domain during CLI release builds so the value embedded via ldflags matches Auth0's OIDC discovery issuer exactly. This prevents `daytona login` from failing before the browser auth flow with a `go-oidc` issuer mismatch when the release secret omits the trailing slash.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #19

## Screenshots

Not relevant.

## Notes

Verified by building the CLI with `DAYTONA_AUTH0_DOMAIN=https://daytonaio.us.auth0.com` and confirming the produced binary embeds `https://daytonaio.us.auth0.com/`. Also verified that `oidc.NewProvider` fails with the unslashed issuer and succeeds with the slashed issuer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytona/codesmith/clients/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785598608&installation_id=142518896&pr_number=34&repository=daytona%2Fclients&return_to=https%3A%2F%2Fgithub.com%2Fdaytona%2Fclients%2Fpull%2F34&signature=de52c6b9bd6136f3caced15cdd10045cd3db3ea7da83eb5abf178669669d991e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize the Auth0 issuer domain in CLI release builds by collapsing trailing slashes to exactly one. This matches Auth0’s OIDC discovery issuer and prevents `go-oidc` mismatches that block `daytona login` (fixes #19).

<sup>Written for commit c5c7e9ced12c90645e302215d517a56bbcef8a7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

