### PR TITLE
chore(cla): add Contributor License Agreement and CLA enforcement check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,9 @@
 SECURITY.md                @MDzaja
 CODE_OF_CONDUCT.md         @MDzaja
 
+# Contributor License Agreement (legal)
+CLA.md                     @MDzaja @aprojic
+
 # CI/CD pipelines and composite actions
 .github/workflows/         @MDzaja
 .github/actions/           @MDzaja

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -52,8 +52,11 @@ jobs:
             Thank you for your contribution! Before we can merge it, we need you
             to sign the [Daytona Contributor License Agreement](https://github.com/daytona/clients/blob/main/CLA.md).
             You only need to do this once, and it will cover all of your future
-            contributions to this repository. Please read the CLA and, if you
-            agree, post the following comment on this PR:
+            contributions to this repository. If you are signing on behalf of an
+            entity (for example, your employer), please also reply with the
+            entity's legal name and your role or title, and confirm that you are
+            authorized to bind it. Please read the CLA and, if you agree, post the
+            following comment on this PR:
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-allsigned-prcomment: >-
             All contributors have signed the CLA. ✅ Thank you!

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,59 @@
+name: '[PR] CLA Assistant'
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# Least-privilege token. `pull_request_target` runs in the BASE repo context so
+# that PRs from forks can still write the signature file and set the status
+# check. This job must ONLY run the trusted CLA action -- never check out or
+# execute the PR head's code here.
+permissions:
+  actions: write # re-run the check via the rerun API
+  contents: write # commit the signature file to the signatures branch
+  pull-requests: write # post / refresh the CLA comment
+  statuses: write # set the pass/fail commit status that gates merge
+
+jobs:
+  cla-assistant:
+    name: CLA signed
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: >-
+          (github.event_name == 'issue_comment' &&
+           github.event.issue.pull_request != null &&
+           (github.event.comment.body == 'recheck' ||
+            github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) ||
+          github.event_name == 'pull_request_target'
+        # contributor-assistant/github-action v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Where signatures are stored, committed to `branch` below. That branch
+          # may be protected against force-pushes and deletions, but must NOT
+          # restrict who can push, require pull requests, or be locked -- the
+          # default GITHUB_TOKEN pushes normal signature commits directly to it.
+          path-to-signatures: 'signatures/version1/cla.json'
+          branch: 'cla-signatures'
+          # The document contributors are agreeing to.
+          path-to-document: 'https://github.com/daytona/clients/blob/main/CLA.md'
+          # Bots and automation cannot sign -- exempt them. Explicit logins only:
+          # a `bot*` wildcard would let a human register a matching username
+          # (e.g. "bottle") and bypass the CLA gate.
+          allowlist: 'dependabot[bot],renovate[bot],github-actions[bot]'
+          # Lock the PR conversation after merge so a signature comment can't be
+          # deleted/revoked after the fact.
+          lock-pullrequest-aftermerge: true
+          custom-notsigned-prcomment: >-
+            Thank you for your contribution! Before we can merge it, we need you
+            to sign the [Daytona Contributor License Agreement](https://github.com/daytona/clients/blob/main/CLA.md).
+            You only need to do this once, and it will cover all of your future
+            contributions to this repository. Please read the CLA and, if you
+            agree, post the following comment on this PR:
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: >-
+            All contributors have signed the CLA. ✅ Thank you!

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,159 @@
+# Daytona Contributor License Agreement ("Agreement")
+
+Thank you for your interest in Daytona Platforms, Inc. ("Daytona", "We", or
+"Us"). This Agreement documents the rights granted to Us by contributors, whether
+You are an individual contributing on Your own behalf or a legal entity (such as
+a company) contributing through Your employees or agents. This is a legally
+binding document, so please read it carefully before agreeing to it.
+
+> **How to sign.** You accept this Agreement electronically through our CLA
+> assistant. When you open your first pull request to the `daytona/clients`
+> repository, the CLA assistant will comment with a link to this Agreement and
+> ask you to confirm your acceptance by posting the exact comment it provides. By
+> posting that comment, You intend to sign, and to be legally bound by, this
+> Agreement. If You are accepting on behalf of an entity (for example, Your
+> employer), by doing so You confirm that You are authorized to bind that entity
+> to this Agreement. Your GitHub identity and the date of your acceptance are recorded as
+> your signature. Signing once covers all of Your future Contributions to this
+> repository.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the individual or legal entity that accepts this
+Agreement. For a legal entity, the entity on whose behalf a Contribution is
+Submitted is the Contributor, and the individual accepting this Agreement
+represents that they are authorized to bind that entity to it.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is Submitted by You to Us in
+which You own or assert ownership of the Copyright.
+
+**"Copyright"** means all rights protecting works of authorship, including
+copyright, moral, and neighboring rights, as appropriate, for the full term of
+their existence.
+
+**"Submit"** means any form of electronic, verbal, or written communication sent
+to Us or Our representatives, including but not limited to communication on
+electronic mailing lists, source code control systems, and issue tracking
+systems that are managed by, or on behalf of, Us for the purpose of discussing
+and improving the Material, but excluding communication that is conspicuously
+marked or otherwise designated in writing by You as "Not a Contribution."
+
+**"Material"** means the software project owned or managed by Us to which a
+Contribution is Submitted, specifically the `daytona/clients` repository.
+
+## 2. Scope and Consideration
+
+This Agreement applies to all Contributions You Submit to Us. You grant the
+rights set out in this Agreement in consideration of, and as a condition of, the
+opportunity to participate in the Material and to have Your Contributions
+considered for inclusion in it. No monetary or other payment is or will be owed
+to You for Your Contributions or for entering into this Agreement. The
+representations in Section 6 apply to each Contribution You Submit, whether on
+Your own behalf or on behalf of an entity.
+
+## 3. Grant of Copyright License
+
+Subject to the terms of this Agreement, You hereby grant to Us and to recipients
+of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable license under Your Copyright to reproduce, prepare
+derivative works of, publicly display, publicly perform, sublicense, and
+distribute Your Contributions and such derivative works.
+
+## 4. Grant of Patent License
+
+Subject to the terms of this Agreement, You hereby grant to Us and to recipients
+of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license to
+make, have made, use, offer to sell, sell, import, and otherwise transfer the
+Material, where such license applies only to those patent claims licensable by
+You that are necessarily infringed by Your Contribution(s) alone or by
+combination of Your Contribution(s) with the Material to which such
+Contribution(s) was Submitted. If any entity institutes patent litigation
+against You or any other entity (including a cross-claim or counterclaim in a
+lawsuit) alleging that Your Contribution, or the Material to which You have
+contributed, constitutes direct or contributory patent infringement, then any
+patent licenses granted to that entity under this Agreement for that Contribution
+or Material shall terminate as of the date such litigation is filed.
+
+## 5. Outbound License (Relicensing Rights)
+
+Based on the grant of rights in Sections 3 and 4, We may license the Contribution
+under any license terms We choose, including copyleft, permissive, commercial,
+and proprietary licenses. You acknowledge that We currently distribute the
+Material under the Apache License 2.0 (with the `cli/` directory under the GNU
+Affero General Public License v3.0 (AGPLv3)), and that We may, in addition, offer
+the Material and Your Contribution under separate commercial or proprietary
+terms, and may change the license or the visibility of the Material at any time,
+in Our sole discretion and without further notice to, consent from, or payment to
+You. Nothing in this Agreement requires Us to use Your Contribution in any product
+or under any license.
+
+## 6. Your Representations
+
+You represent that:
+
+(a) You are legally entitled to grant the above licenses. If You are an
+individual and Your employer(s) has rights to intellectual property that You
+create that includes Your Contributions, You represent that You have received
+permission to make Contributions on behalf of that employer, that Your employer
+has waived such rights for Your Contributions to Us, or that Your employer has
+executed a separate Corporate CLA with Us.
+
+(b) If You are, or are accepting this Agreement on behalf of, a legal entity, You
+represent that You are authorized to enter into this Agreement on that entity's
+behalf, that it binds the entity, and that it covers Contributions Submitted to
+Us by the entity's employees and agents on its behalf.
+
+(c) Each of Your Contributions is Your original creation.
+
+(d) Your Contribution submissions include complete details of any third-party
+license or other restriction (including, but not limited to, related patents and
+trademarks) of which You are personally aware and which are associated with any
+part of Your Contributions.
+
+## 7. Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. Unless required by applicable law or agreed
+to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 8. Notice
+
+You agree to notify Us of any facts or circumstances of which You become aware
+that would make these representations inaccurate in any respect.
+
+## 9. Miscellaneous
+
+This Agreement will be governed by the laws of the State of Massachusetts,
+without regard to any provision of law that would require or permit the
+application of the substantive law of any other jurisdiction. In the event of a
+dispute, the federal or state courts of Massachusetts shall have exclusive
+jurisdiction.
+
+If any provision of this Agreement is, for any reason, held to be invalid or
+unenforceable, the other provisions of this Agreement will remain enforceable and
+the invalid or unenforceable provision will be deemed modified so that it is
+valid and enforceable to the maximum extent permitted by law. Any waiver or
+failure to enforce any provision of this Agreement on one occasion will not be
+deemed a waiver of any other provision or of such provision on any other
+occasion.
+
+Each party shall execute and deliver any and all additional papers, documents,
+and other assurances, and shall do any and all acts and things reasonably
+necessary in connection with the performance of its obligations under this
+Agreement, to carry out the intent of this Agreement.
+
+This Agreement constitutes the entire agreement between the parties with respect
+to Contributions Submitted through the electronic acceptance process described
+above, and does not amend, replace, or supersede any separate written contributor
+or corporate license agreement previously executed between You and Us, unless that
+agreement expressly states otherwise. This Agreement may only be amended in a
+writing signed by duly authorized representatives of the parties.
+
+This Agreement may be executed in one or more counterparts, or accepted
+electronically, each of which shall be deemed an original, but all of which
+together will constitute one instrument.

--- a/CLA.md
+++ b/CLA.md
@@ -10,19 +10,25 @@ binding document, so please read it carefully before agreeing to it.
 > assistant. When you open your first pull request to the `daytona/clients`
 > repository, the CLA assistant will comment with a link to this Agreement and
 > ask you to confirm your acceptance by posting the exact comment it provides. By
-> posting that comment, You intend to sign, and to be legally bound by, this
-> Agreement. If You are accepting on behalf of an entity (for example, Your
+> posting that comment, You affirmatively sign, and agree to be legally bound by,
+> this Agreement. If You are accepting on behalf of an entity (for example, Your
 > employer), by doing so You confirm that You are authorized to bind that entity
-> to this Agreement. Your GitHub identity and the date of your acceptance are recorded as
-> your signature. Signing once covers all of Your future Contributions to this
-> repository.
+> to this Agreement. If accepting on behalf of an entity, You must identify the
+> entity's legal name and Your role or title, or otherwise provide the information
+> requested by the CLA assistant to confirm the entity on whose behalf You are
+> accepting. Your GitHub identity and the date of your acceptance are recorded as
+> your signature. This Agreement applies to the Contributions included in the pull
+> request in which You accept this Agreement, and to all Contributions You Submit
+> to Us after that acceptance.
 
 ## 1. Definitions
 
 **"You"** (or **"Your"**) means the individual or legal entity that accepts this
 Agreement. For a legal entity, the entity on whose behalf a Contribution is
 Submitted is the Contributor, and the individual accepting this Agreement
-represents that they are authorized to bind that entity to it.
+represents that they are authorized to bind that entity to it. If the acceptance
+record identifies an entity, "You" means that entity; otherwise, "You" means the
+individual associated with the recorded GitHub account.
 
 **"Contribution"** means any original work of authorship, including any
 modifications or additions to an existing work, that is Submitted by You to Us in
@@ -44,31 +50,37 @@ Contribution is Submitted, specifically the `daytona/clients` repository.
 
 ## 2. Scope and Consideration
 
-This Agreement applies to all Contributions You Submit to Us. You grant the
-rights set out in this Agreement in consideration of, and as a condition of, the
-opportunity to participate in the Material and to have Your Contributions
-considered for inclusion in it. No monetary or other payment is or will be owed
-to You for Your Contributions or for entering into this Agreement. The
-representations in Section 6 apply to each Contribution You Submit, whether on
-Your own behalf or on behalf of an entity.
+This Agreement applies to the Contributions included in the pull request in which
+You accept this Agreement, and to all Contributions You Submit to Us after that
+acceptance. You grant the rights set out in this Agreement in consideration of,
+and as a condition of, the opportunity to participate in the Material and to have
+Your Contributions considered for inclusion in it. No monetary or other payment
+is or will be owed to You for Your Contributions or for entering into this
+Agreement. The representations in Section 6 apply to each Contribution You Submit,
+whether on Your own behalf or on behalf of an entity.
 
 ## 3. Grant of Copyright License
 
 Subject to the terms of this Agreement, You hereby grant to Us and to recipients
 of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge,
-royalty-free, irrevocable license under Your Copyright to reproduce, prepare
-derivative works of, publicly display, publicly perform, sublicense, and
-distribute Your Contributions and such derivative works.
+royalty-free, irrevocable license, with the right to sublicense to recipients of
+software distributed by Us under terms We choose, under Your Copyright to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative works. To the
+maximum extent permitted by law, You waive and agree not to assert any moral
+rights, neighboring rights, or similar rights in Your Contributions against Us,
+Our sublicensees, or recipients of software distributed by Us.
 
 ## 4. Grant of Patent License
 
 Subject to the terms of this Agreement, You hereby grant to Us and to recipients
 of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge,
-royalty-free, irrevocable (except as stated in this section) patent license to
-make, have made, use, offer to sell, sell, import, and otherwise transfer the
-Material, where such license applies only to those patent claims licensable by
-You that are necessarily infringed by Your Contribution(s) alone or by
-combination of Your Contribution(s) with the Material to which such
+royalty-free, irrevocable (except as stated in this section) patent license, with
+the right to sublicense to recipients of software distributed by Us under terms
+We choose, to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Material, where such license applies only to those patent claims
+licensable by You that are necessarily infringed by Your Contribution(s) alone or
+by combination of Your Contribution(s) with the Material to which such
 Contribution(s) was Submitted. If any entity institutes patent litigation
 against You or any other entity (including a cross-claim or counterclaim in a
 lawsuit) alleging that Your Contribution, or the Material to which You have
@@ -84,26 +96,31 @@ and proprietary licenses. You acknowledge that We currently distribute the
 Material under the Apache License 2.0 (with the `cli/` directory under the GNU
 Affero General Public License v3.0 (AGPLv3)), and that We may, in addition, offer
 the Material and Your Contribution under separate commercial or proprietary
-terms, and may change the license or the visibility of the Material at any time,
-in Our sole discretion and without further notice to, consent from, or payment to
-You. Nothing in this Agreement requires Us to use Your Contribution in any product
-or under any license.
+terms, and may change the license or the visibility of the Material, for future
+versions, distributions, or releases, at any time, in Our sole discretion and
+without further notice to, consent from, or payment to You. Nothing in this
+Agreement requires Us to use Your Contribution in any product or under any
+license.
 
 ## 6. Your Representations
 
 You represent that:
 
-(a) You are legally entitled to grant the above licenses. If You are an
-individual and Your employer(s) has rights to intellectual property that You
-create that includes Your Contributions, You represent that You have received
-permission to make Contributions on behalf of that employer, that Your employer
-has waived such rights for Your Contributions to Us, or that Your employer has
-executed a separate Corporate CLA with Us.
+(a) You are legally entitled, and have the legal capacity, to enter into this
+Agreement and grant the above licenses. If You are an individual and Your
+employer(s) has rights to intellectual property that You create that includes
+Your Contributions, You represent that You have received permission to make
+Contributions on behalf of that employer, that Your employer has waived such
+rights for Your Contributions to Us, that Your employer has authorized You to
+accept this Agreement on its behalf, or that Your employer has otherwise entered
+into a written or electronic agreement with Us covering such Contributions.
 
 (b) If You are, or are accepting this Agreement on behalf of, a legal entity, You
 represent that You are authorized to enter into this Agreement on that entity's
 behalf, that it binds the entity, and that it covers Contributions Submitted to
-Us by the entity's employees and agents on its behalf.
+Us by the entity's employees and agents on its behalf, including Contributions
+submitted through the GitHub account recorded in the CLA assistant acceptance
+process.
 
 (c) Each of Your Contributions is Your original creation.
 
@@ -131,7 +148,7 @@ that would make these representations inaccurate in any respect.
 This Agreement will be governed by the laws of the State of Massachusetts,
 without regard to any provision of law that would require or permit the
 application of the substantive law of any other jurisdiction. In the event of a
-dispute, the federal or state courts of Massachusetts shall have exclusive
+dispute, the federal or state courts located in Massachusetts shall have exclusive
 jurisdiction.
 
 If any provision of this Agreement is, for any reason, held to be invalid or
@@ -149,8 +166,9 @@ Agreement, to carry out the intent of this Agreement.
 
 This Agreement constitutes the entire agreement between the parties with respect
 to Contributions Submitted through the electronic acceptance process described
-above, and does not amend, replace, or supersede any separate written contributor
-or corporate license agreement previously executed between You and Us, unless that
+above, and does not amend, replace, or supersede any separate written contributor,
+including any previously executed individual contributor license agreements, or
+corporate license agreement previously executed between You and Us, unless that
 agreement expressly states otherwise. This Agreement may only be amended in a
 writing signed by duly authorized representatives of the parties.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,8 @@ Run `yarn lint` before opening a PR.
    change.
 3. [Prepare your changes](./PREPARING_YOUR_CHANGES.md) with descriptive commits, and **sign off**
    every commit to comply with the DCO v1.1 (`git commit -s`).
+   The first time you open a PR, our CLA assistant will also ask you to **sign the
+   [Contributor License Agreement](./CLA.md)** (see [Licensing](#licensing) below).
 4. If you changed generated clients, regenerate them (`yarn generate:api-client`) and commit
    the result. If you changed command behavior, regenerate any affected docs.
 5. Ensure `yarn lint`, `yarn build`, and `yarn test` pass.
@@ -93,6 +95,21 @@ Run `yarn lint` before opening a PR.
 
 ## Licensing
 
-This repository is licensed under [Apache-2.0](./LICENSE). By contributing, you agree that
-your contributions are licensed under Apache-2.0 and that you have the right to license them
-(via the DCO sign-off on each commit).
+This repository is currently made available under [Apache-2.0](./LICENSE) (with `cli/` under
+AGPL-3.0). Contributing involves two steps:
+
+1. **DCO sign-off (per commit).** Sign off every commit with `git commit -s` to certify, under
+   the [Developer Certificate of Origin](https://developercertificate.org/) v1.1, that you have
+   the right to submit the code. See [PREPARING_YOUR_CHANGES.md](./PREPARING_YOUR_CHANGES.md).
+
+2. **CLA signature (once).** You must also sign the
+   [Daytona Contributor License Agreement](./CLA.md) — it covers both individual and
+   entity/corporate contributors. You (or, for entity contributors, your organization) retain
+   copyright in your contributions,
+   but you grant Daytona Platforms, Inc. a perpetual, irrevocable, sublicensable license to them —
+   **including the right to relicense and redistribute the software under any terms (open source,
+   proprietary, or closed source) and to change the license or visibility of the project at any
+   time.** A CLA assistant bot will comment on your first pull request with a link and a one-line
+   instruction to sign; a single signature covers all your future contributions to this repo.
+
+Your PR cannot be merged until both the DCO check and the CLA check are green.

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,9 +1,18 @@
-Copyrights in the Daytona software are retained by their contributors.
-No copyright assignment is required to contribute to Daytona software.
+Copyrights in the Daytona software are retained by their respective
+contributors. Contributors keep ownership of the copyright in their
+contributions; no copyright assignment is required.
 
-When we refer to the 'Daytona software authors', we mean anyone who
-has contributed to this repository.
+By contributing, each contributor agrees to the Daytona Contributor License
+Agreement (see CLA.md), under which they grant Daytona Platforms, Inc. a
+perpetual, irrevocable, sublicensable license to their contributions. This
+license includes the right for Daytona to relicense and redistribute the
+software (and any contribution) under any terms of Daytona's choosing,
+including proprietary or closed-source terms, and to change the license or
+visibility of the software at any time.
+
+When we refer to the 'Daytona software authors', we mean anyone who has
+contributed to this repository.
 
 Unless otherwise noted, such as with a LICENSE file in a directory, or a
-specific copyright notice on a file, all files in this repository are
-licensed under the Apache 2.0 license.
+specific copyright notice on a file, all files in this repository are currently
+made available under the Apache 2.0 license.


### PR DESCRIPTION
## Description

Adds a Contributor License Agreement (CLA) and an automated PR check to this
repository. Contributors grant Daytona a perpetual, irrevocable, sublicensable
license to their contributions — including the right to relicense and
redistribute under any terms (open source, proprietary, or closed source) and to
change the license or visibility of the project — while retaining their own
copyright.

The CLA is universal: it covers both individual contributors and entity/corporate
contributors (for example, a company contributing through its employees). It is
governed by the laws of the State of Massachusetts.

### What's included

| File | Change |
|---|---|
| `CLA.md` | New. The Contributor License Agreement: copyright grant, patent grant, outbound/relicensing rights, representations, and disclaimer. |
| `.github/workflows/cla.yaml` | New. CLA Assistant check that comments on PRs and blocks merge until every contributor has signed. Pinned to `contributor-assistant/github-action` v2.6.1 (SHA). |
| `COPYRIGHT` | Updated — contributors retain copyright but grant relicensing rights via the CLA. |
| `CONTRIBUTING.md` | Updated — contributing now requires both a DCO sign-off (per commit) and a one-time CLA signature. |

### How signing works for contributors

- **DCO (per commit):** sign off each commit with `git commit -s`.
- **CLA (one-time):** on a contributor's first PR, the CLA assistant comments with
  a link to `CLA.md`. The contributor replies with
  `I have read the CLA Document and I hereby sign the CLA` to accept. A single
  signature covers all their future contributions to this repository.
- Bots (`dependabot`, `renovate`, etc.) are allowlisted and are never asked to
  sign.

### Where signatures are stored

Signatures are committed to the dedicated `cla-signatures` branch, which is
protected against force-pushes and deletions.

## Notes

- The CLA job runs on `pull_request_target` and PR-scoped `issue_comment`, using
  the default `GITHUB_TOKEN`.
- `contributor-assistant/github-action` is pinned to a specific commit SHA for
  stability.
