### PR TITLE
fix(sdk-typescript): surface snapshot-from-sandbox capture failures

### DIFF
--- a/api-client-go/api/openapi.yaml
+++ b/api-client-go/api/openapi.yaml
@@ -2579,6 +2579,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/Sandbox"
           description: Snapshot creation has been initiated
+        "409":
+          description: A snapshot with this name already exists for the organization
       security:
       - bearer: []
       - oauth2:

--- a/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
@@ -521,6 +521,7 @@ public class SandboxApi {
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with this name already exists for the organization </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createSandboxSnapshotCall(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
@@ -603,6 +604,7 @@ public class SandboxApi {
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with this name already exists for the organization </td><td>  -  </td></tr>
      </table>
      */
     public Sandbox createSandboxSnapshot(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
@@ -623,6 +625,7 @@ public class SandboxApi {
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with this name already exists for the organization </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<Sandbox> createSandboxSnapshotWithHttpInfo(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
@@ -645,6 +648,7 @@ public class SandboxApi {
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with this name already exists for the organization </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createSandboxSnapshotAsync(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback<Sandbox> _callback) throws ApiException {

--- a/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
+++ b/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
@@ -963,6 +963,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -1037,6 +1038,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -1111,6 +1113,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = await self.api_client.call_api(
             *_param,

--- a/api-client-python/daytona_api_client/api/sandbox_api.py
+++ b/api-client-python/daytona_api_client/api/sandbox_api.py
@@ -963,6 +963,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -1037,6 +1038,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -1111,6 +1113,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = self.api_client.call_api(
             *_param,

--- a/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
@@ -69,7 +69,8 @@ new Sandbox(
    sandboxDto: SandboxListItem | Sandbox, 
    clientConfig: Configuration, 
    axiosInstance: AxiosInstance, 
-   sandboxApi: SandboxApi): Sandbox
+   sandboxApi: SandboxApi, 
+   snapshotsApi?: SnapshotsApi): Sandbox
 ```
 
 Creates a new Sandbox instance
@@ -80,6 +81,7 @@ Creates a new Sandbox instance
 - `clientConfig` _Configuration_
 - `axiosInstance` _AxiosInstance_
 - `sandboxApi` _SandboxApi_
+- `snapshotsApi?` _SnapshotsApi_
 
 
 **Returns**:
@@ -98,7 +100,9 @@ Creates a snapshot from the current state of the Sandbox.
 
 This captures the Sandbox's filesystem into a reusable snapshot that can be
 used to create new Sandboxes. The Sandbox will temporarily enter a
-'snapshotting' state and return to its previous state when complete.
+'snapshotting' state and return to its previous state when complete. The
+method waits until the snapshot record reaches the 'active' state and throws
+a DaytonaError carrying the snapshot's error reason if the capture fails.
 
 **Parameters**:
 

--- a/openapi-specs/api.json
+++ b/openapi-specs/api.json
@@ -3310,6 +3310,9 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "A snapshot with this name already exists for the organization"
           }
         },
         "security": [

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -235,6 +235,7 @@ export type CreateSandboxFromSnapshotParams = CreateSandboxBaseParams & {
 export class Daytona implements AsyncDisposable {
   private readonly clientConfig: Configuration
   private readonly sandboxApi: SandboxApi
+  private readonly snapshotsApi: SnapshotsApi
   private readonly objectStorageApi: ObjectStorageApi
   private readonly configApi: ConfigApi
   private readonly target?: string
@@ -331,16 +332,12 @@ export class Daytona implements AsyncDisposable {
     const axiosInstance = Daytona.createAxiosInstance()
 
     this.sandboxApi = new SandboxApi(configuration, '', axiosInstance)
+    this.snapshotsApi = new SnapshotsApi(configuration, '', axiosInstance)
     this.objectStorageApi = new ObjectStorageApi(configuration, '', axiosInstance)
     this.configApi = new ConfigApi(configuration, '', axiosInstance)
     this.volume = new VolumeService(new VolumesApi(configuration, '', axiosInstance))
     this.secret = new SecretService(new SecretApi(configuration, '', axiosInstance))
-    this.snapshot = new SnapshotService(
-      configuration,
-      new SnapshotsApi(configuration, '', axiosInstance),
-      this.objectStorageApi,
-      this.target,
-    )
+    this.snapshot = new SnapshotService(configuration, this.snapshotsApi, this.objectStorageApi, this.target)
     this.clientConfig = configuration
 
     const env = envReader()
@@ -633,6 +630,7 @@ export class Daytona implements AsyncDisposable {
         new Configuration(structuredClone(this.clientConfig)),
         Daytona.createAxiosInstance(),
         this.sandboxApi,
+        this.snapshotsApi,
       )
 
       if (sandbox.state !== 'started') {
@@ -673,6 +671,7 @@ export class Daytona implements AsyncDisposable {
       structuredClone(this.clientConfig),
       Daytona.createAxiosInstance(),
       this.sandboxApi,
+      this.snapshotsApi,
     )
   }
 
@@ -688,7 +687,7 @@ export class Daytona implements AsyncDisposable {
    * }
    */
   public list(query?: ListSandboxesQuery): AsyncIterableIterator<Sandbox> {
-    const { sandboxApi, clientConfig } = this
+    const { sandboxApi, snapshotsApi, clientConfig } = this
     const tracer = trace.getTracer('')
 
     async function* generator(): AsyncGenerator<Sandbox> {
@@ -759,7 +758,13 @@ export class Daytona implements AsyncDisposable {
 
         for (const sandbox of response.data.items) {
           // Sandbox ctor mutates clientConfig.basePath — clone per item.
-          yield new Sandbox(sandbox, structuredClone(clientConfig), Daytona.createAxiosInstance(), sandboxApi)
+          yield new Sandbox(
+            sandbox,
+            structuredClone(clientConfig),
+            Daytona.createAxiosInstance(),
+            sandboxApi,
+            snapshotsApi,
+          )
         }
 
         cursor = response.data.nextCursor ?? undefined

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SandboxState, SandboxApi, SandboxBackupStateEnum, Configuration } from '@daytona/api-client'
+import {
+  SandboxState,
+  SandboxApi,
+  SandboxBackupStateEnum,
+  Configuration,
+  SnapshotsApi,
+  SnapshotState,
+} from '@daytona/api-client'
 import type {
   Sandbox as SandboxDto,
   SandboxListItem as SandboxListItemDto,
@@ -18,6 +25,7 @@ import type {
   UpdateSandboxNetworkSettings,
   SandboxListSortField,
   SandboxListSortDirection,
+  SnapshotDto,
 } from '@daytona/api-client'
 import { Daytona } from './Daytona'
 import type { Resources } from './Daytona'
@@ -40,6 +48,20 @@ import { ComputerUse } from './ComputerUse'
 import type { AxiosInstance } from 'axios'
 import { CodeInterpreter } from './CodeInterpreter'
 import { WithInstrumentation } from './utils/otel.decorator'
+
+// "Legacy API" below means a server that inserts the snapshot record only
+// after a successful capture (instead of creating it up front when the
+// capture is accepted). Such servers restore the sandbox state before the
+// record lands, so the record can be briefly missing even for a capture
+// that succeeded. These constants control how many times the record is
+// re-polled after observing the reverted sandbox, and how far apart.
+const SNAPSHOT_GRACE_READ_ATTEMPTS = 3
+const SNAPSHOT_GRACE_READ_DELAY_MS = 500
+
+// Allowance for clock skew between this client and the API when deciding
+// whether a polled snapshot record predates the capture that is being
+// waited on (pre-existing same-name snapshot on a legacy API).
+const SNAPSHOT_CLOCK_SKEW_TOLERANCE_MS = 5 * 60 * 1000
 
 /**
  * Represents a Daytona Sandbox.
@@ -130,6 +152,7 @@ export class Sandbox {
   public toolboxProxyUrl: string
 
   private infoApi: InfoApi
+  private readonly snapshotsApi: SnapshotsApi
 
   /**
    * Creates a new Sandbox instance
@@ -141,7 +164,14 @@ export class Sandbox {
     private readonly clientConfig: Configuration,
     private readonly axiosInstance: AxiosInstance,
     private readonly sandboxApi: SandboxApi,
+    snapshotsApi?: SnapshotsApi,
   ) {
+    // clientConfig still targets the Daytona API at this point (it is repurposed
+    // for the toolbox below), so a default SnapshotsApi built from a copy of it
+    // polls the correct host when the caller does not provide one.
+    this.snapshotsApi =
+      snapshotsApi ?? new SnapshotsApi(new Configuration({ ...clientConfig }), '', Daytona.createAxiosInstance())
+
     this.processSandboxDto(sandboxDto)
 
     // Set the toolbox base URL
@@ -372,6 +402,7 @@ export class Sandbox {
       structuredClone(this.clientConfig),
       Daytona.createAxiosInstance(),
       this.sandboxApi,
+      this.snapshotsApi,
     )
 
     const timeElapsed = Date.now() - startTime
@@ -385,7 +416,9 @@ export class Sandbox {
    *
    * This captures the Sandbox's filesystem into a reusable snapshot that can be
    * used to create new Sandboxes. The Sandbox will temporarily enter a
-   * 'snapshotting' state and return to its previous state when complete.
+   * 'snapshotting' state and return to its previous state when complete. The
+   * method waits until the snapshot record reaches the 'active' state and throws
+   * a DaytonaError carrying the snapshot's error reason if the capture fails.
    *
    * @param {string} name - Name for the new snapshot
    * @param {number} [timeout] - Maximum time to wait in seconds. 0 means no timeout.
@@ -415,25 +448,73 @@ export class Sandbox {
 
     const timeElapsed = Date.now() - startTime
     const remainingTimeout = timeout ? Math.max(0.001, timeout - timeElapsed / 1000) : timeout
-    await this.waitForSnapshotComplete(remainingTimeout)
+    await this.waitForSnapshotComplete(name, remainingTimeout, new Date(startTime))
   }
 
-  private async waitForSnapshotComplete(timeout: number) {
+  private async waitForSnapshotComplete(name: string, timeout: number, initiatedAt: Date) {
     let checkInterval = 100
     const startTime = Date.now()
 
-    while (this.state === SandboxState.SNAPSHOTTING) {
-      await this.refreshData()
-
-      // @ts-expect-error this.refreshData() can modify this.state so this check is fine
-      if (this.state === SandboxState.ERROR || this.state === SandboxState.BUILD_FAILED) {
-        throw new DaytonaError(
-          `Sandbox ${this.id} snapshot failed with state: ${this.state}, error reason: ${this.errorReason}`,
-        )
+    while (true) {
+      let snapshot: SnapshotDto | undefined
+      try {
+        snapshot = (await this.snapshotsApi.getSnapshot(name)).data
+      } catch (error) {
+        if (!(error instanceof DaytonaNotFoundError)) {
+          throw error
+        }
+        // Legacy APIs create the snapshot record only after a successful capture.
+        // Tolerate the missing record while the sandbox is still snapshotting.
+        await this.refreshData()
+        if (this.state !== SandboxState.SNAPSHOTTING) {
+          // Legacy APIs persist the record and restore the sandbox state in separate
+          // steps, so a poll can observe the reverted sandbox before the record lands.
+          // Re-read a few times, spaced out, before declaring the capture failed.
+          for (let attempt = 1; !snapshot; attempt++) {
+            try {
+              snapshot = (await this.snapshotsApi.getSnapshot(name)).data
+            } catch (graceError) {
+              if (!(graceError instanceof DaytonaNotFoundError)) {
+                throw graceError
+              }
+              const timedOut = timeout !== 0 && Date.now() - startTime > timeout * 1000
+              if (attempt >= SNAPSHOT_GRACE_READ_ATTEMPTS || timedOut) {
+                throw new DaytonaError(
+                  `Sandbox ${this.id} snapshot '${name}' failed: no snapshot record exists and sandbox is no longer snapshotting (state: ${this.state}, error reason: ${this.errorReason})`,
+                )
+              }
+              await new Promise((resolve) => setTimeout(resolve, SNAPSHOT_GRACE_READ_DELAY_MS))
+            }
+          }
+        }
       }
 
-      if (this.state !== SandboxState.SNAPSHOTTING) {
-        return
+      if (snapshot) {
+        // A record that predates this capture (allowing for clock skew) is a
+        // pre-existing snapshot that happens to share the name, not ours:
+        // legacy APIs have no accept-time duplicate check, so the poll
+        // would otherwise resolve against it while the real capture is still
+        // running (and doomed to fail on the duplicate insert).
+        const createdAtMs = snapshot.createdAt ? new Date(snapshot.createdAt).getTime() : Number.NaN
+        if (Number.isFinite(createdAtMs) && createdAtMs < initiatedAt.getTime() - SNAPSHOT_CLOCK_SKEW_TOLERANCE_MS) {
+          throw new DaytonaError(
+            `Snapshot ${name} already existed before this capture started; delete it or choose a different name`,
+          )
+        }
+
+        if (snapshot.state === SnapshotState.ACTIVE) {
+          // Record polling bypasses the sandbox, so sync local data
+          // (state would otherwise stay SNAPSHOTTING) before resolving.
+          // Best-effort: a refresh failure must never reject a successful capture.
+          await this.refreshDataSafe()
+          return
+        }
+        if (snapshot.state === SnapshotState.ERROR || snapshot.state === SnapshotState.BUILD_FAILED) {
+          await this.refreshDataSafe()
+          throw new DaytonaError(
+            `Snapshot ${name} failed with state: ${snapshot.state}, error reason: ${snapshot.errorReason}`,
+          )
+        }
       }
 
       if (timeout !== 0 && Date.now() - startTime > timeout * 1000) {

--- a/sdk-typescript/src/__tests__/Sandbox.test.ts
+++ b/sdk-typescript/src/__tests__/Sandbox.test.ts
@@ -1,7 +1,12 @@
 // Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Configuration, Sandbox as SandboxDto } from '@daytona/api-client'
+import {
+  Configuration as MockedConfiguration,
+  SnapshotsApi as MockedSnapshotsApi,
+  type Configuration,
+  type Sandbox as SandboxDto,
+} from '@daytona/api-client'
 import { createApiResponse } from './helpers'
 import { DaytonaNotFoundError } from '../errors/DaytonaError'
 
@@ -13,7 +18,17 @@ jest.mock(
       ERROR: 'error',
       BUILD_FAILED: 'build_failed',
       DESTROYED: 'destroyed',
+      SNAPSHOTTING: 'snapshotting',
+      STARTED: 'started',
     },
+    SnapshotState: {
+      PENDING: 'pending',
+      ACTIVE: 'active',
+      ERROR: 'error',
+      BUILD_FAILED: 'build_failed',
+    },
+    Configuration: jest.fn((params: Record<string, unknown> = {}) => ({ ...params })),
+    SnapshotsApi: jest.fn(() => ({ getSnapshot: jest.fn() })),
   }),
   { virtual: true },
 )
@@ -52,7 +67,11 @@ const baseDto: SandboxDto = {
 
 const makeSandbox = (
   overrides: Partial<SandboxDto> = {},
-): { sandbox: import('../Sandbox').Sandbox; sandboxApi: Record<string, jest.Mock> } => {
+): {
+  sandbox: import('../Sandbox').Sandbox
+  sandboxApi: Record<string, jest.Mock>
+  snapshotsApi: Record<string, jest.Mock>
+} => {
   const { Sandbox } = require('../Sandbox') as typeof import('../Sandbox')
   const sandboxApi = {
     startSandbox: jest.fn(),
@@ -76,6 +95,10 @@ const makeSandbox = (
     validateSshAccess: jest.fn(),
   }
 
+  const snapshotsApi = {
+    getSnapshot: jest.fn(),
+  }
+
   const cfg: Configuration = {
     basePath: 'http://proxy',
     baseOptions: { headers: {} },
@@ -90,9 +113,10 @@ const makeSandbox = (
     cfg,
     axiosInstance as unknown as never,
     sandboxApi as unknown as never,
+    snapshotsApi as unknown as never,
   )
 
-  return { sandbox, sandboxApi }
+  return { sandbox, sandboxApi, snapshotsApi }
 }
 
 describe('Sandbox', () => {
@@ -242,15 +266,171 @@ describe('Sandbox', () => {
   })
 
   it('creates sandbox snapshots and waits for completion', async () => {
-    const { sandbox, sandboxApi } = makeSandbox({ state: 'snapshotting' })
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
     sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
-    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
+    sandboxApi.getSandbox
+      .mockResolvedValueOnce(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+      .mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
+    snapshotsApi.getSnapshot
+      .mockResolvedValueOnce(createApiResponse({ state: 'pending' }))
+      .mockResolvedValueOnce(createApiResponse({ state: 'active' }))
 
     await sandbox._experimental_createSnapshot('snap-1', 1)
 
     expect(sandboxApi.createSandboxSnapshot).toHaveBeenCalledWith('sb-1', { name: 'snap-1' }, undefined, {
       timeout: 1000,
     })
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledWith('snap-1')
+    expect(snapshotsApi.getSnapshot.mock.calls.length).toBeGreaterThanOrEqual(2)
+    // The success path refreshes local sandbox data once the record turns active.
+    expect(sandbox.state).toBe('started')
+  })
+
+  it('resolves a successful capture even when the success-path refresh fails', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox
+      .mockResolvedValueOnce(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+      .mockRejectedValue(new Error('transient network failure'))
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ state: 'active' }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).resolves.toBeUndefined()
+    // The refresh failure is swallowed; local state simply stays stale.
+    expect(sandbox.state).toBe('snapshotting')
+  })
+
+  it('throws when snapshot record reports a failed capture', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox
+      .mockResolvedValueOnce(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+      .mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ state: 'error', errorReason: 'capture failed' }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).rejects.toThrow(
+      'Snapshot snap-1 failed with state: error, error reason: capture failed',
+    )
+    // The failure path refreshes local sandbox data before throwing.
+    expect(sandbox.state).toBe('started')
+  })
+
+  it('throws when snapshot record reports a failed build', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+    snapshotsApi.getSnapshot.mockResolvedValue(
+      createApiResponse({ state: 'build_failed', errorReason: 'build failed' }),
+    )
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).rejects.toThrow(
+      'Snapshot snap-1 failed with state: build_failed, error reason: build failed',
+    )
+  })
+
+  it('tolerates missing snapshot record while sandbox is still snapshotting (legacy API)', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+    snapshotsApi.getSnapshot
+      .mockRejectedValueOnce(new DaytonaNotFoundError('not found'))
+      .mockResolvedValueOnce(createApiResponse({ state: 'active' }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).resolves.toBeUndefined()
+    expect(snapshotsApi.getSnapshot.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('recovers when the snapshot record appears on the grace re-read after the sandbox reverted', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
+    snapshotsApi.getSnapshot
+      .mockRejectedValueOnce(new DaytonaNotFoundError('not found'))
+      .mockResolvedValueOnce(createApiResponse({ state: 'active' }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).resolves.toBeUndefined()
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledTimes(2)
+  })
+
+  it('fails when sandbox reverted and no snapshot record exists (legacy failure)', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
+    snapshotsApi.getSnapshot.mockRejectedValue(new DaytonaNotFoundError('not found'))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 3)).rejects.toThrow(
+      "Sandbox sb-1 snapshot 'snap-1' failed: no snapshot record exists and sandbox is no longer snapshotting (state: started",
+    )
+    // 1 main poll + 3 spaced grace re-reads before giving up.
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledTimes(4)
+  })
+
+  it('gives up the grace re-reads early when the timeout expires', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
+    snapshotsApi.getSnapshot.mockRejectedValue(new DaytonaNotFoundError('not found'))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 0.2)).rejects.toThrow(
+      'no snapshot record exists and sandbox is no longer snapshotting',
+    )
+    // The 200ms timeout expires during the first 500ms grace delay window.
+    expect(snapshotsApi.getSnapshot.mock.calls.length).toBeLessThan(4)
+  })
+
+  it('throws when the polled record predates the capture (pre-existing same-name snapshot)', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+    const monthOld = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ state: 'active', createdAt: monthOld }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).rejects.toThrow(
+      'Snapshot snap-1 already existed before this capture started',
+    )
+  })
+
+  it('accepts a record created moments before initiation (clock skew tolerance)', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
+    const slightlyBehind = new Date(Date.now() - 60 * 1000).toISOString()
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ state: 'active', createdAt: slightlyBehind }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).resolves.toBeUndefined()
+  })
+
+  it('defaults snapshotsApi to an API-targeted client when omitted', async () => {
+    const { Sandbox } = require('../Sandbox') as typeof import('../Sandbox')
+    const apiClient = {
+      SnapshotsApi: MockedSnapshotsApi as unknown as jest.Mock,
+      Configuration: MockedConfiguration as unknown as jest.Mock,
+    }
+    apiClient.SnapshotsApi.mockClear()
+    apiClient.Configuration.mockClear()
+
+    const cfg = { basePath: 'http://api', baseOptions: { headers: {} } } as unknown as Configuration
+    const sandboxApi = {
+      createSandboxSnapshot: jest.fn().mockResolvedValue(createApiResponse(undefined)),
+      getSandbox: jest.fn().mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' })),
+    }
+
+    const sandbox = new Sandbox(
+      { ...baseDto, state: 'snapshotting' },
+      cfg,
+      { defaults: { baseURL: '' } } as unknown as never,
+      sandboxApi as unknown as never,
+    )
+
+    // The default SnapshotsApi must be built from the API base path captured
+    // before the constructor repoints clientConfig at the toolbox proxy.
+    expect(apiClient.Configuration).toHaveBeenCalledWith(expect.objectContaining({ basePath: 'http://api' }))
+    expect(cfg.basePath).toBe('http://proxy/sb-1')
+
+    const snapshotsApi = apiClient.SnapshotsApi.mock.results[0].value as { getSnapshot: jest.Mock }
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ state: 'active' }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).resolves.toBeUndefined()
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledWith('snap-1')
   })
 
   it('waitUntilStarted throws when sandbox enters an error state', async () => {


### PR DESCRIPTION
## Summary

`sandbox._experimental_createSnapshot()` used to watch only the sandbox
state. A snapshot-from-sandbox capture reverts the sandbox to its previous
state on **both** success and failure, so a failed capture was reported to
the caller as success while the snapshot never materialized (404 forever).

This PR makes the SDK wait on the **snapshot record** instead:

- Resolve when the record reaches `active`.
- Throw a `DaytonaError` carrying the record's `errorReason` when it reaches
  `error` / `build_failed`.
- The capture route now documents a `409` when a snapshot with that name
  already exists for the organization; the response is propagated into the
  generated Go / Java / Python clients.

`Sandbox` takes an optional `SnapshotsApi` (defaulted from the API-targeted
client configuration, since the sandbox's own config is repurposed to point
at the toolbox proxy) so the poller queries the Daytona API directly.

### Compatibility with servers that create the record only after success

The code refers to these as the "legacy API" path — a server that inserts
the snapshot record only after a successful capture, rather than up front
when the capture is accepted. Two guards keep the poller correct against
them:

- **Grace re-reads.** The record insert and the sandbox-state revert happen
  in separate steps, so a poll can observe the reverted sandbox before the
  record lands. After seeing the sandbox leave `snapshotting` with no record
  yet, re-read the record up to 3 times, 500 ms apart, bounded by the caller
  timeout, before declaring the capture failed.
- **Stale-record rejection.** These servers have no accept-time duplicate
  check, so polling by name could resolve against a pre-existing same-name
  snapshot while the real capture is still running. Reject any polled record
  whose `createdAt` predates the capture initiation beyond a 5-minute
  clock-skew allowance.

## Behavior changes worth noting

- A failed capture now surfaces as a thrown `DaytonaError` with the real
  error reason, instead of a silent success.
- Attempting to capture into a name that already exists now returns `409`
  from the capture route.

## Test plan

- [x] `nx test sdk-typescript` — 16 suites / 215 tests green (adds coverage
  for success, capture failure, build failure, the legacy grace-read
  recovery and timeout paths, stale-record rejection, clock-skew tolerance,
  and the default `SnapshotsApi` wiring).
- [x] TypeScript type-only import check (`tsc --verbatimModuleSyntax`) green.
- [x] `eslint sdk-typescript/src/**/*.ts` — no new errors.
- [x] `yarn generate:api-client` — generated client drift limited to the
  additive `409` response (Go/Java/Python).
- [x] `nx run sdk-typescript:docs` — regenerated SDK reference reflects the
  new constructor argument and method contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytona/codesmith/clients/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785612357&installation_id=142518896&pr_number=35&repository=daytona%2Fclients&return_to=https%3A%2F%2Fgithub.com%2Fdaytona%2Fclients%2Fpull%2F35&signature=0b61d131aa82b97f2faf0751455d8c225377cc3c9578cc08d5c527413765f49a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent successes when capturing a snapshot from a sandbox by polling the snapshot record until it’s active and surfacing real failures via `DaytonaError`. Also documents duplicate-name `409` and propagates it to generated clients.

- **Bug Fixes**
  - `_experimental_createSnapshot` now waits on the snapshot record: resolves at `active`; throws `DaytonaError` with `errorReason` at `error`/`build_failed`.
  - Legacy server support: grace re-reads after sandbox leaves `snapshotting`; reject stale records created before the capture (5‑minute skew tolerance).
  - `Sandbox` constructor accepts optional `SnapshotsApi` (defaults to an API-targeted client) so polling hits the Daytona API, not the toolbox proxy.
  - After success, local sandbox data is refreshed best-effort.

- **Dependencies**
  - OpenAPI: capture route documents `409` for duplicate snapshot names.
  - Regenerated clients (`api-client-go`, `api-client-java`, `api-client-python`, `api-client-python-async`) include the `409` response.
  - TypeScript SDK docs updated for the new `SnapshotsApi` arg and the snapshot method’s behavior.

<sup>Written for commit 67cbad89aaaceb2c43b73a8c69dec8fa59bd48b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-beta-begin -->

---

<a href="https://daytona.beta.devinenterprise.com/review/daytona/clients/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-beta-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-beta-light.svg?v=1" alt="Open in Devin Review (Beta)">
  </picture>
</a>
<!-- devin-review-badge-beta-end -->