### PR TITLE
fix(sdk-python): pass S3 region to obstore S3Store (derive from endpoint)

### DIFF
--- a/sdk-python/src/daytona/_async/object_storage.py
+++ b/sdk-python/src/daytona/_async/object_storage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
+import re
 import tarfile
 import threading
 
@@ -15,6 +16,15 @@ from obstore.store import S3Store
 from .._utils.docs_ignore import docs_ignore
 from .._utils.environment import isolated_env
 from .._utils.otel_decorator import with_instrumentation
+
+
+def _region_from_endpoint(endpoint_url: str) -> str:
+    """Derive the S3 region from the endpoint, defaulting to ``us-east-1``.
+
+    obstore defaults SigV4 signing to us-east-1, so buckets in other regions 400 without this.
+    """
+    match = re.search(r"s3[.-]([^.]+)\.amazonaws\.com", endpoint_url or "")
+    return match.group(1) if match else "us-east-1"
 
 
 class AsyncObjectStorage:
@@ -41,6 +51,7 @@ class AsyncObjectStorage:
             self.store: S3Store = S3Store(
                 bucket=bucket_name,
                 endpoint=endpoint_url,
+                region=_region_from_endpoint(endpoint_url),
                 access_key_id=aws_access_key_id,
                 secret_access_key=aws_secret_access_key,
                 session_token=aws_session_token,

--- a/sdk-python/src/daytona/_sync/object_storage.py
+++ b/sdk-python/src/daytona/_sync/object_storage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import tarfile
 import threading
 
@@ -13,6 +14,15 @@ from obstore.store import S3Store
 from .._utils.docs_ignore import docs_ignore
 from .._utils.environment import isolated_env
 from .._utils.otel_decorator import with_instrumentation
+
+
+def _region_from_endpoint(endpoint_url: str) -> str:
+    """Derive the S3 region from the endpoint, defaulting to ``us-east-1``.
+
+    obstore defaults SigV4 signing to us-east-1, so buckets in other regions 400 without this.
+    """
+    match = re.search(r"s3[.-]([^.]+)\.amazonaws\.com", endpoint_url or "")
+    return match.group(1) if match else "us-east-1"
 
 
 class ObjectStorage:
@@ -39,6 +49,7 @@ class ObjectStorage:
             self.store: S3Store = S3Store(
                 bucket=bucket_name,
                 endpoint=endpoint_url,
+                region=_region_from_endpoint(endpoint_url),
                 access_key_id=aws_access_key_id,
                 secret_access_key=aws_secret_access_key,
                 session_token=aws_session_token,

--- a/sdk-python/tests/test_async_object_storage.py
+++ b/sdk-python/tests/test_async_object_storage.py
@@ -21,6 +21,25 @@ def _make_async_storage():
     return storage, mock_store
 
 
+@pytest.mark.parametrize(
+    "endpoint, expected",
+    [
+        ("https://s3.us-east-2.amazonaws.com", "us-east-2"),
+        ("https://s3.us-east-1.amazonaws.com", "us-east-1"),
+        ("https://s3-us-west-1.amazonaws.com", "us-west-1"),  # legacy dash style
+        ("https://s3.ap-northeast-2.amazonaws.com", "ap-northeast-2"),
+        ("https://s3.us-gov-west-1.amazonaws.com", "us-gov-west-1"),  # GovCloud (extra segment)
+        ("https://s3.amazonaws.com", "us-east-1"),  # no region in host -> default
+        ("https://minio.local:9000", "us-east-1"),  # non-AWS endpoint -> default
+        ("", "us-east-1"),
+    ],
+)
+def test_region_from_endpoint(endpoint, expected):
+    from daytona._async.object_storage import _region_from_endpoint
+
+    assert _region_from_endpoint(endpoint) == expected
+
+
 class TestAsyncObjectStorage:
     @pytest.mark.asyncio
     async def test_upload_missing_path_raises(self):

--- a/sdk-python/tests/test_object_storage.py
+++ b/sdk-python/tests/test_object_storage.py
@@ -19,6 +19,25 @@ def _make_storage():
     return storage, mock_store
 
 
+@pytest.mark.parametrize(
+    "endpoint, expected",
+    [
+        ("https://s3.us-east-2.amazonaws.com", "us-east-2"),
+        ("https://s3.us-east-1.amazonaws.com", "us-east-1"),
+        ("https://s3-us-west-1.amazonaws.com", "us-west-1"),  # legacy dash style
+        ("https://s3.ap-northeast-2.amazonaws.com", "ap-northeast-2"),
+        ("https://s3.us-gov-west-1.amazonaws.com", "us-gov-west-1"),  # GovCloud (extra segment)
+        ("https://s3.amazonaws.com", "us-east-1"),  # no region in host -> default
+        ("https://minio.local:9000", "us-east-1"),  # non-AWS endpoint -> default
+        ("", "us-east-1"),
+    ],
+)
+def test_region_from_endpoint(endpoint, expected):
+    from daytona._sync.object_storage import _region_from_endpoint
+
+    assert _region_from_endpoint(endpoint) == expected
+
+
 class TestObjectStorage:
     def test_upload_missing_path_raises(self):
         storage, _store = _make_storage()


### PR DESCRIPTION
### Summary
`ObjectStorage`/`AsyncObjectStorage` built the obstore `S3Store` with an endpoint but no
region, so obstore signs SigV4 for `us-east-1`. Against a build-context/volume bucket in
any other region this returns **HTTP 400** on every object op — breaking self-hosted
deployments outside us-east-1 (Dockerfile snapshot builds, volume uploads).

Fixes #44

### Change
- Derive the region from the endpoint host (`s3.<region>.amazonaws.com`) and pass it to
  `S3Store`.
- Fall back to `us-east-1` when the host is non-standard (minio, custom) → **no behavior
  change** for existing/default users.
- Applied to both `_async` and `_sync`.

### Tests
- Added `test_region_from_endpoint` (parametrized: regional, legacy dash-style, GovCloud,
  no-region host, non-AWS, empty) to both sync and async suites.

### Checklist
- [x] DCO signed off
- [x] `black` / `isort` clean (line-length 120)
- [x] New logic covered by tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the S3 region from the endpoint and passes it to `obstore` `S3Store`, fixing SigV4 region mismatches that returned HTTP 400. Restores object operations for buckets outside us-east-1 in self-hosted setups.

- **Bug Fixes**
  - Parse region from endpoints like s3.<region>.amazonaws.com and s3-<region>.amazonaws.com; default to us-east-1 for custom/non-AWS endpoints.
  - Applied to both sync and async object storage.
  - Added tests covering regional, legacy dash-style, GovCloud, no-region, non-AWS, and empty endpoints.

<sup>Written for commit 3ce48411d5278fceb7a75c7e3d1bfc41a0f73c56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

