### PR TITLE
feat(python): add opt-in client-side timeout to all SDK HTTP methods

### DIFF
--- a/artifacts/sdk-docs/python-sdk/async/async-code-interpreter.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-code-interpreter.mdx
@@ -107,7 +107,9 @@ result = await sandbox.code_interpreter.run_code(
 
 ```python
 @intercept_errors(message_prefix="Failed to create interpreter context: ")
-async def create_context(cwd: str | None = None) -> InterpreterContext
+async def create_context(
+        cwd: str | None = None,
+        request_timeout: float | None = None) -> InterpreterContext
 ```
 
 Create a new isolated interpreter context.
@@ -118,6 +120,10 @@ Variables, imports, and functions defined in one context don't affect others.
 **Arguments**:
 
 - `cwd` _str | None_ - Working directory for the context. If not specified, uses sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -153,13 +159,22 @@ await sandbox.code_interpreter.delete_context(ctx)
 
 ```python
 @intercept_errors(message_prefix="Failed to list interpreter contexts: ")
-async def list_contexts() -> list[InterpreterContext]
+async def list_contexts(
+        request_timeout: float | None = None) -> list[InterpreterContext]
 ```
 
 List all user-created interpreter contexts.
 
 The default context is not included in this list. Only contexts created
 via `create_context()` are returned.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -183,7 +198,8 @@ for ctx in contexts:
 
 ```python
 @intercept_errors(message_prefix="Failed to delete interpreter context: ")
-async def delete_context(context: InterpreterContext) -> None
+async def delete_context(context: InterpreterContext,
+                         request_timeout: float | None = None) -> None
 ```
 
 Delete an interpreter context and shut down all associated processes.
@@ -194,6 +210,10 @@ The default context cannot be deleted.
 **Arguments**:
 
 - `context` _InterpreterContext_ - Context to delete.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:

--- a/artifacts/sdk-docs/python-sdk/async/async-computer-use.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-computer-use.mdx
@@ -28,10 +28,19 @@ for automating desktop interactions within a sandbox.
 ```python
 @intercept_errors(message_prefix="Failed to start computer use: ")
 @with_instrumentation()
-async def start() -> ComputerUseStartResponse
+async def start(
+        request_timeout: float | None = None) -> ComputerUseStartResponse
 ```
 
 Starts all computer use processes (Xvfb, xfce4, x11vnc, novnc).
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -50,10 +59,19 @@ print("Computer use processes started:", result.message)
 ```python
 @intercept_errors(message_prefix="Failed to stop computer use: ")
 @with_instrumentation()
-async def stop() -> ComputerUseStopResponse
+async def stop(
+        request_timeout: float | None = None) -> ComputerUseStopResponse
 ```
 
 Stops all computer use processes.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -72,10 +90,19 @@ print("Computer use processes stopped:", result.message)
 ```python
 @intercept_errors(message_prefix="Failed to get computer use status: ")
 @with_instrumentation()
-async def get_status() -> ComputerUseStatusResponse
+async def get_status(
+        request_timeout: float | None = None) -> ComputerUseStatusResponse
 ```
 
 Gets the status of all computer use processes.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -94,7 +121,9 @@ print("Computer use status:", response.status)
 ```python
 @intercept_errors(message_prefix="Failed to get process status: ")
 @with_instrumentation()
-async def get_process_status(process_name: str) -> ProcessStatusResponse
+async def get_process_status(
+        process_name: str,
+        request_timeout: float | None = None) -> ProcessStatusResponse
 ```
 
 Gets the status of a specific VNC process.
@@ -102,6 +131,10 @@ Gets the status of a specific VNC process.
 **Arguments**:
 
 - `process_name` _str_ - Name of the process to check.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -121,7 +154,9 @@ no_vnc_status = await sandbox.computer_use.get_process_status("novnc")
 ```python
 @intercept_errors(message_prefix="Failed to restart process: ")
 @with_instrumentation()
-async def restart_process(process_name: str) -> ProcessRestartResponse
+async def restart_process(
+        process_name: str,
+        request_timeout: float | None = None) -> ProcessRestartResponse
 ```
 
 Restarts a specific VNC process.
@@ -129,6 +164,10 @@ Restarts a specific VNC process.
 **Arguments**:
 
 - `process_name` _str_ - Name of the process to restart.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -148,7 +187,9 @@ print("XFCE4 process restarted:", result.message)
 ```python
 @intercept_errors(message_prefix="Failed to get process logs: ")
 @with_instrumentation()
-async def get_process_logs(process_name: str) -> ProcessLogsResponse
+async def get_process_logs(
+        process_name: str,
+        request_timeout: float | None = None) -> ProcessLogsResponse
 ```
 
 Gets logs for a specific VNC process.
@@ -156,6 +197,10 @@ Gets logs for a specific VNC process.
 **Arguments**:
 
 - `process_name` _str_ - Name of the process to get logs for.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -175,7 +220,9 @@ print("NoVNC logs:", logs)
 ```python
 @intercept_errors(message_prefix="Failed to get process errors: ")
 @with_instrumentation()
-async def get_process_errors(process_name: str) -> ProcessErrorsResponse
+async def get_process_errors(
+        process_name: str,
+        request_timeout: float | None = None) -> ProcessErrorsResponse
 ```
 
 Gets error logs for a specific VNC process.
@@ -183,6 +230,10 @@ Gets error logs for a specific VNC process.
 **Arguments**:
 
 - `process_name` _str_ - Name of the process to get error logs for.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -211,10 +262,19 @@ Mouse operations for computer use functionality.
 ```python
 @intercept_errors(message_prefix="Failed to get mouse position: ")
 @with_instrumentation()
-async def get_position() -> MousePositionResponse
+async def get_position(
+        request_timeout: float | None = None) -> MousePositionResponse
 ```
 
 Gets the current mouse cursor position.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -233,7 +293,9 @@ print(f"Mouse is at: {position.x}, {position.y}")
 ```python
 @intercept_errors(message_prefix="Failed to move mouse: ")
 @with_instrumentation()
-async def move(x: int, y: int) -> MousePositionResponse
+async def move(x: int,
+               y: int,
+               request_timeout: float | None = None) -> MousePositionResponse
 ```
 
 Moves the mouse cursor to the specified coordinates.
@@ -242,6 +304,10 @@ Moves the mouse cursor to the specified coordinates.
 
 - `x` _int_ - The x coordinate to move to.
 - `y` _int_ - The y coordinate to move to.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -264,7 +330,8 @@ print(f"Mouse moved to: {result.x}, {result.y}")
 async def click(x: int,
                 y: int,
                 button: str = "left",
-                double: bool = False) -> MouseClickResponse
+                double: bool = False,
+                request_timeout: float | None = None) -> MouseClickResponse
 ```
 
 Clicks the mouse at the specified coordinates.
@@ -275,6 +342,10 @@ Clicks the mouse at the specified coordinates.
 - `y` _int_ - The y coordinate to click at.
 - `button` _str_ - The mouse button to click ('left', 'right', 'middle').
 - `double` _bool_ - Whether to perform a double-click.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -304,7 +375,8 @@ async def drag(start_x: int,
                start_y: int,
                end_x: int,
                end_y: int,
-               button: str = "left") -> MouseDragResponse
+               button: str = "left",
+               request_timeout: float | None = None) -> MouseDragResponse
 ```
 
 Drags the mouse from start coordinates to end coordinates.
@@ -316,6 +388,10 @@ Drags the mouse from start coordinates to end coordinates.
 - `end_x` _int_ - The ending x coordinate.
 - `end_y` _int_ - The ending y coordinate.
 - `button` _str_ - The mouse button to use for dragging.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -335,7 +411,11 @@ print(f"Drag ended at {result.x}, {result.y}")
 ```python
 @intercept_errors(message_prefix="Failed to scroll mouse: ")
 @with_instrumentation()
-async def scroll(x: int, y: int, direction: str, amount: int = 1) -> bool
+async def scroll(x: int,
+                 y: int,
+                 direction: str,
+                 amount: int = 1,
+                 request_timeout: float | None = None) -> bool
 ```
 
 Scrolls the mouse wheel at the specified coordinates.
@@ -346,6 +426,10 @@ Scrolls the mouse wheel at the specified coordinates.
 - `y` _int_ - The y coordinate to scroll at.
 - `direction` _str_ - The direction to scroll ('up' or 'down').
 - `amount` _int_ - The amount to scroll.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -376,7 +460,9 @@ Keyboard operations for computer use functionality.
 ```python
 @intercept_errors(message_prefix="Failed to type text: ")
 @with_instrumentation()
-async def type(text: str, delay: int | None = None) -> None
+async def type(text: str,
+               delay: int | None = None,
+               request_timeout: float | None = None) -> None
 ```
 
 Types the specified text.
@@ -385,6 +471,10 @@ Types the specified text.
 
 - `text` _str_ - The text to type.
 - `delay` _int_ - Delay between characters in milliseconds.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -414,7 +504,9 @@ except Exception as e:
 ```python
 @intercept_errors(message_prefix="Failed to press key: ")
 @with_instrumentation()
-async def press(key: str, modifiers: list[str] | None = None) -> None
+async def press(key: str,
+                modifiers: list[str] | None = None,
+                request_timeout: float | None = None) -> None
 ```
 
 Presses a key with optional modifiers.
@@ -429,6 +521,10 @@ Presses a key with optional modifiers.
 - `modifiers` _list[str]_ - Canonical modifier names are 'ctrl', 'alt',
   'shift', and 'cmd'. Common aliases such as 'control', 'option',
   'meta', and 'win' are normalized.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -464,7 +560,7 @@ except Exception as e:
 ```python
 @intercept_errors(message_prefix="Failed to press hotkey: ")
 @with_instrumentation()
-async def hotkey(keys: str) -> None
+async def hotkey(keys: str, request_timeout: float | None = None) -> None
 ```
 
 Presses a hotkey combination.
@@ -474,6 +570,10 @@ Presses a hotkey combination.
 - `keys` _str_ - A single atomic hotkey chord (e.g., 'ctrl+c', 'alt+tab',
   'cmd+shift+t', 'ctrl + c', 'shift'). Uses the same normalized key
   contract as ``press()``.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -519,7 +619,9 @@ Screenshot operations for computer use functionality.
 ```python
 @intercept_errors(message_prefix="Failed to take screenshot: ")
 @with_instrumentation()
-async def take_full_screen(show_cursor: bool = False) -> ScreenshotResponse
+async def take_full_screen(
+        show_cursor: bool = False,
+        request_timeout: float | None = None) -> ScreenshotResponse
 ```
 
 Takes a screenshot of the entire screen.
@@ -527,6 +629,10 @@ Takes a screenshot of the entire screen.
 **Arguments**:
 
 - `show_cursor` _bool_ - Whether to show the cursor in the screenshot.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -549,8 +655,10 @@ with_cursor = await sandbox.computer_use.screenshot.take_full_screen(True)
 ```python
 @intercept_errors(message_prefix="Failed to take region screenshot: ")
 @with_instrumentation()
-async def take_region(region: ScreenshotRegion,
-                      show_cursor: bool = False) -> ScreenshotResponse
+async def take_region(
+        region: ScreenshotRegion,
+        show_cursor: bool = False,
+        request_timeout: float | None = None) -> ScreenshotResponse
 ```
 
 Takes a screenshot of a specific region.
@@ -559,6 +667,10 @@ Takes a screenshot of a specific region.
 
 - `region` _ScreenshotRegion_ - The region to capture.
 - `show_cursor` _bool_ - Whether to show the cursor in the screenshot.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -580,7 +692,8 @@ print(f"Captured region: {screenshot.region.width}x{screenshot.region.height}")
 @intercept_errors(message_prefix="Failed to take compressed screenshot: ")
 @with_instrumentation()
 async def take_compressed(
-        options: ScreenshotOptions | None = None) -> ScreenshotResponse
+        options: ScreenshotOptions | None = None,
+        request_timeout: float | None = None) -> ScreenshotResponse
 ```
 
 Takes a compressed screenshot of the entire screen.
@@ -588,6 +701,10 @@ Takes a compressed screenshot of the entire screen.
 **Arguments**:
 
 - `options` _ScreenshotOptions | None_ - Compression and display options.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -620,7 +737,8 @@ scaled = await sandbox.computer_use.screenshot.take_compressed(
 @with_instrumentation()
 async def take_compressed_region(
         region: ScreenshotRegion,
-        options: ScreenshotOptions | None = None) -> ScreenshotResponse
+        options: ScreenshotOptions | None = None,
+        request_timeout: float | None = None) -> ScreenshotResponse
 ```
 
 Takes a compressed screenshot of a specific region.
@@ -629,6 +747,10 @@ Takes a compressed screenshot of a specific region.
 
 - `region` _ScreenshotRegion_ - The region to capture.
 - `options` _ScreenshotOptions | None_ - Compression and display options.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -660,10 +782,19 @@ Display operations for computer use functionality.
 ```python
 @intercept_errors(message_prefix="Failed to get display info: ")
 @with_instrumentation()
-async def get_info() -> DisplayInfoResponse
+async def get_info(
+        request_timeout: float | None = None) -> DisplayInfoResponse
 ```
 
 Gets information about the displays.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -685,10 +816,18 @@ for i, display in enumerate(info.displays):
 ```python
 @intercept_errors(message_prefix="Failed to get windows: ")
 @with_instrumentation()
-async def get_windows() -> WindowsResponse
+async def get_windows(request_timeout: float | None = None) -> WindowsResponse
 ```
 
 Gets the list of open windows.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -717,7 +856,8 @@ Recording operations for computer use functionality.
 ```python
 @intercept_errors(message_prefix="Failed to start recording: ")
 @with_instrumentation()
-async def start(label: str | None = None) -> Recording
+async def start(label: str | None = None,
+                request_timeout: float | None = None) -> Recording
 ```
 
 Starts a new screen recording session.
@@ -725,6 +865,10 @@ Starts a new screen recording session.
 **Arguments**:
 
 - `label` _str | None_ - Optional custom label for the recording.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -746,7 +890,8 @@ print(f"File: {recording.file_path}")
 ```python
 @intercept_errors(message_prefix="Failed to stop recording: ")
 @with_instrumentation()
-async def stop(recording_id: str) -> Recording
+async def stop(recording_id: str,
+               request_timeout: float | None = None) -> Recording
 ```
 
 Stops an active screen recording session.
@@ -754,6 +899,10 @@ Stops an active screen recording session.
 **Arguments**:
 
 - `recording_id` _str_ - The ID of the recording to stop.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -774,10 +923,18 @@ print(f"Saved to: {result.file_path}")
 ```python
 @intercept_errors(message_prefix="Failed to list recordings: ")
 @with_instrumentation()
-async def list() -> ListRecordingsResponse
+async def list(request_timeout: float | None = None) -> ListRecordingsResponse
 ```
 
 Lists all recordings (active and completed).
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -798,7 +955,8 @@ for rec in recordings.recordings:
 ```python
 @intercept_errors(message_prefix="Failed to get recording: ")
 @with_instrumentation()
-async def get(recording_id: str) -> Recording
+async def get(recording_id: str,
+              request_timeout: float | None = None) -> Recording
 ```
 
 Gets details of a specific recording by ID.
@@ -806,6 +964,10 @@ Gets details of a specific recording by ID.
 **Arguments**:
 
 - `recording_id` _str_ - The ID of the recording to retrieve.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -827,7 +989,8 @@ print(f"Duration: {recording.duration_seconds} seconds")
 ```python
 @intercept_errors(message_prefix="Failed to delete recording: ")
 @with_instrumentation()
-async def delete(recording_id: str) -> None
+async def delete(recording_id: str,
+                 request_timeout: float | None = None) -> None
 ```
 
 Deletes a recording by ID.
@@ -835,6 +998,10 @@ Deletes a recording by ID.
 **Arguments**:
 
 - `recording_id` _str_ - The ID of the recording to delete.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -886,9 +1053,11 @@ API. Start computer use before calling these methods.
 ```python
 @intercept_errors(message_prefix="Failed to get accessibility tree: ")
 @with_instrumentation()
-async def get_tree(scope: str | None = None,
-                   pid: int | None = None,
-                   max_depth: int | None = None) -> AccessibilityTreeResponse
+async def get_tree(
+        scope: str | None = None,
+        pid: int | None = None,
+        max_depth: int | None = None,
+        request_timeout: float | None = None) -> AccessibilityTreeResponse
 ```
 
 Fetches the AT-SPI accessibility tree.
@@ -898,6 +1067,10 @@ Fetches the AT-SPI accessibility tree.
 - `scope` _str | None_ - Tree scope to inspect: ``focused``, ``pid``, or ``all``.
 - `pid` _int | None_ - Process ID when ``scope`` is ``pid``.
 - `max_depth` _int | None_ - Maximum depth to descend. Use ``0`` for the root only.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -917,13 +1090,15 @@ print(tree.root.name)
 ```python
 @intercept_errors(message_prefix="Failed to find accessibility nodes: ")
 @with_instrumentation()
-async def find_nodes(scope: str | None = None,
-                     pid: int | None = None,
-                     role: str | None = None,
-                     name: str | None = None,
-                     name_match: str | None = None,
-                     states: list[str] | None = None,
-                     limit: int | None = None) -> AccessibilityNodesResponse
+async def find_nodes(
+        scope: str | None = None,
+        pid: int | None = None,
+        role: str | None = None,
+        name: str | None = None,
+        name_match: str | None = None,
+        states: list[str] | None = None,
+        limit: int | None = None,
+        request_timeout: float | None = None) -> AccessibilityNodesResponse
 ```
 
 Finds AT-SPI accessibility nodes matching the provided filters.
@@ -937,6 +1112,10 @@ Finds AT-SPI accessibility nodes matching the provided filters.
 - `name_match` _str | None_ - Name match mode, such as ``exact`` or ``substring``.
 - `states` _list[str] | None_ - Required accessibility states.
 - `limit` _int | None_ - Maximum number of matches. Use ``0`` to let the API apply its default.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -961,7 +1140,8 @@ print(len(buttons.matches))
 ```python
 @intercept_errors(message_prefix="Failed to focus accessibility node: ")
 @with_instrumentation()
-async def focus_node(node_id: str) -> None
+async def focus_node(node_id: str,
+                     request_timeout: float | None = None) -> None
 ```
 
 Focuses an AT-SPI accessibility node.
@@ -969,6 +1149,10 @@ Focuses an AT-SPI accessibility node.
 **Arguments**:
 
 - `node_id` _str_ - Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -987,7 +1171,9 @@ await sandbox.computer_use.accessibility.focus_node(node.id)
 ```python
 @intercept_errors(message_prefix="Failed to invoke accessibility node: ")
 @with_instrumentation()
-async def invoke_node(node_id: str, action: str | None = None) -> None
+async def invoke_node(node_id: str,
+                      action: str | None = None,
+                      request_timeout: float | None = None) -> None
 ```
 
 Invokes an AT-SPI accessibility node action.
@@ -996,6 +1182,10 @@ Invokes an AT-SPI accessibility node action.
 
 - `node_id` _str_ - Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
 - `action` _str | None_ - Action name to invoke. If omitted, the API invokes the primary action.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -1014,7 +1204,9 @@ await sandbox.computer_use.accessibility.invoke_node(node.id, action="click")
 ```python
 @intercept_errors(message_prefix="Failed to set accessibility node value: ")
 @with_instrumentation()
-async def set_node_value(node_id: str, value: str) -> None
+async def set_node_value(node_id: str,
+                         value: str,
+                         request_timeout: float | None = None) -> None
 ```
 
 Sets an AT-SPI accessibility node value.
@@ -1023,6 +1215,10 @@ Sets an AT-SPI accessibility node value.
 
 - `node_id` _str_ - Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
 - `value` _str_ - Value to write to the node.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:

--- a/artifacts/sdk-docs/python-sdk/async/async-daytona.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-daytona.mdx
@@ -294,7 +294,8 @@ await daytona.delete(sandbox)  # Clean up when done
 ```python
 @intercept_errors(message_prefix="Failed to get sandbox: ")
 @with_instrumentation()
-async def get(sandbox_id_or_name: str) -> AsyncSandbox
+async def get(sandbox_id_or_name: str,
+              request_timeout: float | None = None) -> AsyncSandbox
 ```
 
 Gets a Sandbox by its ID or name.
@@ -302,6 +303,10 @@ Gets a Sandbox by its ID or name.
 **Arguments**:
 
 - `sandbox_id_or_name` _str_ - The ID or name of the Sandbox to retrieve.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -327,8 +332,8 @@ print(sandbox.state)
 @intercept_errors(message_prefix="Failed to list sandboxes: ")
 @with_instrumentation()
 async def list(
-        query: ListSandboxesQuery | None = None
-) -> AsyncIterator[AsyncSandbox]
+        query: ListSandboxesQuery | None = None,
+        request_timeout: float | None = None) -> AsyncIterator[AsyncSandbox]
 ```
 
 Iterates over Sandboxes matching the given query.
@@ -336,6 +341,10 @@ Iterates over Sandboxes matching the given query.
 **Arguments**:
 
 - `query` - Optional filters, sorting, and per-page size.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Yields**:

--- a/artifacts/sdk-docs/python-sdk/async/async-file-system.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-file-system.mdx
@@ -31,7 +31,9 @@ Initializes a new FileSystem instance.
 ```python
 @intercept_errors(message_prefix="Failed to create folder: ")
 @with_instrumentation()
-async def create_folder(path: str, mode: str) -> None
+async def create_folder(path: str,
+                        mode: str,
+                        request_timeout: float | None = None) -> None
 ```
 
 Creates a new directory in the Sandbox at the specified path with the given
@@ -42,6 +44,10 @@ permissions.
 - `path` _str_ - Path where the folder should be created. Relative paths are resolved based
   on the sandbox working directory.
 - `mode` _str_ - Folder permissions in octal format (e.g., "755" for rwxr-xr-x).
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -59,7 +65,9 @@ await sandbox.fs.create_folder("workspace/secrets", "700")
 ```python
 @intercept_errors(message_prefix="Failed to delete file: ")
 @with_instrumentation()
-async def delete_file(path: str, recursive: bool = False) -> None
+async def delete_file(path: str,
+                      recursive: bool = False,
+                      request_timeout: float | None = None) -> None
 ```
 
 Deletes a file from the Sandbox.
@@ -68,6 +76,10 @@ Deletes a file from the Sandbox.
 
 - `path` _str_ - Path to the file to delete. Relative paths are resolved based on the sandbox working directory.
 - `recursive` _bool_ - If the file is a directory, this must be true to delete it.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -252,7 +264,9 @@ for result in results:
 ```python
 @intercept_errors(message_prefix="Failed to find files: ")
 @with_instrumentation()
-async def find_files(path: str, pattern: str) -> list[Match]
+async def find_files(path: str,
+                     pattern: str,
+                     request_timeout: float | None = None) -> list[Match]
 ```
 
 Searches for files containing a pattern, similar to
@@ -264,6 +278,10 @@ the grep command.
   the search will be performed recursively. Relative paths are resolved based
   on the sandbox working directory.
 - `pattern` _str_ - Search pattern to match against file contents.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -288,7 +306,8 @@ for match in matches:
 ```python
 @intercept_errors(message_prefix="Failed to get file info: ")
 @with_instrumentation()
-async def get_file_info(path: str) -> FileInfo
+async def get_file_info(path: str,
+                        request_timeout: float | None = None) -> FileInfo
 ```
 
 Gets detailed information about a file or directory, including its
@@ -298,6 +317,10 @@ size, permissions, and timestamps.
 
 - `path` _str_ - Path to the file or directory. Relative paths are resolved based
   on the sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -333,7 +356,9 @@ if info.is_dir:
 ```python
 @intercept_errors(message_prefix="Failed to list files: ")
 @with_instrumentation()
-async def list_files(path: str, depth: int | None = None) -> list[FileInfo]
+async def list_files(path: str,
+                     depth: int | None = None,
+                     request_timeout: float | None = None) -> list[FileInfo]
 ```
 
 Lists files and directories in a given path and returns their information, similar to the ls -l command.
@@ -345,6 +370,10 @@ Lists files and directories in a given path and returns their information, simil
 - `depth` _int | None_ - How many levels deep to list. depth=1 (default) lists the
   directory's entries, depth=2 also includes their children, and so on. Must be >= 1.
   Each returned FileInfo carries a full `path` field.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -374,7 +403,9 @@ print("Paths:", ", ".join(f.path for f in tree))
 ```python
 @intercept_errors(message_prefix="Failed to move files: ")
 @with_instrumentation()
-async def move_files(source: str, destination: str) -> None
+async def move_files(source: str,
+                     destination: str,
+                     request_timeout: float | None = None) -> None
 ```
 
 Moves or renames a file or directory. The parent directory of the destination must exist.
@@ -385,6 +416,10 @@ Moves or renames a file or directory. The parent directory of the destination mu
   based on the sandbox working directory.
 - `destination` _str_ - Path to the destination. Relative paths are resolved based on
   the sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -414,8 +449,11 @@ await sandbox.fs.move_files(
 ```python
 @intercept_errors(message_prefix="Failed to replace in files: ")
 @with_instrumentation()
-async def replace_in_files(files: list[str], pattern: str,
-                           new_value: str) -> list[ReplaceResult]
+async def replace_in_files(
+        files: list[str],
+        pattern: str,
+        new_value: str,
+        request_timeout: float | None = None) -> list[ReplaceResult]
 ```
 
 Performs search and replace operations across multiple files.
@@ -426,6 +464,10 @@ Performs search and replace operations across multiple files.
   resolved based on the sandbox working directory.
 - `pattern` _str_ - Pattern to search for.
 - `new_value` _str_ - Text to replace matches with.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -460,7 +502,10 @@ for result in results:
 ```python
 @intercept_errors(message_prefix="Failed to search files: ")
 @with_instrumentation()
-async def search_files(path: str, pattern: str) -> SearchFilesResponse
+async def search_files(
+        path: str,
+        pattern: str,
+        request_timeout: float | None = None) -> SearchFilesResponse
 ```
 
 Searches for files and directories whose names match the
@@ -472,6 +517,10 @@ specified pattern. The pattern can be a simple string or a glob pattern.
   based on the sandbox working directory.
 - `pattern` _str_ - Pattern to match against file names. Supports glob
   patterns (e.g., "*.py" for Python files).
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -501,7 +550,8 @@ print(f"Found {len(result.files)} test files")
 async def set_file_permissions(path: str,
                                mode: str | None = None,
                                owner: str | None = None,
-                               group: str | None = None) -> None
+                               group: str | None = None,
+                               request_timeout: float | None = None) -> None
 ```
 
 Sets permissions and ownership for a file or directory. Any of the parameters can be None
@@ -515,6 +565,10 @@ to leave that attribute unchanged.
   (e.g., "644" for rw-r--r--).
 - `owner` _str | None_ - User owner of the file.
 - `group` _str | None_ - Group owner of the file.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:

--- a/artifacts/sdk-docs/python-sdk/async/async-git.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-git.mdx
@@ -51,7 +51,9 @@ Initializes a new Git handler instance.
 ```python
 @intercept_errors(message_prefix="Failed to add files: ")
 @with_instrumentation()
-async def add(path: str, files: list[str]) -> None
+async def add(path: str,
+              files: list[str],
+              request_timeout: float | None = None) -> None
 ```
 
 Stages the specified files for the next commit, similar to
@@ -62,6 +64,10 @@ running 'git add' on the command line.
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
 - `files` _list[str]_ - List of file paths or directories to stage, relative to the repository root.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -83,7 +89,8 @@ await sandbox.git.add("workspace/repo", [
 ```python
 @intercept_errors(message_prefix="Failed to list branches: ")
 @with_instrumentation()
-async def branches(path: str) -> ListBranchResponse
+async def branches(path: str,
+                   request_timeout: float | None = None) -> ListBranchResponse
 ```
 
 Lists branches in the repository.
@@ -92,6 +99,10 @@ Lists branches in the repository.
 
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -118,7 +129,8 @@ async def clone(url: str,
                 username: str | None = None,
                 password: str | None = None,
                 insecure_skip_tls: bool | None = None,
-                depth: int | None = None) -> None
+                depth: int | None = None,
+                request_timeout: float | None = None) -> None
 ```
 
 Clones a Git repository into the specified path. It supports
@@ -140,6 +152,10 @@ repository if credentials are provided.
   Use only for trusted internal Git servers with self-signed or private-CA certs;
   credentials, if supplied, are transmitted over an unverified TLS connection.
 - `depth` _int | None_ - Create a shallow clone truncated to the given number of commits.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -177,7 +193,8 @@ async def commit(path: str,
                  message: str,
                  author: str,
                  email: str,
-                 allow_empty: bool = False) -> GitCommitResponse
+                 allow_empty: bool = False,
+                 request_timeout: float | None = None) -> GitCommitResponse
 ```
 
 Creates a new commit with the staged changes. Make sure to stage
@@ -191,6 +208,10 @@ changes using the add() method before committing.
 - `author` _str_ - Name of the commit author.
 - `email` _str_ - Email address of the commit author.
 - `allow_empty` _bool_ - Allow creating an empty commit when no changes are staged. Defaults to False.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -217,7 +238,8 @@ async def push(path: str,
                password: str | None = None,
                branch: str | None = None,
                remote: str | None = None,
-               set_upstream: bool = False) -> None
+               set_upstream: bool = False,
+               request_timeout: float | None = None) -> None
 ```
 
 Pushes all local commits on the current branch to the remote
@@ -234,6 +256,10 @@ username and password/token.
 - `remote` _str | None_ - Remote to push to. Defaults to "origin".
 - `set_upstream` _bool, optional_ - Record the pushed branch as the upstream tracking
   branch. Defaults to False.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -262,7 +288,8 @@ async def pull(path: str,
                username: str | None = None,
                password: str | None = None,
                branch: str | None = None,
-               remote: str | None = None) -> None
+               remote: str | None = None,
+               request_timeout: float | None = None) -> None
 ```
 
 Pulls changes from the remote repository. If the remote repository requires authentication,
@@ -276,6 +303,10 @@ provide username and password/token.
 - `password` _str | None_ - Git password or token for authentication.
 - `branch` _str | None_ - Branch to pull. Defaults to the current branch's upstream.
 - `remote` _str | None_ - Remote to pull from. Defaults to "origin".
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -300,7 +331,7 @@ await sandbox.git.pull("workspace/repo", remote="upstream", branch="main")
 ```python
 @intercept_errors(message_prefix="Failed to get status: ")
 @with_instrumentation()
-async def status(path: str) -> GitStatus
+async def status(path: str, request_timeout: float | None = None) -> GitStatus
 ```
 
 Gets the current Git repository status.
@@ -309,6 +340,10 @@ Gets the current Git repository status.
 
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -335,7 +370,9 @@ print(f"Commits behind: {status.behind}")
 ```python
 @intercept_errors(message_prefix="Failed to checkout branch: ")
 @with_instrumentation()
-async def checkout_branch(path: str, branch: str) -> None
+async def checkout_branch(path: str,
+                          branch: str,
+                          request_timeout: float | None = None) -> None
 ```
 
 Checkout branch in the repository.
@@ -345,6 +382,10 @@ Checkout branch in the repository.
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
 - `branch` _str_ - Name of the branch to checkout
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -359,7 +400,9 @@ await sandbox.git.checkout_branch("workspace/repo", "feature-branch")
 ```python
 @intercept_errors(message_prefix="Failed to create branch: ")
 @with_instrumentation()
-async def create_branch(path: str, name: str) -> None
+async def create_branch(path: str,
+                        name: str,
+                        request_timeout: float | None = None) -> None
 ```
 
 Create branch in the repository.
@@ -369,6 +412,10 @@ Create branch in the repository.
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
 - `name` _str_ - Name of the new branch to create
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -383,7 +430,9 @@ await sandbox.git.create_branch("workspace/repo", "new-feature")
 ```python
 @intercept_errors(message_prefix="Failed to delete branch: ")
 @with_instrumentation()
-async def delete_branch(path: str, name: str) -> None
+async def delete_branch(path: str,
+                        name: str,
+                        request_timeout: float | None = None) -> None
 ```
 
 Delete branch in the repository.
@@ -393,6 +442,10 @@ Delete branch in the repository.
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
 - `name` _str_ - Name of the branch to delete
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -409,7 +462,8 @@ await sandbox.git.delete_branch("workspace/repo", "old-feature")
 @with_instrumentation()
 async def init(path: str,
                bare: bool = False,
-               initial_branch: str | None = None) -> None
+               initial_branch: str | None = None,
+               request_timeout: float | None = None) -> None
 ```
 
 Initializes a new Git repository at the specified path.
@@ -421,6 +475,10 @@ Initializes a new Git repository at the specified path.
 - `bare` _bool, optional_ - Create a bare repository without a working tree. Defaults to False.
 - `initial_branch` _str | None_ - Name of the initial branch. If not specified, uses the
   Git default.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -437,7 +495,8 @@ await sandbox.git.init("workspace/repo", initial_branch="main")
 async def reset(path: str,
                 mode: str | None = None,
                 target: str | None = None,
-                files: list[str] | None = None) -> None
+                files: list[str] | None = None,
+                request_timeout: float | None = None) -> None
 ```
 
 Resets the current HEAD to the specified state.
@@ -449,6 +508,10 @@ Resets the current HEAD to the specified state.
 - `mode` _str | None_ - Reset mode, one of "soft", "mixed" (default), "hard", "merge" or "keep".
 - `target` _str | None_ - Revision to reset to. Defaults to HEAD.
 - `files` _list[str] | None_ - Constrain the reset to the given paths.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -470,7 +533,8 @@ async def restore(path: str,
                   files: list[str],
                   staged: bool | None = None,
                   worktree: bool | None = None,
-                  source: str | None = None) -> None
+                  source: str | None = None,
+                  request_timeout: float | None = None) -> None
 ```
 
 Restores working tree files or unstages changes.
@@ -484,6 +548,10 @@ Restores working tree files or unstages changes.
 - `worktree` _bool | None_ - Restore the working tree for the given files. Defaults to
   True when neither staged nor worktree is provided.
 - `source` _str | None_ - Restore file contents from the given revision instead of the index.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -505,7 +573,8 @@ async def remote_add(path: str,
                      name: str,
                      url: str,
                      fetch: bool = False,
-                     overwrite: bool = False) -> None
+                     overwrite: bool = False,
+                     request_timeout: float | None = None) -> None
 ```
 
 Adds (or overwrites) a remote in the repository.
@@ -518,6 +587,10 @@ Adds (or overwrites) a remote in the repository.
 - `url` _str_ - URL of the remote.
 - `fetch` _bool, optional_ - Fetch from the remote immediately after adding it. Defaults to False.
 - `overwrite` _bool, optional_ - Replace an existing remote with the same name. Defaults to False.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -531,7 +604,8 @@ await sandbox.git.remote_add("workspace/repo", "origin", "https://github.com/use
 ```python
 @intercept_errors(message_prefix="Failed to list remotes: ")
 @with_instrumentation()
-async def remotes(path: str) -> ListRemotesResponse
+async def remotes(path: str,
+                  request_timeout: float | None = None) -> ListRemotesResponse
 ```
 
 Lists the remotes configured in the repository.
@@ -540,6 +614,10 @@ Lists the remotes configured in the repository.
 
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -560,7 +638,9 @@ for remote in response.remotes:
 ```python
 @intercept_errors(message_prefix="Failed to get remote: ")
 @with_instrumentation()
-async def remote_get(path: str, name: str) -> str | None
+async def remote_get(path: str,
+                     name: str,
+                     request_timeout: float | None = None) -> str | None
 ```
 
 Gets the URL of a remote, or None when it does not exist.
@@ -570,6 +650,10 @@ Gets the URL of a remote, or None when it does not exist.
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
 - `name` _str_ - Name of the remote.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -591,7 +675,8 @@ url = await sandbox.git.remote_get("workspace/repo", "origin")
 async def set_config(key: str,
                      value: str,
                      scope: str = "global",
-                     path: str | None = None) -> None
+                     path: str | None = None,
+                     request_timeout: float | None = None) -> None
 ```
 
 Sets a Git config value at the given scope.
@@ -602,6 +687,10 @@ Sets a Git config value at the given scope.
 - `value` _str_ - Config value.
 - `scope` _str, optional_ - Config scope, one of "global" (default), "local" or "system".
 - `path` _str | None_ - Repository path, required when scope is "local".
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -617,7 +706,8 @@ await sandbox.git.set_config("user.name", "John Doe")
 @with_instrumentation()
 async def get_config(key: str,
                      scope: str = "global",
-                     path: str | None = None) -> str | None
+                     path: str | None = None,
+                     request_timeout: float | None = None) -> str | None
 ```
 
 Gets a Git config value at the given scope, or None when unset.
@@ -627,6 +717,10 @@ Gets a Git config value at the given scope, or None when unset.
 - `key` _str_ - Config key in dotted form (e.g. "user.name").
 - `scope` _str, optional_ - Config scope, one of "global" (default), "local" or "system".
 - `path` _str | None_ - Repository path, required when scope is "local".
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -648,7 +742,8 @@ name = await sandbox.git.get_config("user.name")
 async def configure_user(name: str,
                          email: str,
                          scope: str = "global",
-                         path: str | None = None) -> None
+                         path: str | None = None,
+                         request_timeout: float | None = None) -> None
 ```
 
 Configures the Git user name and email at the given scope.
@@ -659,6 +754,10 @@ Configures the Git user name and email at the given scope.
 - `email` _str_ - User email (user.email).
 - `scope` _str, optional_ - Config scope, one of "global" (default), "local" or "system".
 - `path` _str | None_ - Repository path, required when scope is "local".
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -672,10 +771,12 @@ await sandbox.git.configure_user("John Doe", "john@example.com")
 ```python
 @intercept_errors(message_prefix="Failed to authenticate: ")
 @with_instrumentation()
-async def dangerously_authenticate(username: str,
-                                   password: str,
-                                   host: str | None = None,
-                                   protocol: str | None = None) -> None
+async def dangerously_authenticate(
+        username: str,
+        password: str,
+        host: str | None = None,
+        protocol: str | None = None,
+        request_timeout: float | None = None) -> None
 ```
 
 Persists Git credentials globally so that subsequent operations against the
@@ -692,6 +793,10 @@ given host authenticate automatically.
 - `password` _str_ - Git password or token.
 - `host` _str | None_ - Host to authenticate against. Defaults to "github.com".
 - `protocol` _str | None_ - Protocol to authenticate against. Defaults to "https".
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:

--- a/artifacts/sdk-docs/python-sdk/async/async-lsp-server.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-lsp-server.mdx
@@ -33,13 +33,21 @@ Initializes a new LSP server instance.
 ```python
 @intercept_errors(message_prefix="Failed to start LSP server: ")
 @with_instrumentation()
-async def start() -> None
+async def start(request_timeout: float | None = None) -> None
 ```
 
 Starts the language server.
 
 This method must be called before using any other LSP functionality.
 It initializes the language server for the specified language and project.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Example**:
 
@@ -54,13 +62,21 @@ await lsp.start()  # Initialize the server
 ```python
 @intercept_errors(message_prefix="Failed to stop LSP server: ")
 @with_instrumentation()
-async def stop() -> None
+async def stop(request_timeout: float | None = None) -> None
 ```
 
 Stops the language server.
 
 This method should be called when the LSP server is no longer needed to
 free up system resources.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Example**:
 
@@ -74,7 +90,7 @@ await lsp.stop()  # Clean up resources
 ```python
 @intercept_errors(message_prefix="Failed to open file: ")
 @with_instrumentation()
-async def did_open(path: str) -> None
+async def did_open(path: str, request_timeout: float | None = None) -> None
 ```
 
 Notifies the language server that a file has been opened.
@@ -87,6 +103,10 @@ will begin tracking the file's contents and providing language features.
 
 - `path` _str_ - Path to the opened file. Relative paths are resolved based on the project path
   set in the LSP server constructor.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -102,7 +122,7 @@ await lsp.did_open("workspace/project/src/index.ts")
 ```python
 @intercept_errors(message_prefix="Failed to close file: ")
 @with_instrumentation()
-async def did_close(path: str) -> None
+async def did_close(path: str, request_timeout: float | None = None) -> None
 ```
 
 Notify the language server that a file has been closed.
@@ -114,6 +134,10 @@ the language server to clean up any resources associated with that file.
 
 - `path` _str_ - Path to the closed file. Relative paths are resolved based on the project path
   set in the LSP server constructor.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -128,7 +152,9 @@ await lsp.did_close("workspace/project/src/index.ts")
 ```python
 @intercept_errors(message_prefix="Failed to get symbols from document: ")
 @with_instrumentation()
-async def document_symbols(path: str) -> list[LspSymbol]
+async def document_symbols(path: str,
+                           request_timeout: float | None = None
+                           ) -> list[LspSymbol]
 ```
 
 Gets symbol information (functions, classes, variables, etc.) from a document.
@@ -137,6 +163,10 @@ Gets symbol information (functions, classes, variables, etc.) from a document.
 
 - `path` _str_ - Path to the file to get symbols from. Relative paths are resolved based on the project path
   set in the LSP server constructor.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -164,7 +194,9 @@ for symbol in symbols:
     "Method is deprecated. Use `sandbox_symbols` instead. This method will be removed in a future version."
 )
 @with_instrumentation()
-async def workspace_symbols(query: str) -> list[LspSymbol]
+async def workspace_symbols(query: str,
+                            request_timeout: float | None = None
+                            ) -> list[LspSymbol]
 ```
 
 Searches for symbols matching the query string across all files
@@ -173,6 +205,10 @@ in the Sandbox.
 **Arguments**:
 
 - `query` _str_ - Search query to match against symbol names.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -184,7 +220,9 @@ in the Sandbox.
 ```python
 @intercept_errors(message_prefix="Failed to get symbols from sandbox: ")
 @with_instrumentation()
-async def sandbox_symbols(query: str) -> list[LspSymbol]
+async def sandbox_symbols(query: str,
+                          request_timeout: float | None = None
+                          ) -> list[LspSymbol]
 ```
 
 Searches for symbols matching the query string across all files
@@ -193,6 +231,10 @@ in the Sandbox.
 **Arguments**:
 
 - `query` _str_ - Search query to match against symbol names.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -219,7 +261,8 @@ for symbol in symbols:
 @intercept_errors(message_prefix="Failed to get completions: ")
 @with_instrumentation()
 async def completions(path: str,
-                      position: LspCompletionPosition) -> CompletionList
+                      position: LspCompletionPosition,
+                      request_timeout: float | None = None) -> CompletionList
 ```
 
 Gets completion suggestions at a position in a file.
@@ -229,6 +272,10 @@ Gets completion suggestions at a position in a file.
 - `path` _str_ - Path to the file. Relative paths are resolved based on the project path
   set in the LSP server constructor.
 - `position` _LspCompletionPosition_ - Cursor position to get completions for.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:

--- a/artifacts/sdk-docs/python-sdk/async/async-process.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-process.mdx
@@ -153,7 +153,8 @@ if chart.type == ChartType.LINE and isinstance(chart, LineChart):
 ```python
 @intercept_errors(message_prefix="Failed to create session: ")
 @with_instrumentation()
-async def create_session(session_id: str) -> None
+async def create_session(session_id: str,
+                         request_timeout: float | None = None) -> None
 ```
 
 Creates a new long-running background session in the Sandbox.
@@ -165,6 +166,10 @@ long-running commands and monitor process status.
 **Arguments**:
 
 - `session_id` _str_ - Unique identifier for the new session.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -182,7 +187,8 @@ await sandbox.process.delete_session(session_id)
 
 ```python
 @intercept_errors(message_prefix="Failed to get session: ")
-async def get_session(session_id: str) -> Session
+async def get_session(session_id: str,
+                      request_timeout: float | None = None) -> Session
 ```
 
 Gets a session in the Sandbox.
@@ -190,6 +196,10 @@ Gets a session in the Sandbox.
 **Arguments**:
 
 - `session_id` _str_ - Unique identifier of the session to retrieve.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -211,10 +221,19 @@ for cmd in session.commands:
 
 ```python
 @intercept_errors(message_prefix="Failed to get sandbox entrypoint session: ")
-async def get_entrypoint_session() -> Session
+async def get_entrypoint_session(
+        request_timeout: float | None = None) -> Session
 ```
 
 Gets the sandbox entrypoint session.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -236,7 +255,9 @@ for cmd in session.commands:
 ```python
 @intercept_errors(message_prefix="Failed to get session command: ")
 @with_instrumentation()
-async def get_session_command(session_id: str, command_id: str) -> Command
+async def get_session_command(session_id: str,
+                              command_id: str,
+                              request_timeout: float | None = None) -> Command
 ```
 
 Gets information about a specific command executed in a session.
@@ -245,6 +266,10 @@ Gets information about a specific command executed in a session.
 
 - `session_id` _str_ - Unique identifier of the session.
 - `command_id` _str_ - Unique identifier of the command.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -321,7 +346,9 @@ print(f"Command stderr: {result.stderr}")
 @intercept_errors(message_prefix="Failed to get session command logs: ")
 @with_instrumentation()
 async def get_session_command_logs(
-        session_id: str, command_id: str) -> SessionCommandLogsResponse
+        session_id: str,
+        command_id: str,
+        request_timeout: float | None = None) -> SessionCommandLogsResponse
 ```
 
 Get the logs for a command executed in a session.
@@ -330,6 +357,10 @@ Get the logs for a command executed in a session.
 
 - `session_id` _str_ - Unique identifier of the session.
 - `command_id` _str_ - Unique identifier of the command.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -390,10 +421,19 @@ await sandbox.process.get_session_command_logs_async(
 ```python
 @intercept_errors(message_prefix="Failed to get entrypoint logs: ")
 @with_instrumentation()
-async def get_entrypoint_logs() -> SessionCommandLogsResponse
+async def get_entrypoint_logs(
+        request_timeout: float | None = None) -> SessionCommandLogsResponse
 ```
 
 Get the logs for the entrypoint session.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -440,8 +480,11 @@ await sandbox.process.get_entrypoint_logs_async(
 
 ```python
 @intercept_errors(message_prefix="Failed to send session command input: ")
-async def send_session_command_input(session_id: str, command_id: str,
-                                     data: str) -> None
+async def send_session_command_input(
+        session_id: str,
+        command_id: str,
+        data: str,
+        request_timeout: float | None = None) -> None
 ```
 
 Sends input data to a command executed in a session.
@@ -451,16 +494,28 @@ Sends input data to a command executed in a session.
 - `session_id` _str_ - Unique identifier of the session.
 - `command_id` _str_ - Unique identifier of the command.
 - `data` _str_ - Input data to send.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### AsyncProcess.list\_sessions
 
 ```python
 @intercept_errors(message_prefix="Failed to list sessions: ")
 @with_instrumentation()
-async def list_sessions() -> list[Session]
+async def list_sessions(request_timeout: float | None = None) -> list[Session]
 ```
 
 Lists all sessions in the Sandbox.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -481,7 +536,8 @@ for session in sessions:
 ```python
 @intercept_errors(message_prefix="Failed to delete session: ")
 @with_instrumentation()
-async def delete_session(session_id: str) -> None
+async def delete_session(session_id: str,
+                         request_timeout: float | None = None) -> None
 ```
 
 Terminates and removes a session from the Sandbox, cleaning up any resources
@@ -490,6 +546,10 @@ associated with it.
 **Arguments**:
 
 - `session_id` _str_ - Unique identifier of the session to delete.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -577,12 +637,21 @@ interact with a previously created terminal session.
 ```python
 @intercept_errors(message_prefix="Failed to list PTY sessions: ")
 @with_instrumentation()
-async def list_pty_sessions() -> list[PtySessionInfo]
+async def list_pty_sessions(
+        request_timeout: float | None = None) -> list[PtySessionInfo]
 ```
 
 Lists all PTY sessions in the Sandbox.
 
 Retrieves information about all PTY sessions in this Sandbox.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -607,7 +676,9 @@ for session in sessions:
 ```python
 @intercept_errors(message_prefix="Failed to get PTY session info: ")
 @with_instrumentation()
-async def get_pty_session_info(session_id: str) -> PtySessionInfo
+async def get_pty_session_info(
+        session_id: str,
+        request_timeout: float | None = None) -> PtySessionInfo
 ```
 
 Gets detailed information about a specific PTY session.
@@ -618,6 +689,10 @@ configuration, and metadata.
 **Arguments**:
 
 - `session_id` - Unique identifier of the PTY session to retrieve information for.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -648,7 +723,8 @@ print(f"Terminal Size: {session_info.cols}x{session_info.rows}")
 ```python
 @intercept_errors(message_prefix="Failed to kill PTY session: ")
 @with_instrumentation()
-async def kill_pty_session(session_id: str) -> None
+async def kill_pty_session(session_id: str,
+                           request_timeout: float | None = None) -> None
 ```
 
 Kills a PTY session and terminates its associated process.
@@ -660,6 +736,10 @@ This operation is irreversible. Any unsaved work in the terminal session will be
 **Arguments**:
 
 - `session_id` - Unique identifier of the PTY session to kill.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -684,8 +764,10 @@ for pty_session in pty_sessions:
 ```python
 @intercept_errors(message_prefix="Failed to resize PTY session: ")
 @with_instrumentation()
-async def resize_pty_session(session_id: str,
-                             pty_size: PtySize) -> PtySessionInfo
+async def resize_pty_session(
+        session_id: str,
+        pty_size: PtySize,
+        request_timeout: float | None = None) -> PtySessionInfo
 ```
 
 Resizes a PTY session's terminal dimensions.
@@ -698,6 +780,10 @@ output requirements.
 
 - `session_id` - Unique identifier of the PTY session to resize.
 - `pty_size` - New terminal dimensions containing the desired columns and rows.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:

--- a/artifacts/sdk-docs/python-sdk/async/async-sandbox.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-sandbox.mdx
@@ -78,10 +78,18 @@ pyright: ignore[reportRedeclaration]
 ```python
 @intercept_errors(message_prefix="Failed to refresh sandbox data: ")
 @with_instrumentation()
-async def refresh_data() -> None
+async def refresh_data(request_timeout: float | None = None) -> None
 ```
 
 Refreshes the Sandbox data from the API.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Example**:
 
@@ -173,7 +181,8 @@ lsp = sandbox.create_lsp_server("python", "workspace/project")
 ```python
 @intercept_errors(message_prefix="Failed to set labels: ")
 @with_instrumentation()
-async def set_labels(labels: dict[str, str]) -> dict[str, str]
+async def set_labels(labels: dict[str, str],
+                     request_timeout: float | None = None) -> dict[str, str]
 ```
 
 Sets labels for the Sandbox.
@@ -183,6 +192,10 @@ Labels are key-value pairs that can be used to organize and identify Sandboxes.
 **Arguments**:
 
 - `labels` _dict[str, str]_ - Dictionary of key-value pairs representing Sandbox labels.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -355,7 +368,8 @@ Treats destroyed as stopped to cover ephemeral sandboxes that are automatically 
 ```python
 @intercept_errors(message_prefix="Failed to set auto-stop interval: ")
 @with_instrumentation()
-async def set_autostop_interval(interval: int) -> None
+async def set_autostop_interval(interval: int,
+                                request_timeout: float | None = None) -> None
 ```
 
 Sets the auto-stop interval for the Sandbox.
@@ -368,6 +382,10 @@ Interactions using Sandbox Previews are not included.
 
 - `interval` _int_ - Number of minutes of inactivity before auto-stopping.
   Set to 0 to disable auto-stop. Defaults to 15.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -389,7 +407,9 @@ sandbox.set_autostop_interval(0)
 ```python
 @intercept_errors(message_prefix="Failed to set auto-archive interval: ")
 @with_instrumentation()
-async def set_auto_archive_interval(interval: int) -> None
+async def set_auto_archive_interval(interval: int,
+                                    request_timeout: float | None = None
+                                    ) -> None
 ```
 
 Sets the auto-archive interval for the Sandbox.
@@ -400,6 +420,10 @@ The Sandbox will automatically archive after being continuously stopped for the 
 
 - `interval` _int_ - Number of minutes after which a continuously stopped Sandbox will be auto-archived.
   Set to 0 for the maximum interval. Default is 7 days.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -421,7 +445,9 @@ sandbox.set_auto_archive_interval(0)
 ```python
 @intercept_errors(message_prefix="Failed to set auto-delete interval: ")
 @with_instrumentation()
-async def set_auto_delete_interval(interval: int) -> None
+async def set_auto_delete_interval(interval: int,
+                                   request_timeout: float | None = None
+                                   ) -> None
 ```
 
 Sets the auto-delete interval for the Sandbox.
@@ -433,6 +459,10 @@ The Sandbox will automatically delete after being continuously stopped for the s
 - `interval` _int_ - Number of minutes after which a continuously stopped Sandbox will be auto-deleted.
   Set to negative value to disable auto-delete. Set to 0 to delete immediately upon stopping.
   By default, auto-delete is disabled.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -455,7 +485,8 @@ async def update_network_settings(
         *,
         network_block_all: bool | None = None,
         network_allow_list: str | None = None,
-        domain_allow_list: str | None = None) -> None
+        domain_allow_list: str | None = None,
+        request_timeout: float | None = None) -> None
 ```
 
 Updates outbound network policy on the runner (block all, restore access, or CIDR allow list).
@@ -466,6 +497,10 @@ Updates outbound network policy on the runner (block all, restore access, or CID
   outbound access (and clears a stored allow list).
 - `network_allow_list` - Comma-separated IPv4 CIDRs to allow; implies not blocking all.
 - `domain_allow_list` - Comma-separated domains to allow; implies not blocking all.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -539,7 +574,9 @@ await sandbox.update_env({"MY_VAR": "value"}, unset=["OLD_VAR"])
 ```python
 @intercept_errors(message_prefix="Failed to get preview link: ")
 @with_instrumentation()
-async def get_preview_link(port: int) -> PortPreviewUrl
+async def get_preview_link(port: int,
+                           request_timeout: float | None = None
+                           ) -> PortPreviewUrl
 ```
 
 Retrieves the preview link for the sandbox at the specified port. If the port is closed,
@@ -549,6 +586,10 @@ to the URL.
 **Arguments**:
 
 - `port` _int_ - The port to open the preview link on.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -571,7 +612,8 @@ print(f"Token: {preview_link.token}")
 @intercept_errors(message_prefix="Failed to create signed preview url: ")
 async def create_signed_preview_url(
         port: int,
-        expires_in_seconds: int | None = None) -> SignedPortPreviewUrl
+        expires_in_seconds: int | None = None,
+        request_timeout: float | None = None) -> SignedPortPreviewUrl
 ```
 
 Creates a signed preview URL for the sandbox at the specified port.
@@ -581,6 +623,10 @@ Creates a signed preview URL for the sandbox at the specified port.
 - `port` _int_ - The port to open the preview link on.
 - `expires_in_seconds` _int | None_ - The number of seconds the signed preview
   url will be valid for. Defaults to 60 seconds.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -591,7 +637,10 @@ Creates a signed preview URL for the sandbox at the specified port.
 
 ```python
 @intercept_errors(message_prefix="Failed to expire signed preview url: ")
-async def expire_signed_preview_url(port: int, token: str) -> None
+async def expire_signed_preview_url(port: int,
+                                    token: str,
+                                    request_timeout: float | None = None
+                                    ) -> None
 ```
 
 Expires a signed preview URL for the sandbox at the specified port.
@@ -600,13 +649,17 @@ Expires a signed preview URL for the sandbox at the specified port.
 
 - `port` _int_ - The port to expire the signed preview url on.
 - `token` _str_ - The token to expire the signed preview url on.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### AsyncSandbox.archive
 
 ```python
 @intercept_errors(message_prefix="Failed to archive sandbox: ")
 @with_instrumentation()
-async def archive() -> None
+async def archive(request_timeout: float | None = None) -> None
 ```
 
 Archives the sandbox, making it inactive and preserving its state. When sandboxes are
@@ -614,6 +667,13 @@ archived, the entire filesystem state is moved to cost-effective object storage,
 possible to keep sandboxes available for an extended period. The tradeoff between archived
 and stopped states is that starting an archived sandbox takes more time, depending on its size.
 Sandbox must be stopped before archiving.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### AsyncSandbox.resize
 
@@ -682,7 +742,8 @@ the state is no longer 'resizing'.
 @intercept_errors(message_prefix="Failed to create SSH access: ")
 @with_instrumentation()
 async def create_ssh_access(
-        expires_in_minutes: int | None = None) -> SshAccessDto
+        expires_in_minutes: int | None = None,
+        request_timeout: float | None = None) -> SshAccessDto
 ```
 
 Creates an SSH access token for the sandbox.
@@ -690,13 +751,18 @@ Creates an SSH access token for the sandbox.
 **Arguments**:
 
 - `expires_in_minutes` _int | None_ - The number of minutes the SSH access token will be valid for.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### AsyncSandbox.revoke\_ssh\_access
 
 ```python
 @intercept_errors(message_prefix="Failed to revoke SSH access: ")
 @with_instrumentation()
-async def revoke_ssh_access(token: str) -> None
+async def revoke_ssh_access(token: str,
+                            request_timeout: float | None = None) -> None
 ```
 
 Revokes an SSH access token for the sandbox.
@@ -704,13 +770,19 @@ Revokes an SSH access token for the sandbox.
 **Arguments**:
 
 - `token` _str_ - The token to revoke.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### AsyncSandbox.validate\_ssh\_access
 
 ```python
 @intercept_errors(message_prefix="Failed to validate SSH access: ")
 @with_instrumentation()
-async def validate_ssh_access(token: str) -> SshAccessValidationDto
+async def validate_ssh_access(
+        token: str,
+        request_timeout: float | None = None) -> SshAccessValidationDto
 ```
 
 Validates an SSH access token for the sandbox.
@@ -718,18 +790,30 @@ Validates an SSH access token for the sandbox.
 **Arguments**:
 
 - `token` _str_ - The token to validate.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### AsyncSandbox.refresh\_activity
 
 ```python
 @intercept_errors(message_prefix="Failed to refresh sandbox activity: ")
-async def refresh_activity() -> None
+async def refresh_activity(request_timeout: float | None = None) -> None
 ```
 
 Refreshes the sandbox activity to reset the timer for automated lifecycle management actions.
 
 This method updates the sandbox's last activity timestamp without changing its state.
 It is useful for keeping long-running sessions alive while there is still user activity.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Example**:
 

--- a/artifacts/sdk-docs/python-sdk/sync/code-interpreter.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/code-interpreter.mdx
@@ -108,7 +108,8 @@ result = sandbox.code_interpreter.run_code(
 
 ```python
 @intercept_errors(message_prefix="Failed to create interpreter context: ")
-def create_context(cwd: str | None = None) -> InterpreterContext
+def create_context(cwd: str | None = None,
+                   request_timeout: float | None = None) -> InterpreterContext
 ```
 
 Create a new isolated interpreter context.
@@ -119,6 +120,10 @@ Variables, imports, and functions defined in one context don't affect others.
 **Arguments**:
 
 - `cwd` _str | None_ - Working directory for the context. If not specified, uses sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -154,13 +159,22 @@ sandbox.code_interpreter.delete_context(ctx)
 
 ```python
 @intercept_errors(message_prefix="Failed to list interpreter contexts: ")
-def list_contexts() -> list[InterpreterContext]
+def list_contexts(
+        request_timeout: float | None = None) -> list[InterpreterContext]
 ```
 
 List all user-created interpreter contexts.
 
 The default context is not included in this list. Only contexts created
 via `create_context()` are returned.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -184,7 +198,8 @@ for ctx in contexts:
 
 ```python
 @intercept_errors(message_prefix="Failed to delete interpreter context: ")
-def delete_context(context: InterpreterContext) -> None
+def delete_context(context: InterpreterContext,
+                   request_timeout: float | None = None) -> None
 ```
 
 Delete an interpreter context and shut down all associated processes.
@@ -195,6 +210,10 @@ The default context cannot be deleted.
 **Arguments**:
 
 - `context` _InterpreterContext_ - Context to delete.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:

--- a/artifacts/sdk-docs/python-sdk/sync/computer-use.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/computer-use.mdx
@@ -28,10 +28,18 @@ for automating desktop interactions within a sandbox.
 ```python
 @intercept_errors(message_prefix="Failed to start computer use: ")
 @with_instrumentation()
-def start() -> ComputerUseStartResponse
+def start(request_timeout: float | None = None) -> ComputerUseStartResponse
 ```
 
 Starts all computer use processes (Xvfb, xfce4, x11vnc, novnc).
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -50,10 +58,18 @@ print("Computer use processes started:", result.message)
 ```python
 @intercept_errors(message_prefix="Failed to stop computer use: ")
 @with_instrumentation()
-def stop() -> ComputerUseStopResponse
+def stop(request_timeout: float | None = None) -> ComputerUseStopResponse
 ```
 
 Stops all computer use processes.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -72,10 +88,19 @@ print("Computer use processes stopped:", result.message)
 ```python
 @intercept_errors(message_prefix="Failed to get computer use status: ")
 @with_instrumentation()
-def get_status() -> ComputerUseStatusResponse
+def get_status(
+        request_timeout: float | None = None) -> ComputerUseStatusResponse
 ```
 
 Gets the status of all computer use processes.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -94,7 +119,9 @@ print("Computer use status:", response.status)
 ```python
 @intercept_errors(message_prefix="Failed to get process status: ")
 @with_instrumentation()
-def get_process_status(process_name: str) -> ProcessStatusResponse
+def get_process_status(
+        process_name: str,
+        request_timeout: float | None = None) -> ProcessStatusResponse
 ```
 
 Gets the status of a specific VNC process.
@@ -102,6 +129,10 @@ Gets the status of a specific VNC process.
 **Arguments**:
 
 - `process_name` _str_ - Name of the process to check.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -121,7 +152,9 @@ no_vnc_status = sandbox.computer_use.get_process_status("novnc")
 ```python
 @intercept_errors(message_prefix="Failed to restart process: ")
 @with_instrumentation()
-def restart_process(process_name: str) -> ProcessRestartResponse
+def restart_process(
+        process_name: str,
+        request_timeout: float | None = None) -> ProcessRestartResponse
 ```
 
 Restarts a specific VNC process.
@@ -129,6 +162,10 @@ Restarts a specific VNC process.
 **Arguments**:
 
 - `process_name` _str_ - Name of the process to restart.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -148,7 +185,9 @@ print("XFCE4 process restarted:", result.message)
 ```python
 @intercept_errors(message_prefix="Failed to get process logs: ")
 @with_instrumentation()
-def get_process_logs(process_name: str) -> ProcessLogsResponse
+def get_process_logs(
+        process_name: str,
+        request_timeout: float | None = None) -> ProcessLogsResponse
 ```
 
 Gets logs for a specific VNC process.
@@ -156,6 +195,10 @@ Gets logs for a specific VNC process.
 **Arguments**:
 
 - `process_name` _str_ - Name of the process to get logs for.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -175,7 +218,9 @@ print("NoVNC logs:", logs)
 ```python
 @intercept_errors(message_prefix="Failed to get process errors: ")
 @with_instrumentation()
-def get_process_errors(process_name: str) -> ProcessErrorsResponse
+def get_process_errors(
+        process_name: str,
+        request_timeout: float | None = None) -> ProcessErrorsResponse
 ```
 
 Gets error logs for a specific VNC process.
@@ -183,6 +228,10 @@ Gets error logs for a specific VNC process.
 **Arguments**:
 
 - `process_name` _str_ - Name of the process to get error logs for.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -211,10 +260,19 @@ Mouse operations for computer use functionality.
 ```python
 @intercept_errors(message_prefix="Failed to get mouse position: ")
 @with_instrumentation()
-def get_position() -> MousePositionResponse
+def get_position(
+        request_timeout: float | None = None) -> MousePositionResponse
 ```
 
 Gets the current mouse cursor position.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -233,7 +291,9 @@ print(f"Mouse is at: {position.x}, {position.y}")
 ```python
 @intercept_errors(message_prefix="Failed to move mouse: ")
 @with_instrumentation()
-def move(x: int, y: int) -> MousePositionResponse
+def move(x: int,
+         y: int,
+         request_timeout: float | None = None) -> MousePositionResponse
 ```
 
 Moves the mouse cursor to the specified coordinates.
@@ -242,6 +302,10 @@ Moves the mouse cursor to the specified coordinates.
 
 - `x` _int_ - The x coordinate to move to.
 - `y` _int_ - The y coordinate to move to.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -264,7 +328,8 @@ print(f"Mouse moved to: {result.x}, {result.y}")
 def click(x: int,
           y: int,
           button: str = "left",
-          double: bool = False) -> MouseClickResponse
+          double: bool = False,
+          request_timeout: float | None = None) -> MouseClickResponse
 ```
 
 Clicks the mouse at the specified coordinates.
@@ -275,6 +340,10 @@ Clicks the mouse at the specified coordinates.
 - `y` _int_ - The y coordinate to click at.
 - `button` _str_ - The mouse button to click ('left', 'right', 'middle').
 - `double` _bool_ - Whether to perform a double-click.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -304,7 +373,8 @@ def drag(start_x: int,
          start_y: int,
          end_x: int,
          end_y: int,
-         button: str = "left") -> MouseDragResponse
+         button: str = "left",
+         request_timeout: float | None = None) -> MouseDragResponse
 ```
 
 Drags the mouse from start coordinates to end coordinates.
@@ -316,6 +386,10 @@ Drags the mouse from start coordinates to end coordinates.
 - `end_x` _int_ - The ending x coordinate.
 - `end_y` _int_ - The ending y coordinate.
 - `button` _str_ - The mouse button to use for dragging.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -335,7 +409,11 @@ print(f"Drag ended at {result.x}, {result.y}")
 ```python
 @intercept_errors(message_prefix="Failed to scroll mouse: ")
 @with_instrumentation()
-def scroll(x: int, y: int, direction: str, amount: int = 1) -> bool
+def scroll(x: int,
+           y: int,
+           direction: str,
+           amount: int = 1,
+           request_timeout: float | None = None) -> bool
 ```
 
 Scrolls the mouse wheel at the specified coordinates.
@@ -346,6 +424,10 @@ Scrolls the mouse wheel at the specified coordinates.
 - `y` _int_ - The y coordinate to scroll at.
 - `direction` _str_ - The direction to scroll ('up' or 'down').
 - `amount` _int_ - The amount to scroll.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -376,7 +458,9 @@ Keyboard operations for computer use functionality.
 ```python
 @intercept_errors(message_prefix="Failed to type text: ")
 @with_instrumentation()
-def type(text: str, delay: int | None = None) -> None
+def type(text: str,
+         delay: int | None = None,
+         request_timeout: float | None = None) -> None
 ```
 
 Types the specified text.
@@ -385,6 +469,10 @@ Types the specified text.
 
 - `text` _str_ - The text to type.
 - `delay` _int_ - Delay between characters in milliseconds.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -414,7 +502,9 @@ except Exception as e:
 ```python
 @intercept_errors(message_prefix="Failed to press key: ")
 @with_instrumentation()
-def press(key: str, modifiers: list[str] | None = None) -> None
+def press(key: str,
+          modifiers: list[str] | None = None,
+          request_timeout: float | None = None) -> None
 ```
 
 Presses a key with optional modifiers.
@@ -429,6 +519,10 @@ Presses a key with optional modifiers.
 - `modifiers` _list[str]_ - Canonical modifier names are 'ctrl', 'alt',
   'shift', and 'cmd'. Common aliases such as 'control', 'option',
   'meta', and 'win' are normalized.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -464,7 +558,7 @@ except Exception as e:
 ```python
 @intercept_errors(message_prefix="Failed to press hotkey: ")
 @with_instrumentation()
-def hotkey(keys: str) -> None
+def hotkey(keys: str, request_timeout: float | None = None) -> None
 ```
 
 Presses a hotkey combination.
@@ -474,6 +568,10 @@ Presses a hotkey combination.
 - `keys` _str_ - A single atomic hotkey chord (e.g., 'ctrl+c', 'alt+tab',
   'cmd+shift+t', 'ctrl + c', 'shift'). Uses the same normalized key
   contract as ``press()``.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -519,7 +617,9 @@ Screenshot operations for computer use functionality.
 ```python
 @intercept_errors(message_prefix="Failed to take screenshot: ")
 @with_instrumentation()
-def take_full_screen(show_cursor: bool = False) -> ScreenshotResponse
+def take_full_screen(
+        show_cursor: bool = False,
+        request_timeout: float | None = None) -> ScreenshotResponse
 ```
 
 Takes a screenshot of the entire screen.
@@ -527,6 +627,10 @@ Takes a screenshot of the entire screen.
 **Arguments**:
 
 - `show_cursor` _bool_ - Whether to show the cursor in the screenshot.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -550,7 +654,8 @@ with_cursor = sandbox.computer_use.screenshot.take_full_screen(True)
 @intercept_errors(message_prefix="Failed to take region screenshot: ")
 @with_instrumentation()
 def take_region(region: ScreenshotRegion,
-                show_cursor: bool = False) -> ScreenshotResponse
+                show_cursor: bool = False,
+                request_timeout: float | None = None) -> ScreenshotResponse
 ```
 
 Takes a screenshot of a specific region.
@@ -559,6 +664,10 @@ Takes a screenshot of a specific region.
 
 - `region` _ScreenshotRegion_ - The region to capture.
 - `show_cursor` _bool_ - Whether to show the cursor in the screenshot.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -580,7 +689,8 @@ print(f"Captured region: {screenshot.region.width}x{screenshot.region.height}")
 @intercept_errors(message_prefix="Failed to take compressed screenshot: ")
 @with_instrumentation()
 def take_compressed(
-        options: ScreenshotOptions | None = None) -> ScreenshotResponse
+        options: ScreenshotOptions | None = None,
+        request_timeout: float | None = None) -> ScreenshotResponse
 ```
 
 Takes a compressed screenshot of the entire screen.
@@ -588,6 +698,10 @@ Takes a compressed screenshot of the entire screen.
 **Arguments**:
 
 - `options` _ScreenshotOptions | None_ - Compression and display options.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -620,7 +734,8 @@ scaled = sandbox.computer_use.screenshot.take_compressed(
 @with_instrumentation()
 def take_compressed_region(
         region: ScreenshotRegion,
-        options: ScreenshotOptions | None = None) -> ScreenshotResponse
+        options: ScreenshotOptions | None = None,
+        request_timeout: float | None = None) -> ScreenshotResponse
 ```
 
 Takes a compressed screenshot of a specific region.
@@ -629,6 +744,10 @@ Takes a compressed screenshot of a specific region.
 
 - `region` _ScreenshotRegion_ - The region to capture.
 - `options` _ScreenshotOptions | None_ - Compression and display options.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -660,10 +779,18 @@ Display operations for computer use functionality.
 ```python
 @intercept_errors(message_prefix="Failed to get display info: ")
 @with_instrumentation()
-def get_info() -> DisplayInfoResponse
+def get_info(request_timeout: float | None = None) -> DisplayInfoResponse
 ```
 
 Gets information about the displays.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -685,10 +812,18 @@ for i, display in enumerate(info.displays):
 ```python
 @intercept_errors(message_prefix="Failed to get windows: ")
 @with_instrumentation()
-def get_windows() -> WindowsResponse
+def get_windows(request_timeout: float | None = None) -> WindowsResponse
 ```
 
 Gets the list of open windows.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -717,7 +852,8 @@ Recording operations for computer use functionality.
 ```python
 @intercept_errors(message_prefix="Failed to start recording: ")
 @with_instrumentation()
-def start(label: str | None = None) -> Recording
+def start(label: str | None = None,
+          request_timeout: float | None = None) -> Recording
 ```
 
 Starts a new screen recording session.
@@ -725,6 +861,10 @@ Starts a new screen recording session.
 **Arguments**:
 
 - `label` _str | None_ - Optional custom label for the recording.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -746,7 +886,7 @@ print(f"File: {recording.file_path}")
 ```python
 @intercept_errors(message_prefix="Failed to stop recording: ")
 @with_instrumentation()
-def stop(recording_id: str) -> Recording
+def stop(recording_id: str, request_timeout: float | None = None) -> Recording
 ```
 
 Stops an active screen recording session.
@@ -754,6 +894,10 @@ Stops an active screen recording session.
 **Arguments**:
 
 - `recording_id` _str_ - The ID of the recording to stop.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -774,10 +918,18 @@ print(f"Saved to: {result.file_path}")
 ```python
 @intercept_errors(message_prefix="Failed to list recordings: ")
 @with_instrumentation()
-def list() -> ListRecordingsResponse
+def list(request_timeout: float | None = None) -> ListRecordingsResponse
 ```
 
 Lists all recordings (active and completed).
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -798,7 +950,7 @@ for rec in recordings.recordings:
 ```python
 @intercept_errors(message_prefix="Failed to get recording: ")
 @with_instrumentation()
-def get(recording_id: str) -> Recording
+def get(recording_id: str, request_timeout: float | None = None) -> Recording
 ```
 
 Gets details of a specific recording by ID.
@@ -806,6 +958,10 @@ Gets details of a specific recording by ID.
 **Arguments**:
 
 - `recording_id` _str_ - The ID of the recording to retrieve.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -827,7 +983,7 @@ print(f"Duration: {recording.duration_seconds} seconds")
 ```python
 @intercept_errors(message_prefix="Failed to delete recording: ")
 @with_instrumentation()
-def delete(recording_id: str) -> None
+def delete(recording_id: str, request_timeout: float | None = None) -> None
 ```
 
 Deletes a recording by ID.
@@ -835,6 +991,10 @@ Deletes a recording by ID.
 **Arguments**:
 
 - `recording_id` _str_ - The ID of the recording to delete.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -886,9 +1046,11 @@ API. Start computer use before calling these methods.
 ```python
 @intercept_errors(message_prefix="Failed to get accessibility tree: ")
 @with_instrumentation()
-def get_tree(scope: str | None = None,
-             pid: int | None = None,
-             max_depth: int | None = None) -> AccessibilityTreeResponse
+def get_tree(
+        scope: str | None = None,
+        pid: int | None = None,
+        max_depth: int | None = None,
+        request_timeout: float | None = None) -> AccessibilityTreeResponse
 ```
 
 Fetches the AT-SPI accessibility tree.
@@ -898,6 +1060,10 @@ Fetches the AT-SPI accessibility tree.
 - `scope` _str | None_ - Tree scope to inspect: ``focused``, ``pid``, or ``all``.
 - `pid` _int | None_ - Process ID when ``scope`` is ``pid``.
 - `max_depth` _int | None_ - Maximum depth to descend. Use ``0`` for the root only.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -917,13 +1083,15 @@ print(tree.root.name)
 ```python
 @intercept_errors(message_prefix="Failed to find accessibility nodes: ")
 @with_instrumentation()
-def find_nodes(scope: str | None = None,
-               pid: int | None = None,
-               role: str | None = None,
-               name: str | None = None,
-               name_match: str | None = None,
-               states: list[str] | None = None,
-               limit: int | None = None) -> AccessibilityNodesResponse
+def find_nodes(
+        scope: str | None = None,
+        pid: int | None = None,
+        role: str | None = None,
+        name: str | None = None,
+        name_match: str | None = None,
+        states: list[str] | None = None,
+        limit: int | None = None,
+        request_timeout: float | None = None) -> AccessibilityNodesResponse
 ```
 
 Finds AT-SPI accessibility nodes matching the provided filters.
@@ -937,6 +1105,10 @@ Finds AT-SPI accessibility nodes matching the provided filters.
 - `name_match` _str | None_ - Name match mode, such as ``exact`` or ``substring``.
 - `states` _list[str] | None_ - Required accessibility states.
 - `limit` _int | None_ - Maximum number of matches. Use ``0`` to let the API apply its default.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -961,7 +1133,7 @@ print(len(buttons.matches))
 ```python
 @intercept_errors(message_prefix="Failed to focus accessibility node: ")
 @with_instrumentation()
-def focus_node(node_id: str) -> None
+def focus_node(node_id: str, request_timeout: float | None = None) -> None
 ```
 
 Focuses an AT-SPI accessibility node.
@@ -969,6 +1141,10 @@ Focuses an AT-SPI accessibility node.
 **Arguments**:
 
 - `node_id` _str_ - Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -987,7 +1163,9 @@ sandbox.computer_use.accessibility.focus_node(node.id)
 ```python
 @intercept_errors(message_prefix="Failed to invoke accessibility node: ")
 @with_instrumentation()
-def invoke_node(node_id: str, action: str | None = None) -> None
+def invoke_node(node_id: str,
+                action: str | None = None,
+                request_timeout: float | None = None) -> None
 ```
 
 Invokes an AT-SPI accessibility node action.
@@ -996,6 +1174,10 @@ Invokes an AT-SPI accessibility node action.
 
 - `node_id` _str_ - Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
 - `action` _str | None_ - Action name to invoke. If omitted, the API invokes the primary action.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -1014,7 +1196,9 @@ sandbox.computer_use.accessibility.invoke_node(node.id, action="click")
 ```python
 @intercept_errors(message_prefix="Failed to set accessibility node value: ")
 @with_instrumentation()
-def set_node_value(node_id: str, value: str) -> None
+def set_node_value(node_id: str,
+                   value: str,
+                   request_timeout: float | None = None) -> None
 ```
 
 Sets an AT-SPI accessibility node value.
@@ -1023,6 +1207,10 @@ Sets an AT-SPI accessibility node value.
 
 - `node_id` _str_ - Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
 - `value` _str_ - Value to write to the node.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:

--- a/artifacts/sdk-docs/python-sdk/sync/daytona.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/daytona.mdx
@@ -243,7 +243,8 @@ daytona.delete(sandbox)  # Clean up when done
 ```python
 @intercept_errors(message_prefix="Failed to get sandbox: ")
 @with_instrumentation()
-def get(sandbox_id_or_name: str) -> Sandbox
+def get(sandbox_id_or_name: str,
+        request_timeout: float | None = None) -> Sandbox
 ```
 
 Gets a Sandbox by its ID or name.
@@ -251,6 +252,10 @@ Gets a Sandbox by its ID or name.
 **Arguments**:
 
 - `sandbox_id_or_name` _str_ - The ID or name of the Sandbox to retrieve.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -275,7 +280,8 @@ print(sandbox.state)
 ```python
 @intercept_errors(message_prefix="Failed to list sandboxes: ")
 @with_instrumentation()
-def list(query: ListSandboxesQuery | None = None) -> Iterator[Sandbox]
+def list(query: ListSandboxesQuery | None = None,
+         request_timeout: float | None = None) -> Iterator[Sandbox]
 ```
 
 Iterates over Sandboxes matching the given query.
@@ -283,6 +289,10 @@ Iterates over Sandboxes matching the given query.
 **Arguments**:
 
 - `query` - Optional filters, sorting, and per-page size.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Yields**:

--- a/artifacts/sdk-docs/python-sdk/sync/file-system.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/file-system.mdx
@@ -32,7 +32,9 @@ Initializes a new FileSystem instance.
 ```python
 @intercept_errors(message_prefix="Failed to create folder: ")
 @with_instrumentation()
-def create_folder(path: str, mode: str) -> None
+def create_folder(path: str,
+                  mode: str,
+                  request_timeout: float | None = None) -> None
 ```
 
 Creates a new directory in the Sandbox at the specified path with the given
@@ -43,6 +45,10 @@ permissions.
 - `path` _str_ - Path where the folder should be created. Relative paths are resolved based
   on the sandbox working directory.
 - `mode` _str_ - Folder permissions in octal format (e.g., "755" for rwxr-xr-x).
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -60,7 +66,9 @@ sandbox.fs.create_folder("workspace/secrets", "700")
 ```python
 @intercept_errors(message_prefix="Failed to delete file: ")
 @with_instrumentation()
-def delete_file(path: str, recursive: bool = False) -> None
+def delete_file(path: str,
+                recursive: bool = False,
+                request_timeout: float | None = None) -> None
 ```
 
 Deletes a file from the Sandbox.
@@ -69,6 +77,10 @@ Deletes a file from the Sandbox.
 
 - `path` _str_ - Path to the file to delete. Relative paths are resolved based on the sandbox working directory.
 - `recursive` _bool_ - If the file is a directory, this must be true to delete it.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -249,7 +261,9 @@ for result in results:
 ```python
 @intercept_errors(message_prefix="Failed to find files: ")
 @with_instrumentation()
-def find_files(path: str, pattern: str) -> list[Match]
+def find_files(path: str,
+               pattern: str,
+               request_timeout: float | None = None) -> list[Match]
 ```
 
 Searches for files containing a pattern, similar to
@@ -261,6 +275,10 @@ the grep command.
   the search will be performed recursively. Relative paths are resolved based
   on the sandbox working directory.
 - `pattern` _str_ - Search pattern to match against file contents.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -285,7 +303,7 @@ for match in matches:
 ```python
 @intercept_errors(message_prefix="Failed to get file info: ")
 @with_instrumentation()
-def get_file_info(path: str) -> FileInfo
+def get_file_info(path: str, request_timeout: float | None = None) -> FileInfo
 ```
 
 Gets detailed information about a file or directory, including its
@@ -295,6 +313,10 @@ size, permissions, and timestamps.
 
 - `path` _str_ - Path to the file or directory. Relative paths are resolved based
   on the sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -330,7 +352,9 @@ if info.is_dir:
 ```python
 @intercept_errors(message_prefix="Failed to list files: ")
 @with_instrumentation()
-def list_files(path: str, depth: int | None = None) -> list[FileInfo]
+def list_files(path: str,
+               depth: int | None = None,
+               request_timeout: float | None = None) -> list[FileInfo]
 ```
 
 Lists files and directories in a given path and returns their information, similar to the ls -l command.
@@ -342,6 +366,10 @@ Lists files and directories in a given path and returns their information, simil
 - `depth` _int | None_ - How many levels deep to list. depth=1 (default) lists the
   directory's entries, depth=2 also includes their children, and so on. Must be >= 1.
   Each returned FileInfo carries a full `path` field.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -371,7 +399,9 @@ print("Paths:", ", ".join(f.path for f in tree))
 ```python
 @intercept_errors(message_prefix="Failed to move files: ")
 @with_instrumentation()
-def move_files(source: str, destination: str) -> None
+def move_files(source: str,
+               destination: str,
+               request_timeout: float | None = None) -> None
 ```
 
 Moves or renames a file or directory. The parent directory of the destination must exist.
@@ -382,6 +412,10 @@ Moves or renames a file or directory. The parent directory of the destination mu
   based on the sandbox working directory.
 - `destination` _str_ - Path to the destination. Relative paths are resolved based on
   the sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -411,8 +445,11 @@ sandbox.fs.move_files(
 ```python
 @intercept_errors(message_prefix="Failed to replace in files: ")
 @with_instrumentation()
-def replace_in_files(files: list[str], pattern: str,
-                     new_value: str) -> list[ReplaceResult]
+def replace_in_files(
+        files: list[str],
+        pattern: str,
+        new_value: str,
+        request_timeout: float | None = None) -> list[ReplaceResult]
 ```
 
 Performs search and replace operations across multiple files.
@@ -423,6 +460,10 @@ Performs search and replace operations across multiple files.
   resolved based on the sandbox working directory.
 - `pattern` _str_ - Pattern to search for.
 - `new_value` _str_ - Text to replace matches with.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -457,7 +498,9 @@ for result in results:
 ```python
 @intercept_errors(message_prefix="Failed to search files: ")
 @with_instrumentation()
-def search_files(path: str, pattern: str) -> SearchFilesResponse
+def search_files(path: str,
+                 pattern: str,
+                 request_timeout: float | None = None) -> SearchFilesResponse
 ```
 
 Searches for files and directories whose names match the
@@ -469,6 +512,10 @@ specified pattern. The pattern can be a simple string or a glob pattern.
   based on the sandbox working directory.
 - `pattern` _str_ - Pattern to match against file names. Supports glob
   patterns (e.g., "*.py" for Python files).
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -498,7 +545,8 @@ print(f"Found {len(result.files)} test files")
 def set_file_permissions(path: str,
                          mode: str | None = None,
                          owner: str | None = None,
-                         group: str | None = None) -> None
+                         group: str | None = None,
+                         request_timeout: float | None = None) -> None
 ```
 
 Sets permissions and ownership for a file or directory. Any of the parameters can be None
@@ -512,6 +560,10 @@ to leave that attribute unchanged.
   (e.g., "644" for rw-r--r--).
 - `owner` _str | None_ - User owner of the file.
 - `group` _str | None_ - Group owner of the file.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:

--- a/artifacts/sdk-docs/python-sdk/sync/git.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/git.mdx
@@ -51,7 +51,9 @@ Initializes a new Git handler instance.
 ```python
 @intercept_errors(message_prefix="Failed to add files: ")
 @with_instrumentation()
-def add(path: str, files: list[str]) -> None
+def add(path: str,
+        files: list[str],
+        request_timeout: float | None = None) -> None
 ```
 
 Stages the specified files for the next commit, similar to
@@ -62,6 +64,10 @@ running 'git add' on the command line.
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
 - `files` _list[str]_ - List of file paths or directories to stage, relative to the repository root.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -83,7 +89,8 @@ sandbox.git.add("workspace/repo", [
 ```python
 @intercept_errors(message_prefix="Failed to list branches: ")
 @with_instrumentation()
-def branches(path: str) -> ListBranchResponse
+def branches(path: str,
+             request_timeout: float | None = None) -> ListBranchResponse
 ```
 
 Lists branches in the repository.
@@ -92,6 +99,10 @@ Lists branches in the repository.
 
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -118,7 +129,8 @@ def clone(url: str,
           username: str | None = None,
           password: str | None = None,
           insecure_skip_tls: bool | None = None,
-          depth: int | None = None) -> None
+          depth: int | None = None,
+          request_timeout: float | None = None) -> None
 ```
 
 Clones a Git repository into the specified path. It supports
@@ -140,6 +152,10 @@ repository if credentials are provided.
   Use only for trusted internal Git servers with self-signed or private-CA certs;
   credentials, if supplied, are transmitted over an unverified TLS connection.
 - `depth` _int | None_ - Create a shallow clone truncated to the given number of commits.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -177,7 +193,8 @@ def commit(path: str,
            message: str,
            author: str,
            email: str,
-           allow_empty: bool = False) -> GitCommitResponse
+           allow_empty: bool = False,
+           request_timeout: float | None = None) -> GitCommitResponse
 ```
 
 Creates a new commit with the staged changes. Make sure to stage
@@ -191,6 +208,10 @@ changes using the add() method before committing.
 - `author` _str_ - Name of the commit author.
 - `email` _str_ - Email address of the commit author.
 - `allow_empty` _bool, optional_ - Allow creating an empty commit when no changes are staged. Defaults to False.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -217,7 +238,8 @@ def push(path: str,
          password: str | None = None,
          branch: str | None = None,
          remote: str | None = None,
-         set_upstream: bool = False) -> None
+         set_upstream: bool = False,
+         request_timeout: float | None = None) -> None
 ```
 
 Pushes all local commits on the current branch to the remote
@@ -234,6 +256,10 @@ username and password/token.
 - `remote` _str | None_ - Remote to push to. Defaults to "origin".
 - `set_upstream` _bool, optional_ - Record the pushed branch as the upstream tracking
   branch. Defaults to False.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -262,7 +288,8 @@ def pull(path: str,
          username: str | None = None,
          password: str | None = None,
          branch: str | None = None,
-         remote: str | None = None) -> None
+         remote: str | None = None,
+         request_timeout: float | None = None) -> None
 ```
 
 Pulls changes from the remote repository. If the remote repository requires authentication,
@@ -276,6 +303,10 @@ provide username and password/token.
 - `password` _str | None_ - Git password or token for authentication.
 - `branch` _str | None_ - Branch to pull. Defaults to the current branch's upstream.
 - `remote` _str | None_ - Remote to pull from. Defaults to "origin".
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -300,7 +331,7 @@ sandbox.git.pull("workspace/repo", remote="upstream", branch="main")
 ```python
 @intercept_errors(message_prefix="Failed to get status: ")
 @with_instrumentation()
-def status(path: str) -> GitStatus
+def status(path: str, request_timeout: float | None = None) -> GitStatus
 ```
 
 Gets the current Git repository status.
@@ -309,6 +340,10 @@ Gets the current Git repository status.
 
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -335,7 +370,9 @@ print(f"Commits behind: {status.behind}")
 ```python
 @intercept_errors(message_prefix="Failed to checkout branch: ")
 @with_instrumentation()
-def checkout_branch(path: str, branch: str) -> None
+def checkout_branch(path: str,
+                    branch: str,
+                    request_timeout: float | None = None) -> None
 ```
 
 Checkout branch in the repository.
@@ -345,6 +382,10 @@ Checkout branch in the repository.
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
 - `branch` _str_ - Name of the branch to checkout
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -359,7 +400,9 @@ sandbox.git.checkout_branch("workspace/repo", "feature-branch")
 ```python
 @intercept_errors(message_prefix="Failed to create branch: ")
 @with_instrumentation()
-def create_branch(path: str, name: str) -> None
+def create_branch(path: str,
+                  name: str,
+                  request_timeout: float | None = None) -> None
 ```
 
 Create branch in the repository.
@@ -369,6 +412,10 @@ Create branch in the repository.
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
 - `name` _str_ - Name of the new branch to create
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -383,7 +430,9 @@ sandbox.git.create_branch("workspace/repo", "new-feature")
 ```python
 @intercept_errors(message_prefix="Failed to delete branch: ")
 @with_instrumentation()
-def delete_branch(path: str, name: str) -> None
+def delete_branch(path: str,
+                  name: str,
+                  request_timeout: float | None = None) -> None
 ```
 
 Delete branch in the repository.
@@ -393,6 +442,10 @@ Delete branch in the repository.
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
 - `name` _str_ - Name of the branch to delete
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -409,7 +462,8 @@ sandbox.git.delete_branch("workspace/repo", "old-feature")
 @with_instrumentation()
 def init(path: str,
          bare: bool = False,
-         initial_branch: str | None = None) -> None
+         initial_branch: str | None = None,
+         request_timeout: float | None = None) -> None
 ```
 
 Initializes a new Git repository at the specified path.
@@ -421,6 +475,10 @@ Initializes a new Git repository at the specified path.
 - `bare` _bool, optional_ - Create a bare repository without a working tree. Defaults to False.
 - `initial_branch` _str | None_ - Name of the initial branch. If not specified, uses the
   Git default.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -437,7 +495,8 @@ sandbox.git.init("workspace/repo", initial_branch="main")
 def reset(path: str,
           mode: str | None = None,
           target: str | None = None,
-          files: list[str] | None = None) -> None
+          files: list[str] | None = None,
+          request_timeout: float | None = None) -> None
 ```
 
 Resets the current HEAD to the specified state.
@@ -449,6 +508,10 @@ Resets the current HEAD to the specified state.
 - `mode` _str | None_ - Reset mode, one of "soft", "mixed" (default), "hard", "merge" or "keep".
 - `target` _str | None_ - Revision to reset to. Defaults to HEAD.
 - `files` _list[str] | None_ - Constrain the reset to the given paths.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -470,7 +533,8 @@ def restore(path: str,
             files: list[str],
             staged: bool | None = None,
             worktree: bool | None = None,
-            source: str | None = None) -> None
+            source: str | None = None,
+            request_timeout: float | None = None) -> None
 ```
 
 Restores working tree files or unstages changes.
@@ -484,6 +548,10 @@ Restores working tree files or unstages changes.
 - `worktree` _bool | None_ - Restore the working tree for the given files. Defaults to
   True when neither staged nor worktree is provided.
 - `source` _str | None_ - Restore file contents from the given revision instead of the index.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -505,7 +573,8 @@ def remote_add(path: str,
                name: str,
                url: str,
                fetch: bool = False,
-               overwrite: bool = False) -> None
+               overwrite: bool = False,
+               request_timeout: float | None = None) -> None
 ```
 
 Adds (or overwrites) a remote in the repository.
@@ -518,6 +587,10 @@ Adds (or overwrites) a remote in the repository.
 - `url` _str_ - URL of the remote.
 - `fetch` _bool, optional_ - Fetch from the remote immediately after adding it. Defaults to False.
 - `overwrite` _bool, optional_ - Replace an existing remote with the same name. Defaults to False.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -531,7 +604,8 @@ sandbox.git.remote_add("workspace/repo", "origin", "https://github.com/user/repo
 ```python
 @intercept_errors(message_prefix="Failed to list remotes: ")
 @with_instrumentation()
-def remotes(path: str) -> ListRemotesResponse
+def remotes(path: str,
+            request_timeout: float | None = None) -> ListRemotesResponse
 ```
 
 Lists the remotes configured in the repository.
@@ -540,6 +614,10 @@ Lists the remotes configured in the repository.
 
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -560,7 +638,9 @@ for remote in response.remotes:
 ```python
 @intercept_errors(message_prefix="Failed to get remote: ")
 @with_instrumentation()
-def remote_get(path: str, name: str) -> str | None
+def remote_get(path: str,
+               name: str,
+               request_timeout: float | None = None) -> str | None
 ```
 
 Gets the URL of a remote, or None when it does not exist.
@@ -570,6 +650,10 @@ Gets the URL of a remote, or None when it does not exist.
 - `path` _str_ - Path to the Git repository root. Relative paths are resolved based on
   the sandbox working directory.
 - `name` _str_ - Name of the remote.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -591,7 +675,8 @@ url = sandbox.git.remote_get("workspace/repo", "origin")
 def set_config(key: str,
                value: str,
                scope: str = "global",
-               path: str | None = None) -> None
+               path: str | None = None,
+               request_timeout: float | None = None) -> None
 ```
 
 Sets a Git config value at the given scope.
@@ -602,6 +687,10 @@ Sets a Git config value at the given scope.
 - `value` _str_ - Config value.
 - `scope` _str, optional_ - Config scope, one of "global" (default), "local" or "system".
 - `path` _str | None_ - Repository path, required when scope is "local".
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -617,7 +706,8 @@ sandbox.git.set_config("user.name", "John Doe")
 @with_instrumentation()
 def get_config(key: str,
                scope: str = "global",
-               path: str | None = None) -> str | None
+               path: str | None = None,
+               request_timeout: float | None = None) -> str | None
 ```
 
 Gets a Git config value at the given scope, or None when unset.
@@ -627,6 +717,10 @@ Gets a Git config value at the given scope, or None when unset.
 - `key` _str_ - Config key in dotted form (e.g. "user.name").
 - `scope` _str, optional_ - Config scope, one of "global" (default), "local" or "system".
 - `path` _str | None_ - Repository path, required when scope is "local".
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -648,7 +742,8 @@ name = sandbox.git.get_config("user.name")
 def configure_user(name: str,
                    email: str,
                    scope: str = "global",
-                   path: str | None = None) -> None
+                   path: str | None = None,
+                   request_timeout: float | None = None) -> None
 ```
 
 Configures the Git user name and email at the given scope.
@@ -659,6 +754,10 @@ Configures the Git user name and email at the given scope.
 - `email` _str_ - User email (user.email).
 - `scope` _str, optional_ - Config scope, one of "global" (default), "local" or "system".
 - `path` _str | None_ - Repository path, required when scope is "local".
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -675,7 +774,8 @@ sandbox.git.configure_user("John Doe", "john@example.com")
 def dangerously_authenticate(username: str,
                              password: str,
                              host: str | None = None,
-                             protocol: str | None = None) -> None
+                             protocol: str | None = None,
+                             request_timeout: float | None = None) -> None
 ```
 
 Persists Git credentials globally so that subsequent operations against the
@@ -692,6 +792,10 @@ given host authenticate automatically.
 - `password` _str_ - Git password or token.
 - `host` _str | None_ - Host to authenticate against. Defaults to "github.com".
 - `protocol` _str | None_ - Protocol to authenticate against. Defaults to "https".
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:

--- a/artifacts/sdk-docs/python-sdk/sync/lsp-server.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/lsp-server.mdx
@@ -33,13 +33,21 @@ Initializes a new LSP server instance.
 ```python
 @intercept_errors(message_prefix="Failed to start LSP server: ")
 @with_instrumentation()
-def start() -> None
+def start(request_timeout: float | None = None) -> None
 ```
 
 Starts the language server.
 
 This method must be called before using any other LSP functionality.
 It initializes the language server for the specified language and project.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Example**:
 
@@ -54,13 +62,21 @@ lsp.start()  # Initialize the server
 ```python
 @intercept_errors(message_prefix="Failed to stop LSP server: ")
 @with_instrumentation()
-def stop() -> None
+def stop(request_timeout: float | None = None) -> None
 ```
 
 Stops the language server.
 
 This method should be called when the LSP server is no longer needed to
 free up system resources.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Example**:
 
@@ -74,7 +90,7 @@ lsp.stop()  # Clean up resources
 ```python
 @intercept_errors(message_prefix="Failed to open file: ")
 @with_instrumentation()
-def did_open(path: str) -> None
+def did_open(path: str, request_timeout: float | None = None) -> None
 ```
 
 Notifies the language server that a file has been opened.
@@ -87,6 +103,10 @@ will begin tracking the file's contents and providing language features.
 
 - `path` _str_ - Path to the opened file. Relative paths are resolved based on the project path
   set in the LSP server constructor.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -102,7 +122,7 @@ lsp.did_open("workspace/project/src/index.ts")
 ```python
 @intercept_errors(message_prefix="Failed to close file: ")
 @with_instrumentation()
-def did_close(path: str) -> None
+def did_close(path: str, request_timeout: float | None = None) -> None
 ```
 
 Notify the language server that a file has been closed.
@@ -114,6 +134,10 @@ the language server to clean up any resources associated with that file.
 
 - `path` _str_ - Path to the closed file. Relative paths are resolved based on the project path
   set in the LSP server constructor.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -128,7 +152,8 @@ lsp.did_close("workspace/project/src/index.ts")
 ```python
 @intercept_errors(message_prefix="Failed to get symbols from document: ")
 @with_instrumentation()
-def document_symbols(path: str) -> list[LspSymbol]
+def document_symbols(path: str,
+                     request_timeout: float | None = None) -> list[LspSymbol]
 ```
 
 Gets symbol information (functions, classes, variables, etc.) from a document.
@@ -137,6 +162,10 @@ Gets symbol information (functions, classes, variables, etc.) from a document.
 
 - `path` _str_ - Path to the file to get symbols from. Relative paths are resolved based on the project path
   set in the LSP server constructor.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -164,7 +193,8 @@ for symbol in symbols:
     "Method is deprecated. Use `sandbox_symbols` instead. This method will be removed in a future version."
 )
 @with_instrumentation()
-def workspace_symbols(query: str) -> list[LspSymbol]
+def workspace_symbols(query: str,
+                      request_timeout: float | None = None) -> list[LspSymbol]
 ```
 
 Searches for symbols matching the query string across all files
@@ -173,6 +203,10 @@ in the Sandbox.
 **Arguments**:
 
 - `query` _str_ - Search query to match against symbol names.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -184,7 +218,8 @@ in the Sandbox.
 ```python
 @intercept_errors(message_prefix="Failed to get symbols from sandbox: ")
 @with_instrumentation()
-def sandbox_symbols(query: str) -> list[LspSymbol]
+def sandbox_symbols(query: str,
+                    request_timeout: float | None = None) -> list[LspSymbol]
 ```
 
 Searches for symbols matching the query string across all files
@@ -193,6 +228,10 @@ in the Sandbox.
 **Arguments**:
 
 - `query` _str_ - Search query to match against symbol names.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -218,7 +257,9 @@ for symbol in symbols:
 ```python
 @intercept_errors(message_prefix="Failed to get completions: ")
 @with_instrumentation()
-def completions(path: str, position: LspCompletionPosition) -> CompletionList
+def completions(path: str,
+                position: LspCompletionPosition,
+                request_timeout: float | None = None) -> CompletionList
 ```
 
 Gets completion suggestions at a position in a file.
@@ -228,6 +269,10 @@ Gets completion suggestions at a position in a file.
 - `path` _str_ - Path to the file. Relative paths are resolved based on the project path
   set in the LSP server constructor.
 - `position` _LspCompletionPosition_ - Cursor position to get completions for.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:

--- a/artifacts/sdk-docs/python-sdk/sync/process.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/process.mdx
@@ -154,7 +154,8 @@ if chart.type == ChartType.LINE and isinstance(chart, LineChart):
 ```python
 @intercept_errors(message_prefix="Failed to create session: ")
 @with_instrumentation()
-def create_session(session_id: str) -> None
+def create_session(session_id: str,
+                   request_timeout: float | None = None) -> None
 ```
 
 Creates a new long-running background session in the Sandbox.
@@ -166,6 +167,10 @@ long-running commands and monitor process status.
 **Arguments**:
 
 - `session_id` _str_ - Unique identifier for the new session.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -183,7 +188,8 @@ sandbox.process.delete_session(session_id)
 
 ```python
 @intercept_errors(message_prefix="Failed to get session: ")
-def get_session(session_id: str) -> Session
+def get_session(session_id: str,
+                request_timeout: float | None = None) -> Session
 ```
 
 Gets a session in the Sandbox.
@@ -191,6 +197,10 @@ Gets a session in the Sandbox.
 **Arguments**:
 
 - `session_id` _str_ - Unique identifier of the session to retrieve.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -212,10 +222,18 @@ for cmd in session.commands:
 
 ```python
 @intercept_errors(message_prefix="Failed to get sandbox entrypoint session: ")
-def get_entrypoint_session() -> Session
+def get_entrypoint_session(request_timeout: float | None = None) -> Session
 ```
 
 Gets the sandbox entrypoint session.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -237,7 +255,9 @@ for cmd in session.commands:
 ```python
 @intercept_errors(message_prefix="Failed to get session command: ")
 @with_instrumentation()
-def get_session_command(session_id: str, command_id: str) -> Command
+def get_session_command(session_id: str,
+                        command_id: str,
+                        request_timeout: float | None = None) -> Command
 ```
 
 Gets information about a specific command executed in a session.
@@ -246,6 +266,10 @@ Gets information about a specific command executed in a session.
 
 - `session_id` _str_ - Unique identifier of the session.
 - `command_id` _str_ - Unique identifier of the command.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -321,8 +345,10 @@ print(f"Command stderr: {result.stderr}")
 ```python
 @intercept_errors(message_prefix="Failed to get session command logs: ")
 @with_instrumentation()
-def get_session_command_logs(session_id: str,
-                             command_id: str) -> SessionCommandLogsResponse
+def get_session_command_logs(
+        session_id: str,
+        command_id: str,
+        request_timeout: float | None = None) -> SessionCommandLogsResponse
 ```
 
 Get the logs for a command executed in a session.
@@ -331,6 +357,10 @@ Get the logs for a command executed in a session.
 
 - `session_id` _str_ - Unique identifier of the session.
 - `command_id` _str_ - Unique identifier of the command.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -391,10 +421,19 @@ await sandbox.process.get_session_command_logs_async(
 ```python
 @intercept_errors(message_prefix="Failed to get entrypoint logs: ")
 @with_instrumentation()
-def get_entrypoint_logs() -> SessionCommandLogsResponse
+def get_entrypoint_logs(
+        request_timeout: float | None = None) -> SessionCommandLogsResponse
 ```
 
 Get the logs for the entrypoint session.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -441,8 +480,10 @@ await sandbox.process.get_entrypoint_logs_async(
 
 ```python
 @intercept_errors(message_prefix="Failed to send session command input: ")
-def send_session_command_input(session_id: str, command_id: str,
-                               data: str) -> None
+def send_session_command_input(session_id: str,
+                               command_id: str,
+                               data: str,
+                               request_timeout: float | None = None) -> None
 ```
 
 Sends input data to a command executed in a session.
@@ -452,16 +493,28 @@ Sends input data to a command executed in a session.
 - `session_id` _str_ - Unique identifier of the session.
 - `command_id` _str_ - Unique identifier of the command.
 - `data` _str_ - Input data to send.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### Process.list\_sessions
 
 ```python
 @intercept_errors(message_prefix="Failed to list sessions: ")
 @with_instrumentation()
-def list_sessions() -> list[Session]
+def list_sessions(request_timeout: float | None = None) -> list[Session]
 ```
 
 Lists all sessions in the Sandbox.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -482,7 +535,8 @@ for session in sessions:
 ```python
 @intercept_errors(message_prefix="Failed to delete session: ")
 @with_instrumentation()
-def delete_session(session_id: str) -> None
+def delete_session(session_id: str,
+                   request_timeout: float | None = None) -> None
 ```
 
 Terminates and removes a session from the Sandbox, cleaning up any resources
@@ -491,6 +545,10 @@ associated with it.
 **Arguments**:
 
 - `session_id` _str_ - Unique identifier of the session to delete.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -571,12 +629,21 @@ interact with a previously created terminal session.
 ```python
 @intercept_errors(message_prefix="Failed to list PTY sessions: ")
 @with_instrumentation()
-def list_pty_sessions() -> list[PtySessionInfo]
+def list_pty_sessions(
+        request_timeout: float | None = None) -> list[PtySessionInfo]
 ```
 
 Lists all PTY sessions in the Sandbox.
 
 Retrieves information about all PTY sessions in this Sandbox.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Returns**:
 
@@ -601,7 +668,9 @@ for session in sessions:
 ```python
 @intercept_errors(message_prefix="Failed to get PTY session info: ")
 @with_instrumentation()
-def get_pty_session_info(session_id: str) -> PtySessionInfo
+def get_pty_session_info(
+        session_id: str,
+        request_timeout: float | None = None) -> PtySessionInfo
 ```
 
 Gets detailed information about a specific PTY session.
@@ -612,6 +681,10 @@ configuration, and metadata.
 **Arguments**:
 
 - `session_id` - Unique identifier of the PTY session to retrieve information for.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -642,7 +715,8 @@ print(f"Terminal Size: {session_info.cols}x{session_info.rows}")
 ```python
 @intercept_errors(message_prefix="Failed to kill PTY session: ")
 @with_instrumentation()
-def kill_pty_session(session_id: str) -> None
+def kill_pty_session(session_id: str,
+                     request_timeout: float | None = None) -> None
 ```
 
 Kills a PTY session and terminates its associated process.
@@ -654,6 +728,10 @@ This operation is irreversible. Any unsaved work in the terminal session will be
 **Arguments**:
 
 - `session_id` - Unique identifier of the PTY session to kill.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -678,7 +756,9 @@ for pty_session in pty_sessions:
 ```python
 @intercept_errors(message_prefix="Failed to resize PTY session: ")
 @with_instrumentation()
-def resize_pty_session(session_id: str, pty_size: PtySize) -> PtySessionInfo
+def resize_pty_session(session_id: str,
+                       pty_size: PtySize,
+                       request_timeout: float | None = None) -> PtySessionInfo
 ```
 
 Resizes a PTY session's terminal dimensions.
@@ -691,6 +771,10 @@ output requirements.
 
 - `session_id` - Unique identifier of the PTY session to resize.
 - `pty_size` - New terminal dimensions containing the desired columns and rows.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:

--- a/artifacts/sdk-docs/python-sdk/sync/sandbox.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/sandbox.mdx
@@ -95,10 +95,18 @@ Initialize a new Sandbox instance.
 ```python
 @intercept_errors(message_prefix="Failed to refresh sandbox data: ")
 @with_instrumentation()
-def refresh_data() -> None
+def refresh_data(request_timeout: float | None = None) -> None
 ```
 
 Refreshes the Sandbox data from the API.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Example**:
 
@@ -190,7 +198,8 @@ lsp = sandbox.create_lsp_server("python", "workspace/project")
 ```python
 @intercept_errors(message_prefix="Failed to set labels: ")
 @with_instrumentation()
-def set_labels(labels: dict[str, str]) -> dict[str, str]
+def set_labels(labels: dict[str, str],
+               request_timeout: float | None = None) -> dict[str, str]
 ```
 
 Sets labels for the Sandbox.
@@ -200,6 +209,10 @@ Labels are key-value pairs that can be used to organize and identify Sandboxes.
 **Arguments**:
 
 - `labels` _dict[str, str]_ - Dictionary of key-value pairs representing Sandbox labels.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -372,7 +385,8 @@ Treats destroyed as stopped to cover ephemeral sandboxes that are automatically 
 ```python
 @intercept_errors(message_prefix="Failed to set auto-stop interval: ")
 @with_instrumentation()
-def set_autostop_interval(interval: int) -> None
+def set_autostop_interval(interval: int,
+                          request_timeout: float | None = None) -> None
 ```
 
 Sets the auto-stop interval for the Sandbox.
@@ -385,6 +399,10 @@ Interactions using Sandbox Previews are not included.
 
 - `interval` _int_ - Number of minutes of inactivity before auto-stopping.
   Set to 0 to disable auto-stop. Defaults to 15.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -406,7 +424,8 @@ sandbox.set_autostop_interval(0)
 ```python
 @intercept_errors(message_prefix="Failed to set auto-archive interval: ")
 @with_instrumentation()
-def set_auto_archive_interval(interval: int) -> None
+def set_auto_archive_interval(interval: int,
+                              request_timeout: float | None = None) -> None
 ```
 
 Sets the auto-archive interval for the Sandbox.
@@ -417,6 +436,10 @@ The Sandbox will automatically archive after being continuously stopped for the 
 
 - `interval` _int_ - Number of minutes after which a continuously stopped Sandbox will be auto-archived.
   Set to 0 for the maximum interval. Default is 7 days.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -438,7 +461,8 @@ sandbox.set_auto_archive_interval(0)
 ```python
 @intercept_errors(message_prefix="Failed to set auto-delete interval: ")
 @with_instrumentation()
-def set_auto_delete_interval(interval: int) -> None
+def set_auto_delete_interval(interval: int,
+                             request_timeout: float | None = None) -> None
 ```
 
 Sets the auto-delete interval for the Sandbox.
@@ -450,6 +474,10 @@ The Sandbox will automatically delete after being continuously stopped for the s
 - `interval` _int_ - Number of minutes after which a continuously stopped Sandbox will be auto-deleted.
   Set to negative value to disable auto-delete. Set to 0 to delete immediately upon stopping.
   By default, auto-delete is disabled.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Example**:
@@ -471,7 +499,8 @@ sandbox.set_auto_delete_interval(-1)
 def update_network_settings(*,
                             network_block_all: bool | None = None,
                             network_allow_list: str | None = None,
-                            domain_allow_list: str | None = None) -> None
+                            domain_allow_list: str | None = None,
+                            request_timeout: float | None = None) -> None
 ```
 
 Updates outbound network policy on the runner (block all, restore access, or CIDR allow list).
@@ -482,6 +511,10 @@ Updates outbound network policy on the runner (block all, restore access, or CID
   outbound access (and clears a stored allow list).
 - `network_allow_list` - Comma-separated IPv4 CIDRs to allow; implies not blocking all.
 - `domain_allow_list` - Comma-separated domains to allow; implies not blocking all.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Raises**:
@@ -553,7 +586,8 @@ sandbox.update_env({"MY_VAR": "value"}, unset=["OLD_VAR"])
 ```python
 @intercept_errors(message_prefix="Failed to get preview link: ")
 @with_instrumentation()
-def get_preview_link(port: int) -> PortPreviewUrl
+def get_preview_link(port: int,
+                     request_timeout: float | None = None) -> PortPreviewUrl
 ```
 
 Retrieves the preview link for the sandbox at the specified port. If the port is closed,
@@ -563,6 +597,10 @@ to the URL.
 **Arguments**:
 
 - `port` _int_ - The port to open the preview link on.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -585,7 +623,8 @@ print(f"Token: {preview_link.token}")
 @intercept_errors(message_prefix="Failed to create signed preview url: ")
 def create_signed_preview_url(
         port: int,
-        expires_in_seconds: int | None = None) -> SignedPortPreviewUrl
+        expires_in_seconds: int | None = None,
+        request_timeout: float | None = None) -> SignedPortPreviewUrl
 ```
 
 Creates a signed preview URL for the sandbox at the specified port.
@@ -595,6 +634,10 @@ Creates a signed preview URL for the sandbox at the specified port.
 - `port` _int_ - The port to open the preview link on.
 - `expires_in_seconds` _int | None_ - The number of seconds the signed preview
   url will be valid for. Defaults to 60 seconds.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
   
 
 **Returns**:
@@ -605,7 +648,9 @@ Creates a signed preview URL for the sandbox at the specified port.
 
 ```python
 @intercept_errors(message_prefix="Failed to expire signed preview url: ")
-def expire_signed_preview_url(port: int, token: str) -> None
+def expire_signed_preview_url(port: int,
+                              token: str,
+                              request_timeout: float | None = None) -> None
 ```
 
 Expires a signed preview URL for the sandbox at the specified port.
@@ -614,13 +659,17 @@ Expires a signed preview URL for the sandbox at the specified port.
 
 - `port` _int_ - The port to expire the signed preview url on.
 - `token` _str_ - The token to expire the signed preview url on.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### Sandbox.archive
 
 ```python
 @intercept_errors(message_prefix="Failed to archive sandbox: ")
 @with_instrumentation()
-def archive() -> None
+def archive(request_timeout: float | None = None) -> None
 ```
 
 Archives the sandbox, making it inactive and preserving its state. When sandboxes are
@@ -628,6 +677,13 @@ archived, the entire filesystem state is moved to cost-effective object storage,
 possible to keep sandboxes available for an extended period. The tradeoff between archived
 and stopped states is that starting an archived sandbox takes more time, depending on its size.
 Sandbox must be stopped before archiving.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### Sandbox.resize
 
@@ -695,7 +751,8 @@ the state is no longer 'resizing'.
 ```python
 @intercept_errors(message_prefix="Failed to create SSH access: ")
 @with_instrumentation()
-def create_ssh_access(expires_in_minutes: int | None = None) -> SshAccessDto
+def create_ssh_access(expires_in_minutes: int | None = None,
+                      request_timeout: float | None = None) -> SshAccessDto
 ```
 
 Creates an SSH access token for the sandbox.
@@ -703,13 +760,18 @@ Creates an SSH access token for the sandbox.
 **Arguments**:
 
 - `expires_in_minutes` _int | None_ - The number of minutes the SSH access token will be valid for.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### Sandbox.revoke\_ssh\_access
 
 ```python
 @intercept_errors(message_prefix="Failed to revoke SSH access: ")
 @with_instrumentation()
-def revoke_ssh_access(token: str) -> None
+def revoke_ssh_access(token: str,
+                      request_timeout: float | None = None) -> None
 ```
 
 Revokes an SSH access token for the sandbox.
@@ -717,13 +779,19 @@ Revokes an SSH access token for the sandbox.
 **Arguments**:
 
 - `token` _str_ - The token to revoke.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### Sandbox.validate\_ssh\_access
 
 ```python
 @intercept_errors(message_prefix="Failed to validate SSH access: ")
 @with_instrumentation()
-def validate_ssh_access(token: str) -> SshAccessValidationDto
+def validate_ssh_access(
+        token: str,
+        request_timeout: float | None = None) -> SshAccessValidationDto
 ```
 
 Validates an SSH access token for the sandbox.
@@ -731,18 +799,30 @@ Validates an SSH access token for the sandbox.
 **Arguments**:
 
 - `token` _str_ - The token to validate.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
 
 #### Sandbox.refresh\_activity
 
 ```python
 @intercept_errors(message_prefix="Failed to refresh sandbox activity: ")
-def refresh_activity() -> None
+def refresh_activity(request_timeout: float | None = None) -> None
 ```
 
 Refreshes the sandbox activity to reset the timer for automated lifecycle management actions.
 
 This method updates the sandbox's last activity timestamp without changing its state.
 It is useful for keeping long-running sessions alive while there is still user activity.
+
+**Arguments**:
+
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
 
 **Example**:
 

--- a/sdk-python/src/daytona/_async/code_interpreter.py
+++ b/sdk-python/src/daytona/_async/code_interpreter.py
@@ -12,6 +12,7 @@ import aiohttp
 from daytona_toolbox_api_client_async import CreateContextRequest, InterpreterApi, InterpreterContext
 
 from .._utils.errors import intercept_errors
+from .._utils.timeout import http_timeout
 from ..common.code_interpreter import ExecutionError, ExecutionResult, OutputMessage
 from ..common.errors import DaytonaConnectionError, DaytonaTimeoutError
 from ..common.process import OutputHandler
@@ -203,6 +204,7 @@ class AsyncCodeInterpreter:
     async def create_context(
         self,
         cwd: str | None = None,
+        request_timeout: float | None = None,
     ) -> InterpreterContext:
         """Create a new isolated interpreter context.
 
@@ -211,6 +213,10 @@ class AsyncCodeInterpreter:
 
         Args:
             cwd (str | None): Working directory for the context. If not specified, uses sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             InterpreterContext: The created context with its ID and metadata.
@@ -236,14 +242,22 @@ class AsyncCodeInterpreter:
             await sandbox.code_interpreter.delete_context(ctx)
             ```
         """
-        return await self._api_client.create_interpreter_context(request=CreateContextRequest(cwd=cwd))
+        return await self._api_client.create_interpreter_context(
+            request=CreateContextRequest(cwd=cwd), _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to list interpreter contexts: ")
-    async def list_contexts(self) -> list[InterpreterContext]:
+    async def list_contexts(self, request_timeout: float | None = None) -> list[InterpreterContext]:
         """List all user-created interpreter contexts.
 
         The default context is not included in this list. Only contexts created
         via `create_context()` are returned.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[InterpreterContext]: List of context objects.
@@ -258,10 +272,12 @@ class AsyncCodeInterpreter:
                 print(f"Context {ctx.id}: {ctx.language} at {ctx.cwd}")
             ```
         """
-        return (await self._api_client.list_interpreter_contexts()).contexts or []
+        return (
+            await self._api_client.list_interpreter_contexts(_request_timeout=http_timeout(request_timeout))
+        ).contexts or []
 
     @intercept_errors(message_prefix="Failed to delete interpreter context: ")
-    async def delete_context(self, context: InterpreterContext) -> None:
+    async def delete_context(self, context: InterpreterContext, request_timeout: float | None = None) -> None:
         """Delete an interpreter context and shut down all associated processes.
 
         This permanently removes the context and all its state (variables, imports, etc.).
@@ -269,6 +285,10 @@ class AsyncCodeInterpreter:
 
         Args:
             context (InterpreterContext): Context to delete.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If deletion fails or context not found.
@@ -280,7 +300,9 @@ class AsyncCodeInterpreter:
             await sandbox.code_interpreter.delete_context(ctx)
             ```
         """
-        _ = await self._api_client.delete_interpreter_context(id=context.id)
+        _ = await self._api_client.delete_interpreter_context(
+            id=context.id, _request_timeout=http_timeout(request_timeout)
+        )
 
     def _maybe_raise_from_ws_close(self, close_code: int | None, close_reason: str | None) -> None:
         """Translate a websocket close into a Daytona error when it indicates failure.

--- a/sdk-python/src/daytona/_async/computer_use.py
+++ b/sdk-python/src/daytona/_async/computer_use.py
@@ -43,6 +43,7 @@ from daytona_toolbox_api_client_async import (
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
+from .._utils.timeout import http_timeout
 from ..common.computer_use import ScreenshotOptions, ScreenshotRegion
 from ..internal.http_client import aiohttp_request_timeout as _request_timeout
 from ..internal.shared_session import http_session_of
@@ -56,8 +57,14 @@ class AsyncMouse:
 
     @intercept_errors(message_prefix="Failed to get mouse position: ")
     @with_instrumentation()
-    async def get_position(self) -> MousePositionResponse:
+    async def get_position(self, request_timeout: float | None = None) -> MousePositionResponse:
         """Gets the current mouse cursor position.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             MousePositionResponse: Current mouse position with x and y coordinates.
@@ -68,17 +75,21 @@ class AsyncMouse:
             print(f"Mouse is at: {position.x}, {position.y}")
             ```
         """
-        response = await self._api_client.get_mouse_position()
+        response = await self._api_client.get_mouse_position(_request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to move mouse: ")
     @with_instrumentation()
-    async def move(self, x: int, y: int) -> MousePositionResponse:
+    async def move(self, x: int, y: int, request_timeout: float | None = None) -> MousePositionResponse:
         """Moves the mouse cursor to the specified coordinates.
 
         Args:
             x (int): The x coordinate to move to.
             y (int): The y coordinate to move to.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             MousePositionResponse: Position after move.
@@ -90,12 +101,14 @@ class AsyncMouse:
             ```
         """
         request = MouseMoveRequest(x=x, y=y)
-        response = await self._api_client.move_mouse(request)
+        response = await self._api_client.move_mouse(request, _request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to click mouse: ")
     @with_instrumentation()
-    async def click(self, x: int, y: int, button: str = "left", double: bool = False) -> MouseClickResponse:
+    async def click(
+        self, x: int, y: int, button: str = "left", double: bool = False, request_timeout: float | None = None
+    ) -> MouseClickResponse:
         """Clicks the mouse at the specified coordinates.
 
         Args:
@@ -103,6 +116,10 @@ class AsyncMouse:
             y (int): The y coordinate to click at.
             button (str): The mouse button to click ('left', 'right', 'middle').
             double (bool): Whether to perform a double-click.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             MouseClickResponse: Click operation result.
@@ -120,12 +137,20 @@ class AsyncMouse:
             ```
         """
         request = MouseClickRequest(x=x, y=y, button=button, double=double)
-        response = await self._api_client.click(request)
+        response = await self._api_client.click(request, _request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to drag mouse: ")
     @with_instrumentation()
-    async def drag(self, start_x: int, start_y: int, end_x: int, end_y: int, button: str = "left") -> MouseDragResponse:
+    async def drag(
+        self,
+        start_x: int,
+        start_y: int,
+        end_x: int,
+        end_y: int,
+        button: str = "left",
+        request_timeout: float | None = None,
+    ) -> MouseDragResponse:
         """Drags the mouse from start coordinates to end coordinates.
 
         Args:
@@ -134,6 +159,10 @@ class AsyncMouse:
             end_x (int): The ending x coordinate.
             end_y (int): The ending y coordinate.
             button (str): The mouse button to use for dragging.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             MouseDragResponse: Drag operation result.
@@ -145,12 +174,14 @@ class AsyncMouse:
             ```
         """
         request = MouseDragRequest(start_x=start_x, start_y=start_y, end_x=end_x, end_y=end_y, button=button)
-        response = await self._api_client.drag(request=request)
+        response = await self._api_client.drag(request=request, _request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to scroll mouse: ")
     @with_instrumentation()
-    async def scroll(self, x: int, y: int, direction: str, amount: int = 1) -> bool:
+    async def scroll(
+        self, x: int, y: int, direction: str, amount: int = 1, request_timeout: float | None = None
+    ) -> bool:
         """Scrolls the mouse wheel at the specified coordinates.
 
         Args:
@@ -158,6 +189,10 @@ class AsyncMouse:
             y (int): The y coordinate to scroll at.
             direction (str): The direction to scroll ('up' or 'down').
             amount (int): The amount to scroll.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             bool: Whether the scroll operation was successful.
@@ -172,7 +207,7 @@ class AsyncMouse:
             ```
         """
         request = MouseScrollRequest(x=x, y=y, direction=direction, amount=amount)
-        response = await self._api_client.scroll(request=request)
+        response = await self._api_client.scroll(request=request, _request_timeout=http_timeout(request_timeout))
         return response.success is True
 
 
@@ -184,12 +219,16 @@ class AsyncKeyboard:
 
     @intercept_errors(message_prefix="Failed to type text: ")
     @with_instrumentation()
-    async def type(self, text: str, delay: int | None = None) -> None:
+    async def type(self, text: str, delay: int | None = None, request_timeout: float | None = None) -> None:
         """Types the specified text.
 
         Args:
             text (str): The text to type.
             delay (int): Delay between characters in milliseconds.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the type operation fails.
@@ -211,11 +250,11 @@ class AsyncKeyboard:
             ```
         """
         request = KeyboardTypeRequest(text=text, delay=delay)
-        _ = await self._api_client.type_text(request=request)
+        _ = await self._api_client.type_text(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to press key: ")
     @with_instrumentation()
-    async def press(self, key: str, modifiers: list[str] | None = None) -> None:
+    async def press(self, key: str, modifiers: list[str] | None = None, request_timeout: float | None = None) -> None:
         """Presses a key with optional modifiers.
 
         Args:
@@ -227,6 +266,10 @@ class AsyncKeyboard:
             modifiers (list[str]): Canonical modifier names are 'ctrl', 'alt',
                 'shift', and 'cmd'. Common aliases such as 'control', 'option',
                 'meta', and 'win' are normalized.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the press operation fails.
@@ -254,17 +297,21 @@ class AsyncKeyboard:
             ```
         """
         request = KeyboardPressRequest(key=key, modifiers=modifiers or [])
-        _ = await self._api_client.press_key(request=request)
+        _ = await self._api_client.press_key(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to press hotkey: ")
     @with_instrumentation()
-    async def hotkey(self, keys: str) -> None:
+    async def hotkey(self, keys: str, request_timeout: float | None = None) -> None:
         """Presses a hotkey combination.
 
         Args:
             keys (str): A single atomic hotkey chord (e.g., 'ctrl+c', 'alt+tab',
                 'cmd+shift+t', 'ctrl + c', 'shift'). Uses the same normalized key
                 contract as ``press()``.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the hotkey operation fails.
@@ -294,7 +341,7 @@ class AsyncKeyboard:
             ```
         """
         request = KeyboardHotkeyRequest(keys=keys)
-        _ = await self._api_client.press_hotkey(request=request)
+        _ = await self._api_client.press_hotkey(request=request, _request_timeout=http_timeout(request_timeout))
 
 
 class AsyncScreenshot:
@@ -305,11 +352,17 @@ class AsyncScreenshot:
 
     @intercept_errors(message_prefix="Failed to take screenshot: ")
     @with_instrumentation()
-    async def take_full_screen(self, show_cursor: bool = False) -> ScreenshotResponse:
+    async def take_full_screen(
+        self, show_cursor: bool = False, request_timeout: float | None = None
+    ) -> ScreenshotResponse:
         """Takes a screenshot of the entire screen.
 
         Args:
             show_cursor (bool): Whether to show the cursor in the screenshot.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ScreenshotResponse: Screenshot data with base64 encoded image.
@@ -323,17 +376,25 @@ class AsyncScreenshot:
             with_cursor = await sandbox.computer_use.screenshot.take_full_screen(True)
             ```
         """
-        response = await self._api_client.take_screenshot(show_cursor=show_cursor)
+        response = await self._api_client.take_screenshot(
+            show_cursor=show_cursor, _request_timeout=http_timeout(request_timeout)
+        )
         return response
 
     @intercept_errors(message_prefix="Failed to take region screenshot: ")
     @with_instrumentation()
-    async def take_region(self, region: ScreenshotRegion, show_cursor: bool = False) -> ScreenshotResponse:
+    async def take_region(
+        self, region: ScreenshotRegion, show_cursor: bool = False, request_timeout: float | None = None
+    ) -> ScreenshotResponse:
         """Takes a screenshot of a specific region.
 
         Args:
             region (ScreenshotRegion): The region to capture.
             show_cursor (bool): Whether to show the cursor in the screenshot.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ScreenshotResponse: Screenshot data with base64 encoded image.
@@ -346,17 +407,28 @@ class AsyncScreenshot:
             ```
         """
         response = await self._api_client.take_region_screenshot(
-            height=region.height, width=region.width, y=region.y, x=region.x, show_cursor=show_cursor
+            height=region.height,
+            width=region.width,
+            y=region.y,
+            x=region.x,
+            show_cursor=show_cursor,
+            _request_timeout=http_timeout(request_timeout),
         )
         return response
 
     @intercept_errors(message_prefix="Failed to take compressed screenshot: ")
     @with_instrumentation()
-    async def take_compressed(self, options: ScreenshotOptions | None = None) -> ScreenshotResponse:
+    async def take_compressed(
+        self, options: ScreenshotOptions | None = None, request_timeout: float | None = None
+    ) -> ScreenshotResponse:
         """Takes a compressed screenshot of the entire screen.
 
         Args:
             options (ScreenshotOptions | None): Compression and display options.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ScreenshotResponse: Compressed screenshot data.
@@ -385,19 +457,24 @@ class AsyncScreenshot:
             quality=options.quality,
             format=options.fmt,
             show_cursor=options.show_cursor,
+            _request_timeout=http_timeout(request_timeout),
         )
         return response
 
     @intercept_errors(message_prefix="Failed to take compressed region screenshot: ")
     @with_instrumentation()
     async def take_compressed_region(
-        self, region: ScreenshotRegion, options: ScreenshotOptions | None = None
+        self, region: ScreenshotRegion, options: ScreenshotOptions | None = None, request_timeout: float | None = None
     ) -> ScreenshotResponse:
         """Takes a compressed screenshot of a specific region.
 
         Args:
             region (ScreenshotRegion): The region to capture.
             options (ScreenshotOptions | None): Compression and display options.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ScreenshotResponse: Compressed screenshot data.
@@ -424,6 +501,7 @@ class AsyncScreenshot:
             quality=options.quality,
             format=options.fmt,
             show_cursor=options.show_cursor,
+            _request_timeout=http_timeout(request_timeout),
         )
         return response
 
@@ -436,8 +514,14 @@ class AsyncDisplay:
 
     @intercept_errors(message_prefix="Failed to get display info: ")
     @with_instrumentation()
-    async def get_info(self) -> DisplayInfoResponse:
+    async def get_info(self, request_timeout: float | None = None) -> DisplayInfoResponse:
         """Gets information about the displays.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             DisplayInfoResponse: Display information including primary display and all available displays.
@@ -451,13 +535,19 @@ class AsyncDisplay:
                 print(f"Display {i}: {display.width}x{display.height} at {display.x},{display.y}")
             ```
         """
-        response = await self._api_client.get_display_info()
+        response = await self._api_client.get_display_info(_request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to get windows: ")
     @with_instrumentation()
-    async def get_windows(self) -> WindowsResponse:
+    async def get_windows(self, request_timeout: float | None = None) -> WindowsResponse:
         """Gets the list of open windows.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             WindowsResponse: List of open windows with their IDs and titles.
@@ -470,7 +560,7 @@ class AsyncDisplay:
                 print(f"- {window.title} (ID: {window.id})")
             ```
         """
-        response = await self._api_client.get_windows()
+        response = await self._api_client.get_windows(_request_timeout=http_timeout(request_timeout))
         return response
 
 
@@ -485,11 +575,15 @@ class AsyncRecordingService:
 
     @intercept_errors(message_prefix="Failed to start recording: ")
     @with_instrumentation()
-    async def start(self, label: str | None = None) -> Recording:
+    async def start(self, label: str | None = None, request_timeout: float | None = None) -> Recording:
         """Starts a new screen recording session.
 
         Args:
             label (str | None): Optional custom label for the recording.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Recording: Recording start response.
@@ -503,15 +597,19 @@ class AsyncRecordingService:
             ```
         """
         request = StartRecordingRequest(label=label)
-        return await self._api_client.start_recording(request=request)
+        return await self._api_client.start_recording(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to stop recording: ")
     @with_instrumentation()
-    async def stop(self, recording_id: str) -> Recording:
+    async def stop(self, recording_id: str, request_timeout: float | None = None) -> Recording:
         """Stops an active screen recording session.
 
         Args:
             recording_id (str): The ID of the recording to stop.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Recording: Recording stop response.
@@ -524,12 +622,18 @@ class AsyncRecordingService:
             ```
         """
         request = StopRecordingRequest(id=recording_id)
-        return await self._api_client.stop_recording(request=request)
+        return await self._api_client.stop_recording(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to list recordings: ")
     @with_instrumentation()
-    async def list(self) -> ListRecordingsResponse:
+    async def list(self, request_timeout: float | None = None) -> ListRecordingsResponse:
         """Lists all recordings (active and completed).
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ListRecordingsResponse: List of all recordings.
@@ -542,15 +646,19 @@ class AsyncRecordingService:
                 print(f"- {rec.file_name}: {rec.status}")
             ```
         """
-        return await self._api_client.list_recordings()
+        return await self._api_client.list_recordings(_request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to get recording: ")
     @with_instrumentation()
-    async def get(self, recording_id: str) -> Recording:
+    async def get(self, recording_id: str, request_timeout: float | None = None) -> Recording:
         """Gets details of a specific recording by ID.
 
         Args:
             recording_id (str): The ID of the recording to retrieve.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Recording: Recording details.
@@ -563,15 +671,19 @@ class AsyncRecordingService:
             print(f"Duration: {recording.duration_seconds} seconds")
             ```
         """
-        return await self._api_client.get_recording(id=recording_id)
+        return await self._api_client.get_recording(id=recording_id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to delete recording: ")
     @with_instrumentation()
-    async def delete(self, recording_id: str) -> None:
+    async def delete(self, recording_id: str, request_timeout: float | None = None) -> None:
         """Deletes a recording by ID.
 
         Args:
             recording_id (str): The ID of the recording to delete.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -579,7 +691,7 @@ class AsyncRecordingService:
             print("Recording deleted")
             ```
         """
-        await self._api_client.delete_recording(id=recording_id)
+        await self._api_client.delete_recording(id=recording_id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to download recording: ")
     @with_instrumentation()
@@ -644,6 +756,7 @@ class AsyncAccessibility:
         scope: str | None = None,
         pid: int | None = None,
         max_depth: int | None = None,
+        request_timeout: float | None = None,
     ) -> AccessibilityTreeResponse:
         """Fetches the AT-SPI accessibility tree.
 
@@ -651,6 +764,10 @@ class AsyncAccessibility:
             scope (str | None): Tree scope to inspect: ``focused``, ``pid``, or ``all``.
             pid (int | None): Process ID when ``scope`` is ``pid``.
             max_depth (int | None): Maximum depth to descend. Use ``0`` for the root only.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             AccessibilityTreeResponse: Accessibility tree rooted at the requested scope.
@@ -661,7 +778,9 @@ class AsyncAccessibility:
             print(tree.root.name)
             ```
         """
-        return await self._api_client.get_accessibility_tree(scope=scope, pid=pid, max_depth=max_depth)
+        return await self._api_client.get_accessibility_tree(
+            scope=scope, pid=pid, max_depth=max_depth, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to find accessibility nodes: ")
     @with_instrumentation()
@@ -674,6 +793,7 @@ class AsyncAccessibility:
         name_match: str | None = None,
         states: list[str] | None = None,
         limit: int | None = None,
+        request_timeout: float | None = None,
     ) -> AccessibilityNodesResponse:
         """Finds AT-SPI accessibility nodes matching the provided filters.
 
@@ -685,6 +805,10 @@ class AsyncAccessibility:
             name_match (str | None): Name match mode, such as ``exact`` or ``substring``.
             states (list[str] | None): Required accessibility states.
             limit (int | None): Maximum number of matches. Use ``0`` to let the API apply its default.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             AccessibilityNodesResponse: Matching accessibility nodes.
@@ -709,15 +833,21 @@ class AsyncAccessibility:
             states=states,
             limit=limit,
         )
-        return await self._api_client.find_accessibility_nodes(request=request)
+        return await self._api_client.find_accessibility_nodes(
+            request=request, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to focus accessibility node: ")
     @with_instrumentation()
-    async def focus_node(self, node_id: str) -> None:
+    async def focus_node(self, node_id: str, request_timeout: float | None = None) -> None:
         """Focuses an AT-SPI accessibility node.
 
         Args:
             node_id (str): Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the focus operation fails. API failures may use a more specific subclass.
@@ -728,16 +858,22 @@ class AsyncAccessibility:
             ```
         """
         request = AccessibilityNodeRequest(id=node_id)
-        _ = await self._api_client.focus_accessibility_node(request=request)
+        _ = await self._api_client.focus_accessibility_node(
+            request=request, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to invoke accessibility node: ")
     @with_instrumentation()
-    async def invoke_node(self, node_id: str, action: str | None = None) -> None:
+    async def invoke_node(self, node_id: str, action: str | None = None, request_timeout: float | None = None) -> None:
         """Invokes an AT-SPI accessibility node action.
 
         Args:
             node_id (str): Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
             action (str | None): Action name to invoke. If omitted, the API invokes the primary action.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the invoke operation fails. API failures may use a more specific subclass.
@@ -748,16 +884,22 @@ class AsyncAccessibility:
             ```
         """
         request = AccessibilityInvokeRequest(id=node_id, action=action)
-        _ = await self._api_client.invoke_accessibility_node(request=request)
+        _ = await self._api_client.invoke_accessibility_node(
+            request=request, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to set accessibility node value: ")
     @with_instrumentation()
-    async def set_node_value(self, node_id: str, value: str) -> None:
+    async def set_node_value(self, node_id: str, value: str, request_timeout: float | None = None) -> None:
         """Sets an AT-SPI accessibility node value.
 
         Args:
             node_id (str): Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
             value (str): Value to write to the node.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the value update fails. API failures may use a more specific subclass.
@@ -768,7 +910,9 @@ class AsyncAccessibility:
             ```
         """
         request = AccessibilitySetValueRequest(id=node_id, value=value)
-        _ = await self._api_client.set_accessibility_node_value(request=request)
+        _ = await self._api_client.set_accessibility_node_value(
+            request=request, _request_timeout=http_timeout(request_timeout)
+        )
 
 
 class AsyncComputerUse:
@@ -801,8 +945,14 @@ class AsyncComputerUse:
 
     @intercept_errors(message_prefix="Failed to start computer use: ")
     @with_instrumentation()
-    async def start(self) -> ComputerUseStartResponse:
+    async def start(self, request_timeout: float | None = None) -> ComputerUseStartResponse:
         """Starts all computer use processes (Xvfb, xfce4, x11vnc, novnc).
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ComputerUseStartResponse: Computer use start response.
@@ -813,13 +963,19 @@ class AsyncComputerUse:
             print("Computer use processes started:", result.message)
             ```
         """
-        response = await self._api_client.start_computer_use()
+        response = await self._api_client.start_computer_use(_request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to stop computer use: ")
     @with_instrumentation()
-    async def stop(self) -> ComputerUseStopResponse:
+    async def stop(self, request_timeout: float | None = None) -> ComputerUseStopResponse:
         """Stops all computer use processes.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ComputerUseStopResponse: Computer use stop response.
@@ -830,13 +986,19 @@ class AsyncComputerUse:
             print("Computer use processes stopped:", result.message)
             ```
         """
-        response = await self._api_client.stop_computer_use()
+        response = await self._api_client.stop_computer_use(_request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to get computer use status: ")
     @with_instrumentation()
-    async def get_status(self) -> ComputerUseStatusResponse:
+    async def get_status(self, request_timeout: float | None = None) -> ComputerUseStatusResponse:
         """Gets the status of all computer use processes.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ComputerUseStatusResponse: Status information about all VNC desktop processes.
@@ -847,15 +1009,21 @@ class AsyncComputerUse:
             print("Computer use status:", response.status)
             ```
         """
-        return await self._api_client.get_computer_use_status()
+        return await self._api_client.get_computer_use_status(_request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to get process status: ")
     @with_instrumentation()
-    async def get_process_status(self, process_name: str) -> ProcessStatusResponse:
+    async def get_process_status(
+        self, process_name: str, request_timeout: float | None = None
+    ) -> ProcessStatusResponse:
         """Gets the status of a specific VNC process.
 
         Args:
             process_name (str): Name of the process to check.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ProcessStatusResponse: Status information about the specific process.
@@ -866,16 +1034,22 @@ class AsyncComputerUse:
             no_vnc_status = await sandbox.computer_use.get_process_status("novnc")
             ```
         """
-        response = await self._api_client.get_process_status(process_name=process_name)
+        response = await self._api_client.get_process_status(
+            process_name=process_name, _request_timeout=http_timeout(request_timeout)
+        )
         return response
 
     @intercept_errors(message_prefix="Failed to restart process: ")
     @with_instrumentation()
-    async def restart_process(self, process_name: str) -> ProcessRestartResponse:
+    async def restart_process(self, process_name: str, request_timeout: float | None = None) -> ProcessRestartResponse:
         """Restarts a specific VNC process.
 
         Args:
             process_name (str): Name of the process to restart.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ProcessRestartResponse: Process restart response.
@@ -886,16 +1060,22 @@ class AsyncComputerUse:
             print("XFCE4 process restarted:", result.message)
             ```
         """
-        response = await self._api_client.restart_process(process_name=process_name)
+        response = await self._api_client.restart_process(
+            process_name=process_name, _request_timeout=http_timeout(request_timeout)
+        )
         return response
 
     @intercept_errors(message_prefix="Failed to get process logs: ")
     @with_instrumentation()
-    async def get_process_logs(self, process_name: str) -> ProcessLogsResponse:
+    async def get_process_logs(self, process_name: str, request_timeout: float | None = None) -> ProcessLogsResponse:
         """Gets logs for a specific VNC process.
 
         Args:
             process_name (str): Name of the process to get logs for.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ProcessLogsResponse: Process logs.
@@ -906,16 +1086,24 @@ class AsyncComputerUse:
             print("NoVNC logs:", logs)
             ```
         """
-        response = await self._api_client.get_process_logs(process_name=process_name)
+        response = await self._api_client.get_process_logs(
+            process_name=process_name, _request_timeout=http_timeout(request_timeout)
+        )
         return response
 
     @intercept_errors(message_prefix="Failed to get process errors: ")
     @with_instrumentation()
-    async def get_process_errors(self, process_name: str) -> ProcessErrorsResponse:
+    async def get_process_errors(
+        self, process_name: str, request_timeout: float | None = None
+    ) -> ProcessErrorsResponse:
         """Gets error logs for a specific VNC process.
 
         Args:
             process_name (str): Name of the process to get error logs for.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ProcessErrorsResponse: Process error logs.
@@ -926,5 +1114,7 @@ class AsyncComputerUse:
             print("X11VNC errors:", errors)
             ```
         """
-        response = await self._api_client.get_process_errors(process_name=process_name)
+        response = await self._api_client.get_process_errors(
+            process_name=process_name, _request_timeout=http_timeout(request_timeout)
+        )
         return response

--- a/sdk-python/src/daytona/_async/daytona.py
+++ b/sdk-python/src/daytona/_async/daytona.py
@@ -654,11 +654,15 @@ class AsyncDaytona:
 
     @intercept_errors(message_prefix="Failed to get sandbox: ")
     @with_instrumentation()
-    async def get(self, sandbox_id_or_name: str) -> AsyncSandbox:
+    async def get(self, sandbox_id_or_name: str, request_timeout: float | None = None) -> AsyncSandbox:
         """Gets a Sandbox by its ID or name.
 
         Args:
             sandbox_id_or_name (str): The ID or name of the Sandbox to retrieve.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Sandbox: The Sandbox instance.
@@ -676,7 +680,9 @@ class AsyncDaytona:
             raise DaytonaValidationError("sandbox_id_or_name is required")
 
         # Get the sandbox instance
-        sandbox_instance = await self._sandbox_api.get_sandbox(sandbox_id_or_name)
+        sandbox_instance = await self._sandbox_api.get_sandbox(
+            sandbox_id_or_name, _request_timeout=http_timeout(request_timeout)
+        )
         language = self._validate_language_label(sandbox_instance.labels.get(CODE_TOOLBOX_LANGUAGE_LABEL)).value
         return AsyncSandbox(
             sandbox_instance,
@@ -691,11 +697,16 @@ class AsyncDaytona:
     async def list(
         self,
         query: ListSandboxesQuery | None = None,
+        request_timeout: float | None = None,
     ) -> AsyncIterator[AsyncSandbox]:
         """Iterates over Sandboxes matching the given query.
 
         Args:
             query: Optional filters, sorting, and per-page size.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Yields:
             AsyncSandbox: Each Sandbox matching the query.
@@ -718,7 +729,7 @@ class AsyncDaytona:
 
         while first_page or cursor:
             first_page = False
-            response = await self._fetch_sandbox_page(q, cursor)
+            response = await self._fetch_sandbox_page(q, cursor, request_timeout)
             for sandbox in response.items:
                 language = self._validate_language_label(sandbox.labels.get(CODE_TOOLBOX_LANGUAGE_LABEL)).value
                 yield AsyncSandbox(
@@ -731,7 +742,9 @@ class AsyncDaytona:
             cursor = response.next_cursor or None
 
     @with_instrumentation(name="AsyncDaytona.list.fetch_page")
-    async def _fetch_sandbox_page(self, q: ListSandboxesQuery, cursor: str | None):
+    async def _fetch_sandbox_page(
+        self, q: ListSandboxesQuery, cursor: str | None, request_timeout: float | None = None
+    ):
         """Fetches a single page of sandboxes. Each call is one OTEL span."""
         # The shared ListSandboxesQuery is typed against the sync api-client
         # enums; the async api-client expects its own copies of those enums.
@@ -762,6 +775,7 @@ class AsyncDaytona:
             last_event_before=q.last_activity_before,
             sort=sort,
             order=order,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     def _validate_language_label(self, language: str | None = None) -> CodeLanguage:

--- a/sdk-python/src/daytona/_async/filesystem.py
+++ b/sdk-python/src/daytona/_async/filesystem.py
@@ -30,6 +30,7 @@ from daytona_toolbox_api_client_async import (
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
+from .._utils.timeout import http_timeout
 from ..common.errors import DaytonaError
 from ..common.file_transfer import (
     create_multipart_parser,
@@ -73,7 +74,7 @@ class AsyncFileSystem:
 
     @intercept_errors(message_prefix="Failed to create folder: ")
     @with_instrumentation()
-    async def create_folder(self, path: str, mode: str) -> None:
+    async def create_folder(self, path: str, mode: str, request_timeout: float | None = None) -> None:
         """Creates a new directory in the Sandbox at the specified path with the given
         permissions.
 
@@ -81,6 +82,10 @@ class AsyncFileSystem:
             path (str): Path where the folder should be created. Relative paths are resolved based
             on the sandbox working directory.
             mode (str): Folder permissions in octal format (e.g., "755" for rwxr-xr-x).
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -94,16 +99,21 @@ class AsyncFileSystem:
         await self._api_client.create_folder(
             path=path,
             mode=mode,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to delete file: ")
     @with_instrumentation()
-    async def delete_file(self, path: str, recursive: bool = False) -> None:
+    async def delete_file(self, path: str, recursive: bool = False, request_timeout: float | None = None) -> None:
         """Deletes a file from the Sandbox.
 
         Args:
             path (str): Path to the file to delete. Relative paths are resolved based on the sandbox working directory.
             recursive (bool): If the file is a directory, this must be true to delete it.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -111,7 +121,9 @@ class AsyncFileSystem:
             await sandbox.fs.delete_file("workspace/data/old_file.txt")
             ```
         """
-        await self._api_client.delete_file(path=path, recursive=recursive)
+        await self._api_client.delete_file(
+            path=path, recursive=recursive, _request_timeout=http_timeout(request_timeout)
+        )
 
     @overload
     async def download_file(self, remote_path: str, timeout: int = 30 * 60) -> bytes:
@@ -598,7 +610,7 @@ class AsyncFileSystem:
 
     @intercept_errors(message_prefix="Failed to find files: ")
     @with_instrumentation()
-    async def find_files(self, path: str, pattern: str) -> list[Match]:
+    async def find_files(self, path: str, pattern: str, request_timeout: float | None = None) -> list[Match]:
         """Searches for files containing a pattern, similar to
         the grep command.
 
@@ -607,6 +619,10 @@ class AsyncFileSystem:
                 the search will be performed recursively. Relative paths are resolved based
                 on the sandbox working directory.
             pattern (str): Search pattern to match against file contents.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[Match]: List of matches found in files. Each Match object includes:
@@ -625,17 +641,22 @@ class AsyncFileSystem:
         return await self._api_client.find_in_files(
             path=path,
             pattern=pattern,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get file info: ")
     @with_instrumentation()
-    async def get_file_info(self, path: str) -> FileInfo:
+    async def get_file_info(self, path: str, request_timeout: float | None = None) -> FileInfo:
         """Gets detailed information about a file or directory, including its
         size, permissions, and timestamps.
 
         Args:
             path (str): Path to the file or directory. Relative paths are resolved based
             on the sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             FileInfo: Detailed file information including:
@@ -662,11 +683,13 @@ class AsyncFileSystem:
                 print("Path is a directory")
             ```
         """
-        return await self._api_client.get_file_info(path=path)
+        return await self._api_client.get_file_info(path=path, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to list files: ")
     @with_instrumentation()
-    async def list_files(self, path: str, depth: int | None = None) -> list[FileInfo]:
+    async def list_files(
+        self, path: str, depth: int | None = None, request_timeout: float | None = None
+    ) -> list[FileInfo]:
         """Lists files and directories in a given path and returns their information, similar to the ls -l command.
 
         Args:
@@ -675,6 +698,10 @@ class AsyncFileSystem:
             depth (int | None): How many levels deep to list. depth=1 (default) lists the
             directory's entries, depth=2 also includes their children, and so on. Must be >= 1.
             Each returned FileInfo carries a full `path` field.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[FileInfo]: List of file and directory information. Each FileInfo
@@ -697,11 +724,11 @@ class AsyncFileSystem:
         """
         if depth is not None and depth < 1:
             raise DaytonaError("depth must be at least 1")
-        return await self._api_client.list_files(path=path, depth=depth)
+        return await self._api_client.list_files(path=path, depth=depth, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to move files: ")
     @with_instrumentation()
-    async def move_files(self, source: str, destination: str) -> None:
+    async def move_files(self, source: str, destination: str, request_timeout: float | None = None) -> None:
         """Moves or renames a file or directory. The parent directory of the destination must exist.
 
         Args:
@@ -709,6 +736,10 @@ class AsyncFileSystem:
             based on the sandbox working directory.
             destination (str): Path to the destination. Relative paths are resolved based on
             the sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -734,11 +765,14 @@ class AsyncFileSystem:
         await self._api_client.move_file(
             source=source,
             destination=destination,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to replace in files: ")
     @with_instrumentation()
-    async def replace_in_files(self, files: list[str], pattern: str, new_value: str) -> list[ReplaceResult]:
+    async def replace_in_files(
+        self, files: list[str], pattern: str, new_value: str, request_timeout: float | None = None
+    ) -> list[ReplaceResult]:
         """Performs search and replace operations across multiple files.
 
         Args:
@@ -746,6 +780,10 @@ class AsyncFileSystem:
             resolved based on the sandbox working directory.
             pattern (str): Pattern to search for.
             new_value (str): Text to replace matches with.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[ReplaceResult]: List of results indicating replacements made in
@@ -776,11 +814,13 @@ class AsyncFileSystem:
 
         replace_request = ReplaceRequest(files=files, new_value=new_value, pattern=pattern)
 
-        return await self._api_client.replace_in_files(request=replace_request)
+        return await self._api_client.replace_in_files(
+            request=replace_request, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to search files: ")
     @with_instrumentation()
-    async def search_files(self, path: str, pattern: str) -> SearchFilesResponse:
+    async def search_files(self, path: str, pattern: str, request_timeout: float | None = None) -> SearchFilesResponse:
         """Searches for files and directories whose names match the
         specified pattern. The pattern can be a simple string or a glob pattern.
 
@@ -789,6 +829,10 @@ class AsyncFileSystem:
             based on the sandbox working directory.
             pattern (str): Pattern to match against file names. Supports glob
                 patterns (e.g., "*.py" for Python files).
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             SearchFilesResponse: Search results containing:
@@ -809,12 +853,18 @@ class AsyncFileSystem:
         return await self._api_client.search_files(
             path=path,
             pattern=pattern,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to set file permissions: ")
     @with_instrumentation()
     async def set_file_permissions(
-        self, path: str, mode: str | None = None, owner: str | None = None, group: str | None = None
+        self,
+        path: str,
+        mode: str | None = None,
+        owner: str | None = None,
+        group: str | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Sets permissions and ownership for a file or directory. Any of the parameters can be None
         to leave that attribute unchanged.
@@ -826,6 +876,10 @@ class AsyncFileSystem:
                 (e.g., "644" for rw-r--r--).
             owner (str | None): User owner of the file.
             group (str | None): Group owner of the file.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -848,6 +902,7 @@ class AsyncFileSystem:
             mode=mode,
             owner=owner,
             group=group,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @overload

--- a/sdk-python/src/daytona/_async/git.py
+++ b/sdk-python/src/daytona/_async/git.py
@@ -27,6 +27,7 @@ from daytona_toolbox_api_client_async import (
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
+from .._utils.timeout import http_timeout
 from ..common.git import GitCommitResponse
 
 
@@ -69,7 +70,7 @@ class AsyncGit:
 
     @intercept_errors(message_prefix="Failed to add files: ")
     @with_instrumentation()
-    async def add(self, path: str, files: list[str]) -> None:
+    async def add(self, path: str, files: list[str], request_timeout: float | None = None) -> None:
         """Stages the specified files for the next commit, similar to
         running 'git add' on the command line.
 
@@ -77,6 +78,10 @@ class AsyncGit:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
             files (list[str]): List of file paths or directories to stage, relative to the repository root.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -93,16 +98,21 @@ class AsyncGit:
         """
         await self._api_client.add_files(
             request=GitAddRequest(path=path, files=files),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to list branches: ")
     @with_instrumentation()
-    async def branches(self, path: str) -> ListBranchResponse:
+    async def branches(self, path: str, request_timeout: float | None = None) -> ListBranchResponse:
         """Lists branches in the repository.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ListBranchResponse: List of branches in the repository.
@@ -115,6 +125,7 @@ class AsyncGit:
         """
         return await self._api_client.list_branches(
             path=path,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to clone repository: ")
@@ -129,6 +140,7 @@ class AsyncGit:
         password: str | None = None,
         insecure_skip_tls: bool | None = None,
         depth: int | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Clones a Git repository into the specified path. It supports
         cloning specific branches or commits, and can authenticate with the remote
@@ -148,6 +160,10 @@ class AsyncGit:
                 Use only for trusted internal Git servers with self-signed or private-CA certs;
                 credentials, if supplied, are transmitted over an unverified TLS connection.
             depth (int | None): Create a shallow clone truncated to the given number of commits.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -185,12 +201,19 @@ class AsyncGit:
                 insecure_skip_tls=insecure_skip_tls,
                 depth=depth,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to commit changes: ")
     @with_instrumentation()
     async def commit(
-        self, path: str, message: str, author: str, email: str, allow_empty: bool = False
+        self,
+        path: str,
+        message: str,
+        author: str,
+        email: str,
+        allow_empty: bool = False,
+        request_timeout: float | None = None,
     ) -> GitCommitResponse:
         """Creates a new commit with the staged changes. Make sure to stage
         changes using the add() method before committing.
@@ -202,6 +225,10 @@ class AsyncGit:
             author (str): Name of the commit author.
             email (str): Email address of the commit author.
             allow_empty (bool): Allow creating an empty commit when no changes are staged. Defaults to False.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -224,6 +251,7 @@ class AsyncGit:
                 email=email,
                 allow_empty=allow_empty,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
         return GitCommitResponse(sha=response.hash)
 
@@ -237,6 +265,7 @@ class AsyncGit:
         branch: str | None = None,
         remote: str | None = None,
         set_upstream: bool = False,
+        request_timeout: float | None = None,
     ) -> None:
         """Pushes all local commits on the current branch to the remote
         repository. If the remote repository requires authentication, provide
@@ -251,6 +280,10 @@ class AsyncGit:
             remote (str | None): Remote to push to. Defaults to "origin".
             set_upstream (bool, optional): Record the pushed branch as the upstream tracking
                 branch. Defaults to False.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -277,6 +310,7 @@ class AsyncGit:
                 remote=remote,
                 set_upstream=set_upstream,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to pull changes: ")
@@ -288,6 +322,7 @@ class AsyncGit:
         password: str | None = None,
         branch: str | None = None,
         remote: str | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Pulls changes from the remote repository. If the remote repository requires authentication,
         provide username and password/token.
@@ -299,6 +334,10 @@ class AsyncGit:
             password (str | None): Git password or token for authentication.
             branch (str | None): Branch to pull. Defaults to the current branch's upstream.
             remote (str | None): Remote to pull from. Defaults to "origin".
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -324,16 +363,21 @@ class AsyncGit:
                 branch=branch,
                 remote=remote,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get status: ")
     @with_instrumentation()
-    async def status(self, path: str) -> GitStatus:
+    async def status(self, path: str, request_timeout: float | None = None) -> GitStatus:
         """Gets the current Git repository status.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             GitStatus: Repository status information including:
@@ -353,17 +397,22 @@ class AsyncGit:
         """
         return await self._api_client.get_status(
             path=path,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to checkout branch: ")
     @with_instrumentation()
-    async def checkout_branch(self, path: str, branch: str) -> None:
+    async def checkout_branch(self, path: str, branch: str, request_timeout: float | None = None) -> None:
         """Checkout branch in the repository.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
             branch (str): Name of the branch to checkout
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -376,17 +425,22 @@ class AsyncGit:
                 path=path,
                 branch=branch,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to create branch: ")
     @with_instrumentation()
-    async def create_branch(self, path: str, name: str) -> None:
+    async def create_branch(self, path: str, name: str, request_timeout: float | None = None) -> None:
         """Create branch in the repository.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
             name (str): Name of the new branch to create
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -399,17 +453,22 @@ class AsyncGit:
                 path=path,
                 name=name,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to delete branch: ")
     @with_instrumentation()
-    async def delete_branch(self, path: str, name: str) -> None:
+    async def delete_branch(self, path: str, name: str, request_timeout: float | None = None) -> None:
         """Delete branch in the repository.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
             name (str): Name of the branch to delete
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -422,11 +481,14 @@ class AsyncGit:
                 path=path,
                 name=name,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to initialize repository: ")
     @with_instrumentation()
-    async def init(self, path: str, bare: bool = False, initial_branch: str | None = None) -> None:
+    async def init(
+        self, path: str, bare: bool = False, initial_branch: str | None = None, request_timeout: float | None = None
+    ) -> None:
         """Initializes a new Git repository at the specified path.
 
         Args:
@@ -435,6 +497,10 @@ class AsyncGit:
             bare (bool, optional): Create a bare repository without a working tree. Defaults to False.
             initial_branch (str | None): Name of the initial branch. If not specified, uses the
                 Git default.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -447,6 +513,7 @@ class AsyncGit:
                 bare=bare,
                 initial_branch=initial_branch,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to reset: ")
@@ -457,6 +524,7 @@ class AsyncGit:
         mode: str | None = None,
         target: str | None = None,
         files: list[str] | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Resets the current HEAD to the specified state.
 
@@ -466,6 +534,10 @@ class AsyncGit:
             mode (str | None): Reset mode, one of "soft", "mixed" (default), "hard", "merge" or "keep".
             target (str | None): Revision to reset to. Defaults to HEAD.
             files (list[str] | None): Constrain the reset to the given paths.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -483,6 +555,7 @@ class AsyncGit:
                 target=target,
                 files=files,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to restore files: ")
@@ -494,6 +567,7 @@ class AsyncGit:
         staged: bool | None = None,
         worktree: bool | None = None,
         source: str | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Restores working tree files or unstages changes.
 
@@ -505,6 +579,10 @@ class AsyncGit:
             worktree (bool | None): Restore the working tree for the given files. Defaults to
                 True when neither staged nor worktree is provided.
             source (str | None): Restore file contents from the given revision instead of the index.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -523,6 +601,7 @@ class AsyncGit:
                 worktree=worktree,
                 source=source,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to add remote: ")
@@ -534,6 +613,7 @@ class AsyncGit:
         url: str,
         fetch: bool = False,
         overwrite: bool = False,
+        request_timeout: float | None = None,
     ) -> None:
         """Adds (or overwrites) a remote in the repository.
 
@@ -544,6 +624,10 @@ class AsyncGit:
             url (str): URL of the remote.
             fetch (bool, optional): Fetch from the remote immediately after adding it. Defaults to False.
             overwrite (bool, optional): Replace an existing remote with the same name. Defaults to False.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -558,16 +642,21 @@ class AsyncGit:
                 fetch=fetch,
                 overwrite=overwrite,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to list remotes: ")
     @with_instrumentation()
-    async def remotes(self, path: str) -> ListRemotesResponse:
+    async def remotes(self, path: str, request_timeout: float | None = None) -> ListRemotesResponse:
         """Lists the remotes configured in the repository.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ListRemotesResponse: The configured remotes (name + URL).
@@ -581,17 +670,22 @@ class AsyncGit:
         """
         return await self._api_client.list_remotes(
             path=path,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get remote: ")
     @with_instrumentation()
-    async def remote_get(self, path: str, name: str) -> str | None:
+    async def remote_get(self, path: str, name: str, request_timeout: float | None = None) -> str | None:
         """Gets the URL of a remote, or None when it does not exist.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
             name (str): Name of the remote.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             str | None: The remote URL, or None when the remote does not exist.
@@ -601,7 +695,7 @@ class AsyncGit:
             url = await sandbox.git.remote_get("workspace/repo", "origin")
             ```
         """
-        response = await self._api_client.list_remotes(path=path)
+        response = await self._api_client.list_remotes(path=path, _request_timeout=http_timeout(request_timeout))
         for remote in response.remotes:
             if remote.name == name:
                 return remote.url
@@ -609,7 +703,9 @@ class AsyncGit:
 
     @intercept_errors(message_prefix="Failed to set config: ")
     @with_instrumentation()
-    async def set_config(self, key: str, value: str, scope: str = "global", path: str | None = None) -> None:
+    async def set_config(
+        self, key: str, value: str, scope: str = "global", path: str | None = None, request_timeout: float | None = None
+    ) -> None:
         """Sets a Git config value at the given scope.
 
         Args:
@@ -617,6 +713,10 @@ class AsyncGit:
             value (str): Config value.
             scope (str, optional): Config scope, one of "global" (default), "local" or "system".
             path (str | None): Repository path, required when scope is "local".
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -630,17 +730,24 @@ class AsyncGit:
                 value=value,
                 scope=scope,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get config: ")
     @with_instrumentation()
-    async def get_config(self, key: str, scope: str = "global", path: str | None = None) -> str | None:
+    async def get_config(
+        self, key: str, scope: str = "global", path: str | None = None, request_timeout: float | None = None
+    ) -> str | None:
         """Gets a Git config value at the given scope, or None when unset.
 
         Args:
             key (str): Config key in dotted form (e.g. "user.name").
             scope (str, optional): Config scope, one of "global" (default), "local" or "system".
             path (str | None): Repository path, required when scope is "local".
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             str | None: The config value, or None when the key is not set.
@@ -650,12 +757,21 @@ class AsyncGit:
             name = await sandbox.git.get_config("user.name")
             ```
         """
-        response = await self._api_client.get_git_config(key=key, scope=scope, path=path)
+        response = await self._api_client.get_git_config(
+            key=key, scope=scope, path=path, _request_timeout=http_timeout(request_timeout)
+        )
         return response.value
 
     @intercept_errors(message_prefix="Failed to configure user: ")
     @with_instrumentation()
-    async def configure_user(self, name: str, email: str, scope: str = "global", path: str | None = None) -> None:
+    async def configure_user(
+        self,
+        name: str,
+        email: str,
+        scope: str = "global",
+        path: str | None = None,
+        request_timeout: float | None = None,
+    ) -> None:
         """Configures the Git user name and email at the given scope.
 
         Args:
@@ -663,6 +779,10 @@ class AsyncGit:
             email (str): User email (user.email).
             scope (str, optional): Config scope, one of "global" (default), "local" or "system".
             path (str | None): Repository path, required when scope is "local".
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -676,6 +796,7 @@ class AsyncGit:
                 email=email,
                 scope=scope,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to authenticate: ")
@@ -686,6 +807,7 @@ class AsyncGit:
         password: str,
         host: str | None = None,
         protocol: str | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Persists Git credentials globally so that subsequent operations against the
         given host authenticate automatically.
@@ -698,6 +820,10 @@ class AsyncGit:
             password (str): Git password or token.
             host (str | None): Host to authenticate against. Defaults to "github.com".
             protocol (str | None): Protocol to authenticate against. Defaults to "https".
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -711,4 +837,5 @@ class AsyncGit:
                 host=host,
                 protocol=protocol,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )

--- a/sdk-python/src/daytona/_async/lsp_server.py
+++ b/sdk-python/src/daytona/_async/lsp_server.py
@@ -17,6 +17,7 @@ from daytona_toolbox_api_client_async import (
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
+from .._utils.timeout import http_timeout
 from ..common.lsp_server import LspCompletionPosition, LspLanguageId, LspLanguageIdLiteral
 
 
@@ -45,11 +46,17 @@ class AsyncLspServer:
 
     @intercept_errors(message_prefix="Failed to start LSP server: ")
     @with_instrumentation()
-    async def start(self) -> None:
+    async def start(self, request_timeout: float | None = None) -> None:
         """Starts the language server.
 
         This method must be called before using any other LSP functionality.
         It initializes the language server for the specified language and project.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -63,15 +70,22 @@ class AsyncLspServer:
                 language_id=self._language_id,
                 path_to_project=self._path_to_project,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to stop LSP server: ")
     @with_instrumentation()
-    async def stop(self) -> None:
+    async def stop(self, request_timeout: float | None = None) -> None:
         """Stops the language server.
 
         This method should be called when the LSP server is no longer needed to
         free up system resources.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -84,11 +98,12 @@ class AsyncLspServer:
                 language_id=self._language_id,
                 path_to_project=self._path_to_project,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to open file: ")
     @with_instrumentation()
-    async def did_open(self, path: str) -> None:
+    async def did_open(self, path: str, request_timeout: float | None = None) -> None:
         """Notifies the language server that a file has been opened.
 
         This method should be called when a file is opened in the editor to enable
@@ -98,6 +113,10 @@ class AsyncLspServer:
         Args:
             path (str): Path to the opened file. Relative paths are resolved based on the project path
             set in the LSP server constructor.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -112,11 +131,12 @@ class AsyncLspServer:
                 path_to_project=self._path_to_project,
                 uri=f"file://{path}",
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to close file: ")
     @with_instrumentation()
-    async def did_close(self, path: str) -> None:
+    async def did_close(self, path: str, request_timeout: float | None = None) -> None:
         """Notify the language server that a file has been closed.
 
         This method should be called when a file is closed in the editor to allow
@@ -125,6 +145,10 @@ class AsyncLspServer:
         Args:
             path (str): Path to the closed file. Relative paths are resolved based on the project path
             set in the LSP server constructor.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -138,16 +162,21 @@ class AsyncLspServer:
                 path_to_project=self._path_to_project,
                 uri=f"file://{path}",
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get symbols from document: ")
     @with_instrumentation()
-    async def document_symbols(self, path: str) -> list[LspSymbol]:
+    async def document_symbols(self, path: str, request_timeout: float | None = None) -> list[LspSymbol]:
         """Gets symbol information (functions, classes, variables, etc.) from a document.
 
         Args:
             path (str): Path to the file to get symbols from. Relative paths are resolved based on the project path
             set in the LSP server constructor.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[LspSymbol]: List of symbols in the document. Each symbol includes:
@@ -167,32 +196,41 @@ class AsyncLspServer:
             language_id=self._language_id,
             path_to_project=self._path_to_project,
             uri=f"file://{path}",
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @deprecated(
         reason="Method is deprecated. Use `sandbox_symbols` instead. This method will be removed in a future version."
     )
     @with_instrumentation()
-    async def workspace_symbols(self, query: str) -> list[LspSymbol]:
+    async def workspace_symbols(self, query: str, request_timeout: float | None = None) -> list[LspSymbol]:
         """Searches for symbols matching the query string across all files
         in the Sandbox.
 
         Args:
             query (str): Search query to match against symbol names.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[LspSymbol]: List of matching symbols from all files.
         """
-        return await self.sandbox_symbols(query)
+        return await self.sandbox_symbols(query, request_timeout=request_timeout)
 
     @intercept_errors(message_prefix="Failed to get symbols from sandbox: ")
     @with_instrumentation()
-    async def sandbox_symbols(self, query: str) -> list[LspSymbol]:
+    async def sandbox_symbols(self, query: str, request_timeout: float | None = None) -> list[LspSymbol]:
         """Searches for symbols matching the query string across all files
         in the Sandbox.
 
         Args:
             query (str): Search query to match against symbol names.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[LspSymbol]: List of matching symbols from all files. Each symbol
@@ -213,17 +251,24 @@ class AsyncLspServer:
             language_id=self._language_id,
             path_to_project=self._path_to_project,
             query=query,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get completions: ")
     @with_instrumentation()
-    async def completions(self, path: str, position: LspCompletionPosition) -> CompletionList:
+    async def completions(
+        self, path: str, position: LspCompletionPosition, request_timeout: float | None = None
+    ) -> CompletionList:
         """Gets completion suggestions at a position in a file.
 
         Args:
             path (str): Path to the file. Relative paths are resolved based on the project path
             set in the LSP server constructor.
             position (LspCompletionPosition): Cursor position to get completions for.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             CompletionList: List of completion suggestions. The list includes:
@@ -253,4 +298,5 @@ class AsyncLspServer:
                 uri=f"file://{path}",
                 position=LspPosition(line=position.line, character=position.character),
             ),
+            _request_timeout=http_timeout(request_timeout),
         )

--- a/sdk-python/src/daytona/_async/process.py
+++ b/sdk-python/src/daytona/_async/process.py
@@ -246,7 +246,7 @@ class AsyncProcess:
 
     @intercept_errors(message_prefix="Failed to create session: ")
     @with_instrumentation()
-    async def create_session(self, session_id: str) -> None:
+    async def create_session(self, session_id: str, request_timeout: float | None = None) -> None:
         """Creates a new long-running background session in the Sandbox.
 
         Sessions are background processes that maintain state between commands, making them ideal for
@@ -255,6 +255,10 @@ class AsyncProcess:
 
         Args:
             session_id (str): Unique identifier for the new session.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -267,14 +271,18 @@ class AsyncProcess:
             ```
         """
         request = CreateSessionRequest(session_id=session_id)
-        await self._api_client.create_session(request=request)
+        await self._api_client.create_session(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to get session: ")
-    async def get_session(self, session_id: str) -> Session:
+    async def get_session(self, session_id: str, request_timeout: float | None = None) -> Session:
         """Gets a session in the Sandbox.
 
         Args:
             session_id (str): Unique identifier of the session to retrieve.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Session: Session information including:
@@ -288,11 +296,17 @@ class AsyncProcess:
                 print(f"Command: {cmd.command}")
             ```
         """
-        return await self._api_client.get_session(session_id=session_id)
+        return await self._api_client.get_session(session_id=session_id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to get sandbox entrypoint session: ")
-    async def get_entrypoint_session(self) -> Session:
+    async def get_entrypoint_session(self, request_timeout: float | None = None) -> Session:
         """Gets the sandbox entrypoint session.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Session: Entrypoint session information including:
@@ -306,16 +320,22 @@ class AsyncProcess:
                 print(f"Command: {cmd.command}")
             ```
         """
-        return await self._api_client.get_entrypoint_session()
+        return await self._api_client.get_entrypoint_session(_request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to get session command: ")
     @with_instrumentation()
-    async def get_session_command(self, session_id: str, command_id: str) -> Command:
+    async def get_session_command(
+        self, session_id: str, command_id: str, request_timeout: float | None = None
+    ) -> Command:
         """Gets information about a specific command executed in a session.
 
         Args:
             session_id (str): Unique identifier of the session.
             command_id (str): Unique identifier of the command.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Command: Command information including:
@@ -330,7 +350,9 @@ class AsyncProcess:
                 print(f"Command {cmd.command} completed successfully")
             ```
         """
-        return await self._api_client.get_session_command(session_id=session_id, command_id=command_id)
+        return await self._api_client.get_session_command(
+            session_id=session_id, command_id=command_id, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to execute session command: ")
     @with_instrumentation()
@@ -393,12 +415,18 @@ class AsyncProcess:
 
     @intercept_errors(message_prefix="Failed to get session command logs: ")
     @with_instrumentation()
-    async def get_session_command_logs(self, session_id: str, command_id: str) -> SessionCommandLogsResponse:
+    async def get_session_command_logs(
+        self, session_id: str, command_id: str, request_timeout: float | None = None
+    ) -> SessionCommandLogsResponse:
         """Get the logs for a command executed in a session.
 
         Args:
             session_id (str): Unique identifier of the session.
             command_id (str): Unique identifier of the command.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             SessionCommandLogsResponse: Command logs including:
@@ -416,7 +444,9 @@ class AsyncProcess:
             print(f"Command stderr: {logs.stderr}")
             ```
         """
-        response = await self._api_client.get_session_command_logs(session_id=session_id, command_id=command_id)
+        response = await self._api_client.get_session_command_logs(
+            session_id=session_id, command_id=command_id, _request_timeout=http_timeout(request_timeout)
+        )
 
         return SessionCommandLogsResponse(output=response.output, stdout=response.stdout, stderr=response.stderr)
 
@@ -462,8 +492,14 @@ class AsyncProcess:
 
     @intercept_errors(message_prefix="Failed to get entrypoint logs: ")
     @with_instrumentation()
-    async def get_entrypoint_logs(self) -> SessionCommandLogsResponse:
+    async def get_entrypoint_logs(self, request_timeout: float | None = None) -> SessionCommandLogsResponse:
         """Get the logs for the entrypoint session.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             SessionCommandLogsResponse: Command logs including:
@@ -478,7 +514,7 @@ class AsyncProcess:
             print(f"Command stderr: {logs.stderr}")
             ```
         """
-        response = await self._api_client.get_entrypoint_logs()
+        response = await self._api_client.get_entrypoint_logs(_request_timeout=http_timeout(request_timeout))
 
         return SessionCommandLogsResponse(output=response.output, stdout=response.stdout, stderr=response.stderr)
 
@@ -512,22 +548,37 @@ class AsyncProcess:
         await self._consume_log_websocket(url, headers, on_stdout, on_stderr)
 
     @intercept_errors(message_prefix="Failed to send session command input: ")
-    async def send_session_command_input(self, session_id: str, command_id: str, data: str) -> None:
+    async def send_session_command_input(
+        self, session_id: str, command_id: str, data: str, request_timeout: float | None = None
+    ) -> None:
         """Sends input data to a command executed in a session.
 
         Args:
             session_id (str): Unique identifier of the session.
             command_id (str): Unique identifier of the command.
             data (str): Input data to send.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
         await self._api_client.send_input(
-            session_id=session_id, command_id=command_id, request=SessionSendInputRequest(data=data)
+            session_id=session_id,
+            command_id=command_id,
+            request=SessionSendInputRequest(data=data),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to list sessions: ")
     @with_instrumentation()
-    async def list_sessions(self) -> list[Session]:
+    async def list_sessions(self, request_timeout: float | None = None) -> list[Session]:
         """Lists all sessions in the Sandbox.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[Session]: List of all sessions in the Sandbox.
@@ -540,16 +591,20 @@ class AsyncProcess:
                 print(f"  Commands: {len(session.commands)}")
             ```
         """
-        return await self._api_client.list_sessions()
+        return await self._api_client.list_sessions(_request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to delete session: ")
     @with_instrumentation()
-    async def delete_session(self, session_id: str) -> None:
+    async def delete_session(self, session_id: str, request_timeout: float | None = None) -> None:
         """Terminates and removes a session from the Sandbox, cleaning up any resources
         associated with it.
 
         Args:
             session_id (str): Unique identifier of the session to delete.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -561,7 +616,7 @@ class AsyncProcess:
             await sandbox.process.delete_session("temp-session")
             ```
         """
-        await self._api_client.delete_session(session_id=session_id)
+        await self._api_client.delete_session(session_id=session_id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to create PTY session: ")
     @with_instrumentation()
@@ -716,10 +771,16 @@ class AsyncProcess:
 
     @intercept_errors(message_prefix="Failed to list PTY sessions: ")
     @with_instrumentation()
-    async def list_pty_sessions(self) -> list[PtySessionInfo]:
+    async def list_pty_sessions(self, request_timeout: float | None = None) -> list[PtySessionInfo]:
         """Lists all PTY sessions in the Sandbox.
 
         Retrieves information about all PTY sessions in this Sandbox.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[PtySessionInfo]: List of PTY session information objects containing
@@ -736,11 +797,11 @@ class AsyncProcess:
                 print(f"Created: {session.created_at}")
             ```
         """
-        return (await self._api_client.list_pty_sessions()).sessions
+        return (await self._api_client.list_pty_sessions(_request_timeout=http_timeout(request_timeout))).sessions
 
     @intercept_errors(message_prefix="Failed to get PTY session info: ")
     @with_instrumentation()
-    async def get_pty_session_info(self, session_id: str) -> PtySessionInfo:
+    async def get_pty_session_info(self, session_id: str, request_timeout: float | None = None) -> PtySessionInfo:
         """Gets detailed information about a specific PTY session.
 
         Retrieves comprehensive information about a PTY session including its current state,
@@ -748,6 +809,10 @@ class AsyncProcess:
 
         Args:
             session_id: Unique identifier of the PTY session to retrieve information for.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             PtySessionInfo: Detailed information about the PTY session including ID, state,
@@ -767,11 +832,13 @@ class AsyncProcess:
             print(f"Terminal Size: {session_info.cols}x{session_info.rows}")
             ```
         """
-        return await self._api_client.get_pty_session(session_id=session_id)
+        return await self._api_client.get_pty_session(
+            session_id=session_id, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to kill PTY session: ")
     @with_instrumentation()
-    async def kill_pty_session(self, session_id: str) -> None:
+    async def kill_pty_session(self, session_id: str, request_timeout: float | None = None) -> None:
         """Kills a PTY session and terminates its associated process.
 
         Forcefully terminates the PTY session and cleans up all associated resources.
@@ -780,6 +847,10 @@ class AsyncProcess:
 
         Args:
             session_id: Unique identifier of the PTY session to kill.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the PTY session doesn't exist or cannot be killed.
@@ -795,11 +866,15 @@ class AsyncProcess:
                 print(f"PTY session: {pty_session.id}")
             ```
         """
-        _ = await self._api_client.delete_pty_session(session_id=session_id)
+        _ = await self._api_client.delete_pty_session(
+            session_id=session_id, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to resize PTY session: ")
     @with_instrumentation()
-    async def resize_pty_session(self, session_id: str, pty_size: PtySize) -> PtySessionInfo:
+    async def resize_pty_session(
+        self, session_id: str, pty_size: PtySize, request_timeout: float | None = None
+    ) -> PtySessionInfo:
         """Resizes a PTY session's terminal dimensions.
 
         Changes the terminal size of an active PTY session. This is useful when the
@@ -809,6 +884,10 @@ class AsyncProcess:
         Args:
             session_id: Unique identifier of the PTY session to resize.
             pty_size: New terminal dimensions containing the desired columns and rows.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             PtySessionInfo: Updated session information reflecting the new terminal size.
@@ -833,4 +912,5 @@ class AsyncProcess:
         return await self._api_client.resize_pty_session(
             session_id=session_id,
             request=PtyResizeRequest(cols=pty_size.cols, rows=pty_size.rows),
+            _request_timeout=http_timeout(request_timeout),
         )

--- a/sdk-python/src/daytona/_async/sandbox.py
+++ b/sdk-python/src/daytona/_async/sandbox.py
@@ -159,8 +159,14 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to refresh sandbox data: ")
     @with_instrumentation()
-    async def refresh_data(self) -> None:
+    async def refresh_data(self, request_timeout: float | None = None) -> None:
         """Refreshes the Sandbox data from the API.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -170,7 +176,7 @@ class AsyncSandbox(SandboxDto):
             print(f"Resources: {sandbox.cpu} CPU, {sandbox.memory} GiB RAM")
             ```
         """
-        instance = await self._sandbox_api.get_sandbox(self.id)
+        instance = await self._sandbox_api.get_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
         self.__process_sandbox_dto(instance)
 
     @intercept_errors(message_prefix="Failed to get user home directory: ")
@@ -247,13 +253,17 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set labels: ")
     @with_instrumentation()
-    async def set_labels(self, labels: dict[str, str]) -> dict[str, str]:
+    async def set_labels(self, labels: dict[str, str], request_timeout: float | None = None) -> dict[str, str]:
         """Sets labels for the Sandbox.
 
         Labels are key-value pairs that can be used to organize and identify Sandboxes.
 
         Args:
             labels (dict[str, str]): Dictionary of key-value pairs representing Sandbox labels.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             dict[str, str]: Dictionary containing the updated Sandbox labels.
@@ -268,7 +278,11 @@ class AsyncSandbox(SandboxDto):
             print(f"Updated labels: {new_labels}")
             ```
         """
-        self.labels = (await self._sandbox_api.replace_labels(self.id, SandboxLabels(labels=labels))).labels
+        self.labels = (
+            await self._sandbox_api.replace_labels(
+                self.id, SandboxLabels(labels=labels), _request_timeout=http_timeout(request_timeout)
+            )
+        ).labels
         return self.labels
 
     @intercept_errors(message_prefix="Failed to start sandbox: ")
@@ -432,7 +446,7 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set auto-stop interval: ")
     @with_instrumentation()
-    async def set_autostop_interval(self, interval: int) -> None:
+    async def set_autostop_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-stop interval for the Sandbox.
 
         The Sandbox will automatically stop after being idle (no new events) for the specified interval.
@@ -442,6 +456,10 @@ class AsyncSandbox(SandboxDto):
         Args:
             interval (int): Number of minutes of inactivity before auto-stopping.
                 Set to 0 to disable auto-stop. Defaults to 15.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaValidationError: If interval is negative
@@ -457,12 +475,14 @@ class AsyncSandbox(SandboxDto):
         if interval < 0:
             raise DaytonaValidationError("Auto-stop interval must be a non-negative integer")
 
-        _ = await self._sandbox_api.set_autostop_interval(self.id, interval)
+        _ = await self._sandbox_api.set_autostop_interval(
+            self.id, interval, _request_timeout=http_timeout(request_timeout)
+        )
         self.auto_stop_interval = interval
 
     @intercept_errors(message_prefix="Failed to set auto-archive interval: ")
     @with_instrumentation()
-    async def set_auto_archive_interval(self, interval: int) -> None:
+    async def set_auto_archive_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-archive interval for the Sandbox.
 
         The Sandbox will automatically archive after being continuously stopped for the specified interval.
@@ -470,6 +490,10 @@ class AsyncSandbox(SandboxDto):
         Args:
             interval (int): Number of minutes after which a continuously stopped Sandbox will be auto-archived.
                 Set to 0 for the maximum interval. Default is 7 days.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaValidationError: If interval is negative
@@ -485,12 +509,14 @@ class AsyncSandbox(SandboxDto):
         if interval < 0:
             raise DaytonaValidationError("Auto-archive interval must be a non-negative integer")
 
-        _ = await self._sandbox_api.set_auto_archive_interval(self.id, interval)
+        _ = await self._sandbox_api.set_auto_archive_interval(
+            self.id, interval, _request_timeout=http_timeout(request_timeout)
+        )
         self.auto_archive_interval = interval
 
     @intercept_errors(message_prefix="Failed to set auto-delete interval: ")
     @with_instrumentation()
-    async def set_auto_delete_interval(self, interval: int) -> None:
+    async def set_auto_delete_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-delete interval for the Sandbox.
 
         The Sandbox will automatically delete after being continuously stopped for the specified interval.
@@ -499,6 +525,10 @@ class AsyncSandbox(SandboxDto):
             interval (int): Number of minutes after which a continuously stopped Sandbox will be auto-deleted.
                 Set to negative value to disable auto-delete. Set to 0 to delete immediately upon stopping.
                 By default, auto-delete is disabled.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -510,7 +540,9 @@ class AsyncSandbox(SandboxDto):
             sandbox.set_auto_delete_interval(-1)
             ```
         """
-        _ = await self._sandbox_api.set_auto_delete_interval(self.id, interval)
+        _ = await self._sandbox_api.set_auto_delete_interval(
+            self.id, interval, _request_timeout=http_timeout(request_timeout)
+        )
         self.auto_delete_interval = interval
 
     @intercept_errors(message_prefix="Failed to update network settings: ")
@@ -521,6 +553,7 @@ class AsyncSandbox(SandboxDto):
         network_block_all: bool | None = None,
         network_allow_list: str | None = None,
         domain_allow_list: str | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Updates outbound network policy on the runner (block all, restore access, or CIDR allow list).
 
@@ -529,6 +562,10 @@ class AsyncSandbox(SandboxDto):
                 outbound access (and clears a stored allow list).
             network_allow_list: Comma-separated IPv4 CIDRs to allow; implies not blocking all.
             domain_allow_list: Comma-separated domains to allow; implies not blocking all.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaValidationError: If neither argument is set.
@@ -549,7 +586,9 @@ class AsyncSandbox(SandboxDto):
             network_allow_list=network_allow_list,
             domain_allow_list=domain_allow_list,
         )
-        updated = await self._sandbox_api.update_network_settings(self.id, body)
+        updated = await self._sandbox_api.update_network_settings(
+            self.id, body, _request_timeout=http_timeout(request_timeout)
+        )
         self.network_block_all = updated.network_block_all
         self.network_allow_list = updated.network_allow_list
         self.domain_allow_list = updated.domain_allow_list
@@ -599,13 +638,17 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to get preview link: ")
     @with_instrumentation()
-    async def get_preview_link(self, port: int) -> PortPreviewUrl:
+    async def get_preview_link(self, port: int, request_timeout: float | None = None) -> PortPreviewUrl:
         """Retrieves the preview link for the sandbox at the specified port. If the port is closed,
         it will be opened automatically. For private sandboxes, a token is included to grant access
         to the URL.
 
         Args:
             port (int): The port to open the preview link on.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             PortPreviewUrl: The response object for the preview link, which includes the `url`
@@ -618,43 +661,65 @@ class AsyncSandbox(SandboxDto):
             print(f"Token: {preview_link.token}")
             ```
         """
-        return await self._sandbox_api.get_port_preview_url(self.id, port)
+        return await self._sandbox_api.get_port_preview_url(
+            self.id, port, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to create signed preview url: ")
-    async def create_signed_preview_url(self, port: int, expires_in_seconds: int | None = None) -> SignedPortPreviewUrl:
+    async def create_signed_preview_url(
+        self, port: int, expires_in_seconds: int | None = None, request_timeout: float | None = None
+    ) -> SignedPortPreviewUrl:
         """Creates a signed preview URL for the sandbox at the specified port.
 
         Args:
             port (int): The port to open the preview link on.
             expires_in_seconds (int | None): The number of seconds the signed preview
                 url will be valid for. Defaults to 60 seconds.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             SignedPortPreviewUrl: The response object for the signed preview url.
         """
-        return await self._sandbox_api.get_signed_port_preview_url(self.id, port, expires_in_seconds=expires_in_seconds)
+        return await self._sandbox_api.get_signed_port_preview_url(
+            self.id, port, expires_in_seconds=expires_in_seconds, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to expire signed preview url: ")
-    async def expire_signed_preview_url(self, port: int, token: str) -> None:
+    async def expire_signed_preview_url(self, port: int, token: str, request_timeout: float | None = None) -> None:
         """Expires a signed preview URL for the sandbox at the specified port.
 
         Args:
             port (int): The port to expire the signed preview url on.
             token (str): The token to expire the signed preview url on.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
-        await self._sandbox_api.expire_signed_port_preview_url(self.id, port, token)
+        await self._sandbox_api.expire_signed_port_preview_url(
+            self.id, port, token, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to archive sandbox: ")
     @with_instrumentation()
-    async def archive(self) -> None:
+    async def archive(self, request_timeout: float | None = None) -> None:
         """Archives the sandbox, making it inactive and preserving its state. When sandboxes are
         archived, the entire filesystem state is moved to cost-effective object storage, making it
         possible to keep sandboxes available for an extended period. The tradeoff between archived
         and stopped states is that starting an archived sandbox takes more time, depending on its size.
         Sandbox must be stopped before archiving.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = await self._sandbox_api.archive_sandbox(self.id)
-        await self.refresh_data()
+        _ = await self._sandbox_api.archive_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
+        await self.refresh_data(request_timeout=request_timeout)
 
     @intercept_errors(message_prefix="Failed to resize sandbox: ")
     @with_timeout()
@@ -733,47 +798,69 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to create SSH access: ")
     @with_instrumentation()
-    async def create_ssh_access(self, expires_in_minutes: int | None = None) -> SshAccessDto:
+    async def create_ssh_access(
+        self, expires_in_minutes: int | None = None, request_timeout: float | None = None
+    ) -> SshAccessDto:
         """Creates an SSH access token for the sandbox.
 
         Args:
             expires_in_minutes (int | None): The number of minutes the SSH access token will be valid for.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
-        return await self._sandbox_api.create_ssh_access(self.id, expires_in_minutes=expires_in_minutes)
+        return await self._sandbox_api.create_ssh_access(
+            self.id, expires_in_minutes=expires_in_minutes, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to revoke SSH access: ")
     @with_instrumentation()
-    async def revoke_ssh_access(self, token: str) -> None:
+    async def revoke_ssh_access(self, token: str, request_timeout: float | None = None) -> None:
         """Revokes an SSH access token for the sandbox.
 
         Args:
             token (str): The token to revoke.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = await self._sandbox_api.revoke_ssh_access(self.id, token)
+        _ = await self._sandbox_api.revoke_ssh_access(self.id, token, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to validate SSH access: ")
     @with_instrumentation()
-    async def validate_ssh_access(self, token: str) -> SshAccessValidationDto:
+    async def validate_ssh_access(self, token: str, request_timeout: float | None = None) -> SshAccessValidationDto:
         """Validates an SSH access token for the sandbox.
 
         Args:
             token (str): The token to validate.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
-        return await self._sandbox_api.validate_ssh_access(token)
+        return await self._sandbox_api.validate_ssh_access(token, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to refresh sandbox activity: ")
-    async def refresh_activity(self) -> None:
+    async def refresh_activity(self, request_timeout: float | None = None) -> None:
         """Refreshes the sandbox activity to reset the timer for automated lifecycle management actions.
 
         This method updates the sandbox's last activity timestamp without changing its state.
         It is useful for keeping long-running sessions alive while there is still user activity.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
             await sandbox.refresh_activity()
             ```
         """
-        await self._sandbox_api.update_last_activity(self.id)
+        await self._sandbox_api.update_last_activity(self.id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to fork sandbox: ")
     @with_timeout()

--- a/sdk-python/src/daytona/_sync/code_interpreter.py
+++ b/sdk-python/src/daytona/_sync/code_interpreter.py
@@ -13,6 +13,7 @@ from wsproto.events import BytesMessage, CloseConnection, TextMessage
 from daytona_toolbox_api_client import CreateContextRequest, InterpreterApi, InterpreterContext
 
 from .._utils.errors import intercept_errors
+from .._utils.timeout import http_timeout
 from ..common.code_interpreter import ExecutionError, ExecutionResult, OutputMessage
 from ..common.errors import DaytonaConnectionError, DaytonaTimeoutError
 from ..common.process import OutputHandler
@@ -175,6 +176,7 @@ class CodeInterpreter:
     def create_context(
         self,
         cwd: str | None = None,
+        request_timeout: float | None = None,
     ) -> InterpreterContext:
         """Create a new isolated interpreter context.
 
@@ -183,6 +185,10 @@ class CodeInterpreter:
 
         Args:
             cwd (str | None): Working directory for the context. If not specified, uses sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             InterpreterContext: The created context with its ID and metadata.
@@ -208,14 +214,22 @@ class CodeInterpreter:
             sandbox.code_interpreter.delete_context(ctx)
             ```
         """
-        return self._api_client.create_interpreter_context(request=CreateContextRequest(cwd=cwd))
+        return self._api_client.create_interpreter_context(
+            request=CreateContextRequest(cwd=cwd), _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to list interpreter contexts: ")
-    def list_contexts(self) -> list[InterpreterContext]:
+    def list_contexts(self, request_timeout: float | None = None) -> list[InterpreterContext]:
         """List all user-created interpreter contexts.
 
         The default context is not included in this list. Only contexts created
         via `create_context()` are returned.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[InterpreterContext]: List of context objects.
@@ -230,10 +244,12 @@ class CodeInterpreter:
                 print(f"Context {ctx.id}: {ctx.language} at {ctx.cwd}")
             ```
         """
-        return (self._api_client.list_interpreter_contexts()).contexts or []
+        return (
+            self._api_client.list_interpreter_contexts(_request_timeout=http_timeout(request_timeout))
+        ).contexts or []
 
     @intercept_errors(message_prefix="Failed to delete interpreter context: ")
-    def delete_context(self, context: InterpreterContext) -> None:
+    def delete_context(self, context: InterpreterContext, request_timeout: float | None = None) -> None:
         """Delete an interpreter context and shut down all associated processes.
 
         This permanently removes the context and all its state (variables, imports, etc.).
@@ -241,6 +257,10 @@ class CodeInterpreter:
 
         Args:
             context (InterpreterContext): Context to delete.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If deletion fails or context not found.
@@ -252,7 +272,7 @@ class CodeInterpreter:
             sandbox.code_interpreter.delete_context(ctx)
             ```
         """
-        _ = self._api_client.delete_interpreter_context(id=context.id)
+        _ = self._api_client.delete_interpreter_context(id=context.id, _request_timeout=http_timeout(request_timeout))
 
     def _maybe_raise_from_close(self, close_code: int | None, close_reason: str | None) -> None:
         """Translate a websocket close into a Daytona error when it indicates failure.

--- a/sdk-python/src/daytona/_sync/computer_use.py
+++ b/sdk-python/src/daytona/_sync/computer_use.py
@@ -43,6 +43,7 @@ from daytona_toolbox_api_client import (
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
+from .._utils.timeout import http_timeout
 from ..common.computer_use import ScreenshotOptions, ScreenshotRegion
 from ..internal.http_client import request_timeout as _request_timeout
 
@@ -55,8 +56,14 @@ class Mouse:
 
     @intercept_errors(message_prefix="Failed to get mouse position: ")
     @with_instrumentation()
-    def get_position(self) -> MousePositionResponse:
+    def get_position(self, request_timeout: float | None = None) -> MousePositionResponse:
         """Gets the current mouse cursor position.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             MousePositionResponse: Current mouse position with x and y coordinates.
@@ -67,17 +74,21 @@ class Mouse:
             print(f"Mouse is at: {position.x}, {position.y}")
             ```
         """
-        response = self._api_client.get_mouse_position()
+        response = self._api_client.get_mouse_position(_request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to move mouse: ")
     @with_instrumentation()
-    def move(self, x: int, y: int) -> MousePositionResponse:
+    def move(self, x: int, y: int, request_timeout: float | None = None) -> MousePositionResponse:
         """Moves the mouse cursor to the specified coordinates.
 
         Args:
             x (int): The x coordinate to move to.
             y (int): The y coordinate to move to.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             MousePositionResponse: Position after move.
@@ -89,12 +100,14 @@ class Mouse:
             ```
         """
         request = MouseMoveRequest(x=x, y=y)
-        response = self._api_client.move_mouse(request)
+        response = self._api_client.move_mouse(request, _request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to click mouse: ")
     @with_instrumentation()
-    def click(self, x: int, y: int, button: str = "left", double: bool = False) -> MouseClickResponse:
+    def click(
+        self, x: int, y: int, button: str = "left", double: bool = False, request_timeout: float | None = None
+    ) -> MouseClickResponse:
         """Clicks the mouse at the specified coordinates.
 
         Args:
@@ -102,6 +115,10 @@ class Mouse:
             y (int): The y coordinate to click at.
             button (str): The mouse button to click ('left', 'right', 'middle').
             double (bool): Whether to perform a double-click.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             MouseClickResponse: Click operation result.
@@ -119,12 +136,20 @@ class Mouse:
             ```
         """
         request = MouseClickRequest(x=x, y=y, button=button, double=double)
-        response = self._api_client.click(request)
+        response = self._api_client.click(request, _request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to drag mouse: ")
     @with_instrumentation()
-    def drag(self, start_x: int, start_y: int, end_x: int, end_y: int, button: str = "left") -> MouseDragResponse:
+    def drag(
+        self,
+        start_x: int,
+        start_y: int,
+        end_x: int,
+        end_y: int,
+        button: str = "left",
+        request_timeout: float | None = None,
+    ) -> MouseDragResponse:
         """Drags the mouse from start coordinates to end coordinates.
 
         Args:
@@ -133,6 +158,10 @@ class Mouse:
             end_x (int): The ending x coordinate.
             end_y (int): The ending y coordinate.
             button (str): The mouse button to use for dragging.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             MouseDragResponse: Drag operation result.
@@ -144,12 +173,12 @@ class Mouse:
             ```
         """
         request = MouseDragRequest(start_x=start_x, start_y=start_y, end_x=end_x, end_y=end_y, button=button)
-        response = self._api_client.drag(request=request)
+        response = self._api_client.drag(request=request, _request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to scroll mouse: ")
     @with_instrumentation()
-    def scroll(self, x: int, y: int, direction: str, amount: int = 1) -> bool:
+    def scroll(self, x: int, y: int, direction: str, amount: int = 1, request_timeout: float | None = None) -> bool:
         """Scrolls the mouse wheel at the specified coordinates.
 
         Args:
@@ -157,6 +186,10 @@ class Mouse:
             y (int): The y coordinate to scroll at.
             direction (str): The direction to scroll ('up' or 'down').
             amount (int): The amount to scroll.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             bool: Whether the scroll operation was successful.
@@ -171,7 +204,7 @@ class Mouse:
             ```
         """
         request = MouseScrollRequest(x=x, y=y, direction=direction, amount=amount)
-        response = self._api_client.scroll(request=request)
+        response = self._api_client.scroll(request=request, _request_timeout=http_timeout(request_timeout))
         return response.success is True
 
 
@@ -183,12 +216,16 @@ class Keyboard:
 
     @intercept_errors(message_prefix="Failed to type text: ")
     @with_instrumentation()
-    def type(self, text: str, delay: int | None = None) -> None:
+    def type(self, text: str, delay: int | None = None, request_timeout: float | None = None) -> None:
         """Types the specified text.
 
         Args:
             text (str): The text to type.
             delay (int): Delay between characters in milliseconds.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the type operation fails.
@@ -210,11 +247,11 @@ class Keyboard:
             ```
         """
         request = KeyboardTypeRequest(text=text, delay=delay)
-        _ = self._api_client.type_text(request=request)
+        _ = self._api_client.type_text(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to press key: ")
     @with_instrumentation()
-    def press(self, key: str, modifiers: list[str] | None = None) -> None:
+    def press(self, key: str, modifiers: list[str] | None = None, request_timeout: float | None = None) -> None:
         """Presses a key with optional modifiers.
 
         Args:
@@ -226,6 +263,10 @@ class Keyboard:
             modifiers (list[str]): Canonical modifier names are 'ctrl', 'alt',
                 'shift', and 'cmd'. Common aliases such as 'control', 'option',
                 'meta', and 'win' are normalized.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the press operation fails.
@@ -253,17 +294,21 @@ class Keyboard:
             ```
         """
         request = KeyboardPressRequest(key=key, modifiers=modifiers or [])
-        _ = self._api_client.press_key(request=request)
+        _ = self._api_client.press_key(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to press hotkey: ")
     @with_instrumentation()
-    def hotkey(self, keys: str) -> None:
+    def hotkey(self, keys: str, request_timeout: float | None = None) -> None:
         """Presses a hotkey combination.
 
         Args:
             keys (str): A single atomic hotkey chord (e.g., 'ctrl+c', 'alt+tab',
                 'cmd+shift+t', 'ctrl + c', 'shift'). Uses the same normalized key
                 contract as ``press()``.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the hotkey operation fails.
@@ -293,7 +338,7 @@ class Keyboard:
             ```
         """
         request = KeyboardHotkeyRequest(keys=keys)
-        _ = self._api_client.press_hotkey(request=request)
+        _ = self._api_client.press_hotkey(request=request, _request_timeout=http_timeout(request_timeout))
 
 
 class Screenshot:
@@ -304,11 +349,15 @@ class Screenshot:
 
     @intercept_errors(message_prefix="Failed to take screenshot: ")
     @with_instrumentation()
-    def take_full_screen(self, show_cursor: bool = False) -> ScreenshotResponse:
+    def take_full_screen(self, show_cursor: bool = False, request_timeout: float | None = None) -> ScreenshotResponse:
         """Takes a screenshot of the entire screen.
 
         Args:
             show_cursor (bool): Whether to show the cursor in the screenshot.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ScreenshotResponse: Screenshot data with base64 encoded image.
@@ -322,17 +371,25 @@ class Screenshot:
             with_cursor = sandbox.computer_use.screenshot.take_full_screen(True)
             ```
         """
-        response = self._api_client.take_screenshot(show_cursor=show_cursor)
+        response = self._api_client.take_screenshot(
+            show_cursor=show_cursor, _request_timeout=http_timeout(request_timeout)
+        )
         return response
 
     @intercept_errors(message_prefix="Failed to take region screenshot: ")
     @with_instrumentation()
-    def take_region(self, region: ScreenshotRegion, show_cursor: bool = False) -> ScreenshotResponse:
+    def take_region(
+        self, region: ScreenshotRegion, show_cursor: bool = False, request_timeout: float | None = None
+    ) -> ScreenshotResponse:
         """Takes a screenshot of a specific region.
 
         Args:
             region (ScreenshotRegion): The region to capture.
             show_cursor (bool): Whether to show the cursor in the screenshot.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ScreenshotResponse: Screenshot data with base64 encoded image.
@@ -345,17 +402,28 @@ class Screenshot:
             ```
         """
         response = self._api_client.take_region_screenshot(
-            height=region.height, width=region.width, y=region.y, x=region.x, show_cursor=show_cursor
+            height=region.height,
+            width=region.width,
+            y=region.y,
+            x=region.x,
+            show_cursor=show_cursor,
+            _request_timeout=http_timeout(request_timeout),
         )
         return response
 
     @intercept_errors(message_prefix="Failed to take compressed screenshot: ")
     @with_instrumentation()
-    def take_compressed(self, options: ScreenshotOptions | None = None) -> ScreenshotResponse:
+    def take_compressed(
+        self, options: ScreenshotOptions | None = None, request_timeout: float | None = None
+    ) -> ScreenshotResponse:
         """Takes a compressed screenshot of the entire screen.
 
         Args:
             options (ScreenshotOptions | None): Compression and display options.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ScreenshotResponse: Compressed screenshot data.
@@ -384,19 +452,24 @@ class Screenshot:
             quality=options.quality,
             format=options.fmt,
             show_cursor=options.show_cursor,
+            _request_timeout=http_timeout(request_timeout),
         )
         return response
 
     @intercept_errors(message_prefix="Failed to take compressed region screenshot: ")
     @with_instrumentation()
     def take_compressed_region(
-        self, region: ScreenshotRegion, options: ScreenshotOptions | None = None
+        self, region: ScreenshotRegion, options: ScreenshotOptions | None = None, request_timeout: float | None = None
     ) -> ScreenshotResponse:
         """Takes a compressed screenshot of a specific region.
 
         Args:
             region (ScreenshotRegion): The region to capture.
             options (ScreenshotOptions | None): Compression and display options.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ScreenshotResponse: Compressed screenshot data.
@@ -423,6 +496,7 @@ class Screenshot:
             quality=options.quality,
             format=options.fmt,
             show_cursor=options.show_cursor,
+            _request_timeout=http_timeout(request_timeout),
         )
         return response
 
@@ -435,8 +509,14 @@ class Display:
 
     @intercept_errors(message_prefix="Failed to get display info: ")
     @with_instrumentation()
-    def get_info(self) -> DisplayInfoResponse:
+    def get_info(self, request_timeout: float | None = None) -> DisplayInfoResponse:
         """Gets information about the displays.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             DisplayInfoResponse: Display information including primary display and all available displays.
@@ -450,13 +530,19 @@ class Display:
                 print(f"Display {i}: {display.width}x{display.height} at {display.x},{display.y}")
             ```
         """
-        response = self._api_client.get_display_info()
+        response = self._api_client.get_display_info(_request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to get windows: ")
     @with_instrumentation()
-    def get_windows(self) -> WindowsResponse:
+    def get_windows(self, request_timeout: float | None = None) -> WindowsResponse:
         """Gets the list of open windows.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             WindowsResponse: List of open windows with their IDs and titles.
@@ -469,7 +555,7 @@ class Display:
                 print(f"- {window.title} (ID: {window.id})")
             ```
         """
-        response = self._api_client.get_windows()
+        response = self._api_client.get_windows(_request_timeout=http_timeout(request_timeout))
         return response
 
 
@@ -486,11 +572,15 @@ class RecordingService:
 
     @intercept_errors(message_prefix="Failed to start recording: ")
     @with_instrumentation()
-    def start(self, label: str | None = None) -> Recording:
+    def start(self, label: str | None = None, request_timeout: float | None = None) -> Recording:
         """Starts a new screen recording session.
 
         Args:
             label (str | None): Optional custom label for the recording.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Recording: Recording start response.
@@ -504,15 +594,19 @@ class RecordingService:
             ```
         """
         request = StartRecordingRequest(label=label)
-        return self._api_client.start_recording(request=request)
+        return self._api_client.start_recording(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to stop recording: ")
     @with_instrumentation()
-    def stop(self, recording_id: str) -> Recording:
+    def stop(self, recording_id: str, request_timeout: float | None = None) -> Recording:
         """Stops an active screen recording session.
 
         Args:
             recording_id (str): The ID of the recording to stop.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Recording: Recording stop response.
@@ -525,12 +619,18 @@ class RecordingService:
             ```
         """
         request = StopRecordingRequest(id=recording_id)
-        return self._api_client.stop_recording(request=request)
+        return self._api_client.stop_recording(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to list recordings: ")
     @with_instrumentation()
-    def list(self) -> ListRecordingsResponse:
+    def list(self, request_timeout: float | None = None) -> ListRecordingsResponse:
         """Lists all recordings (active and completed).
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ListRecordingsResponse: List of all recordings.
@@ -543,15 +643,19 @@ class RecordingService:
                 print(f"- {rec.file_name}: {rec.status}")
             ```
         """
-        return self._api_client.list_recordings()
+        return self._api_client.list_recordings(_request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to get recording: ")
     @with_instrumentation()
-    def get(self, recording_id: str) -> Recording:
+    def get(self, recording_id: str, request_timeout: float | None = None) -> Recording:
         """Gets details of a specific recording by ID.
 
         Args:
             recording_id (str): The ID of the recording to retrieve.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Recording: Recording details.
@@ -564,15 +668,19 @@ class RecordingService:
             print(f"Duration: {recording.duration_seconds} seconds")
             ```
         """
-        return self._api_client.get_recording(id=recording_id)
+        return self._api_client.get_recording(id=recording_id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to delete recording: ")
     @with_instrumentation()
-    def delete(self, recording_id: str) -> None:
+    def delete(self, recording_id: str, request_timeout: float | None = None) -> None:
         """Deletes a recording by ID.
 
         Args:
             recording_id (str): The ID of the recording to delete.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -580,7 +688,7 @@ class RecordingService:
             print("Recording deleted")
             ```
         """
-        self._api_client.delete_recording(id=recording_id)
+        self._api_client.delete_recording(id=recording_id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to download recording: ")
     @with_instrumentation()
@@ -642,6 +750,7 @@ class Accessibility:
         scope: str | None = None,
         pid: int | None = None,
         max_depth: int | None = None,
+        request_timeout: float | None = None,
     ) -> AccessibilityTreeResponse:
         """Fetches the AT-SPI accessibility tree.
 
@@ -649,6 +758,10 @@ class Accessibility:
             scope (str | None): Tree scope to inspect: ``focused``, ``pid``, or ``all``.
             pid (int | None): Process ID when ``scope`` is ``pid``.
             max_depth (int | None): Maximum depth to descend. Use ``0`` for the root only.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             AccessibilityTreeResponse: Accessibility tree rooted at the requested scope.
@@ -659,7 +772,9 @@ class Accessibility:
             print(tree.root.name)
             ```
         """
-        return self._api_client.get_accessibility_tree(scope=scope, pid=pid, max_depth=max_depth)
+        return self._api_client.get_accessibility_tree(
+            scope=scope, pid=pid, max_depth=max_depth, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to find accessibility nodes: ")
     @with_instrumentation()
@@ -672,6 +787,7 @@ class Accessibility:
         name_match: str | None = None,
         states: list[str] | None = None,
         limit: int | None = None,
+        request_timeout: float | None = None,
     ) -> AccessibilityNodesResponse:
         """Finds AT-SPI accessibility nodes matching the provided filters.
 
@@ -683,6 +799,10 @@ class Accessibility:
             name_match (str | None): Name match mode, such as ``exact`` or ``substring``.
             states (list[str] | None): Required accessibility states.
             limit (int | None): Maximum number of matches. Use ``0`` to let the API apply its default.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             AccessibilityNodesResponse: Matching accessibility nodes.
@@ -707,15 +827,21 @@ class Accessibility:
             states=states,
             limit=limit,
         )
-        return self._api_client.find_accessibility_nodes(request=request)
+        return self._api_client.find_accessibility_nodes(
+            request=request, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to focus accessibility node: ")
     @with_instrumentation()
-    def focus_node(self, node_id: str) -> None:
+    def focus_node(self, node_id: str, request_timeout: float | None = None) -> None:
         """Focuses an AT-SPI accessibility node.
 
         Args:
             node_id (str): Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the focus operation fails. API failures may use a more specific subclass.
@@ -726,16 +852,20 @@ class Accessibility:
             ```
         """
         request = AccessibilityNodeRequest(id=node_id)
-        _ = self._api_client.focus_accessibility_node(request=request)
+        _ = self._api_client.focus_accessibility_node(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to invoke accessibility node: ")
     @with_instrumentation()
-    def invoke_node(self, node_id: str, action: str | None = None) -> None:
+    def invoke_node(self, node_id: str, action: str | None = None, request_timeout: float | None = None) -> None:
         """Invokes an AT-SPI accessibility node action.
 
         Args:
             node_id (str): Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
             action (str | None): Action name to invoke. If omitted, the API invokes the primary action.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the invoke operation fails. API failures may use a more specific subclass.
@@ -746,16 +876,20 @@ class Accessibility:
             ```
         """
         request = AccessibilityInvokeRequest(id=node_id, action=action)
-        _ = self._api_client.invoke_accessibility_node(request=request)
+        _ = self._api_client.invoke_accessibility_node(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to set accessibility node value: ")
     @with_instrumentation()
-    def set_node_value(self, node_id: str, value: str) -> None:
+    def set_node_value(self, node_id: str, value: str, request_timeout: float | None = None) -> None:
         """Sets an AT-SPI accessibility node value.
 
         Args:
             node_id (str): Accessibility node ID returned by ``get_tree`` or ``find_nodes``.
             value (str): Value to write to the node.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the value update fails. API failures may use a more specific subclass.
@@ -766,7 +900,9 @@ class Accessibility:
             ```
         """
         request = AccessibilitySetValueRequest(id=node_id, value=value)
-        _ = self._api_client.set_accessibility_node_value(request=request)
+        _ = self._api_client.set_accessibility_node_value(
+            request=request, _request_timeout=http_timeout(request_timeout)
+        )
 
 
 class ComputerUse:
@@ -800,8 +936,14 @@ class ComputerUse:
 
     @intercept_errors(message_prefix="Failed to start computer use: ")
     @with_instrumentation()
-    def start(self) -> ComputerUseStartResponse:
+    def start(self, request_timeout: float | None = None) -> ComputerUseStartResponse:
         """Starts all computer use processes (Xvfb, xfce4, x11vnc, novnc).
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ComputerUseStartResponse: Computer use start response.
@@ -812,13 +954,19 @@ class ComputerUse:
             print("Computer use processes started:", result.message)
             ```
         """
-        response = self._api_client.start_computer_use()
+        response = self._api_client.start_computer_use(_request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to stop computer use: ")
     @with_instrumentation()
-    def stop(self) -> ComputerUseStopResponse:
+    def stop(self, request_timeout: float | None = None) -> ComputerUseStopResponse:
         """Stops all computer use processes.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ComputerUseStopResponse: Computer use stop response.
@@ -829,13 +977,19 @@ class ComputerUse:
             print("Computer use processes stopped:", result.message)
             ```
         """
-        response = self._api_client.stop_computer_use()
+        response = self._api_client.stop_computer_use(_request_timeout=http_timeout(request_timeout))
         return response
 
     @intercept_errors(message_prefix="Failed to get computer use status: ")
     @with_instrumentation()
-    def get_status(self) -> ComputerUseStatusResponse:
+    def get_status(self, request_timeout: float | None = None) -> ComputerUseStatusResponse:
         """Gets the status of all computer use processes.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ComputerUseStatusResponse: Status information about all VNC desktop processes.
@@ -846,15 +1000,19 @@ class ComputerUse:
             print("Computer use status:", response.status)
             ```
         """
-        return self._api_client.get_computer_use_status()
+        return self._api_client.get_computer_use_status(_request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to get process status: ")
     @with_instrumentation()
-    def get_process_status(self, process_name: str) -> ProcessStatusResponse:
+    def get_process_status(self, process_name: str, request_timeout: float | None = None) -> ProcessStatusResponse:
         """Gets the status of a specific VNC process.
 
         Args:
             process_name (str): Name of the process to check.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ProcessStatusResponse: Status information about the specific process.
@@ -865,16 +1023,22 @@ class ComputerUse:
             no_vnc_status = sandbox.computer_use.get_process_status("novnc")
             ```
         """
-        response = self._api_client.get_process_status(process_name=process_name)
+        response = self._api_client.get_process_status(
+            process_name=process_name, _request_timeout=http_timeout(request_timeout)
+        )
         return response
 
     @intercept_errors(message_prefix="Failed to restart process: ")
     @with_instrumentation()
-    def restart_process(self, process_name: str) -> ProcessRestartResponse:
+    def restart_process(self, process_name: str, request_timeout: float | None = None) -> ProcessRestartResponse:
         """Restarts a specific VNC process.
 
         Args:
             process_name (str): Name of the process to restart.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ProcessRestartResponse: Process restart response.
@@ -885,16 +1049,22 @@ class ComputerUse:
             print("XFCE4 process restarted:", result.message)
             ```
         """
-        response = self._api_client.restart_process(process_name=process_name)
+        response = self._api_client.restart_process(
+            process_name=process_name, _request_timeout=http_timeout(request_timeout)
+        )
         return response
 
     @intercept_errors(message_prefix="Failed to get process logs: ")
     @with_instrumentation()
-    def get_process_logs(self, process_name: str) -> ProcessLogsResponse:
+    def get_process_logs(self, process_name: str, request_timeout: float | None = None) -> ProcessLogsResponse:
         """Gets logs for a specific VNC process.
 
         Args:
             process_name (str): Name of the process to get logs for.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ProcessLogsResponse: Process logs.
@@ -905,16 +1075,22 @@ class ComputerUse:
             print("NoVNC logs:", logs)
             ```
         """
-        response = self._api_client.get_process_logs(process_name=process_name)
+        response = self._api_client.get_process_logs(
+            process_name=process_name, _request_timeout=http_timeout(request_timeout)
+        )
         return response
 
     @intercept_errors(message_prefix="Failed to get process errors: ")
     @with_instrumentation()
-    def get_process_errors(self, process_name: str) -> ProcessErrorsResponse:
+    def get_process_errors(self, process_name: str, request_timeout: float | None = None) -> ProcessErrorsResponse:
         """Gets error logs for a specific VNC process.
 
         Args:
             process_name (str): Name of the process to get error logs for.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ProcessErrorsResponse: Process error logs.
@@ -925,5 +1101,7 @@ class ComputerUse:
             print("X11VNC errors:", errors)
             ```
         """
-        response = self._api_client.get_process_errors(process_name=process_name)
+        response = self._api_client.get_process_errors(
+            process_name=process_name, _request_timeout=http_timeout(request_timeout)
+        )
         return response

--- a/sdk-python/src/daytona/_sync/daytona.py
+++ b/sdk-python/src/daytona/_sync/daytona.py
@@ -538,11 +538,15 @@ class Daytona:
 
     @intercept_errors(message_prefix="Failed to get sandbox: ")
     @with_instrumentation()
-    def get(self, sandbox_id_or_name: str) -> Sandbox:
+    def get(self, sandbox_id_or_name: str, request_timeout: float | None = None) -> Sandbox:
         """Gets a Sandbox by its ID or name.
 
         Args:
             sandbox_id_or_name (str): The ID or name of the Sandbox to retrieve.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Sandbox: The Sandbox instance.
@@ -560,7 +564,9 @@ class Daytona:
             raise DaytonaValidationError("sandbox_id_or_name is required")
 
         # Get the sandbox instance
-        sandbox_instance = self._sandbox_api.get_sandbox(sandbox_id_or_name)
+        sandbox_instance = self._sandbox_api.get_sandbox(
+            sandbox_id_or_name, _request_timeout=http_timeout(request_timeout)
+        )
         language = self._validate_language_label(sandbox_instance.labels.get(CODE_TOOLBOX_LANGUAGE_LABEL)).value
         return Sandbox(
             sandbox_instance,
@@ -575,11 +581,16 @@ class Daytona:
     def list(
         self,
         query: ListSandboxesQuery | None = None,
+        request_timeout: float | None = None,
     ) -> Iterator[Sandbox]:
         """Iterates over Sandboxes matching the given query.
 
         Args:
             query: Optional filters, sorting, and per-page size.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Yields:
             Sandbox: Each Sandbox matching the query.
@@ -602,7 +613,7 @@ class Daytona:
 
         while first_page or cursor:
             first_page = False
-            response = self._fetch_sandbox_page(q, cursor)
+            response = self._fetch_sandbox_page(q, cursor, request_timeout)
             for sandbox in response.items:
                 language = self._validate_language_label(sandbox.labels.get(CODE_TOOLBOX_LANGUAGE_LABEL)).value
                 yield Sandbox(
@@ -615,7 +626,7 @@ class Daytona:
             cursor = response.next_cursor or None
 
     @with_instrumentation(name="Daytona.list.fetch_page")
-    def _fetch_sandbox_page(self, q: ListSandboxesQuery, cursor: str | None):
+    def _fetch_sandbox_page(self, q: ListSandboxesQuery, cursor: str | None, request_timeout: float | None = None):
         """Fetches a single page of sandboxes. Each call is one OTEL span."""
         return self._sandbox_api.list_sandboxes(
             labels=json.dumps(q.labels) if q.labels else None,
@@ -640,6 +651,7 @@ class Daytona:
             last_event_before=q.last_activity_before,
             sort=q.sort,
             order=q.order,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     def _validate_language_label(self, language: str | None = None) -> CodeLanguage:

--- a/sdk-python/src/daytona/_sync/filesystem.py
+++ b/sdk-python/src/daytona/_sync/filesystem.py
@@ -25,6 +25,7 @@ from daytona_toolbox_api_client import (
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
+from .._utils.timeout import http_timeout
 from ..common.errors import DaytonaError
 from ..common.file_transfer import (
     create_multipart_parser,
@@ -70,7 +71,7 @@ class FileSystem:
 
     @intercept_errors(message_prefix="Failed to create folder: ")
     @with_instrumentation()
-    def create_folder(self, path: str, mode: str) -> None:
+    def create_folder(self, path: str, mode: str, request_timeout: float | None = None) -> None:
         """Creates a new directory in the Sandbox at the specified path with the given
         permissions.
 
@@ -78,6 +79,10 @@ class FileSystem:
             path (str): Path where the folder should be created. Relative paths are resolved based
             on the sandbox working directory.
             mode (str): Folder permissions in octal format (e.g., "755" for rwxr-xr-x).
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -91,16 +96,21 @@ class FileSystem:
         self._api_client.create_folder(
             path=path,
             mode=mode,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to delete file: ")
     @with_instrumentation()
-    def delete_file(self, path: str, recursive: bool = False) -> None:
+    def delete_file(self, path: str, recursive: bool = False, request_timeout: float | None = None) -> None:
         """Deletes a file from the Sandbox.
 
         Args:
             path (str): Path to the file to delete. Relative paths are resolved based on the sandbox working directory.
             recursive (bool): If the file is a directory, this must be true to delete it.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -108,7 +118,7 @@ class FileSystem:
             sandbox.fs.delete_file("workspace/data/old_file.txt")
             ```
         """
-        self._api_client.delete_file(path=path, recursive=recursive)
+        self._api_client.delete_file(path=path, recursive=recursive, _request_timeout=http_timeout(request_timeout))
 
     @overload
     def download_file(self, remote_path: str, timeout: int = 30 * 60) -> bytes:
@@ -560,7 +570,7 @@ class FileSystem:
 
     @intercept_errors(message_prefix="Failed to find files: ")
     @with_instrumentation()
-    def find_files(self, path: str, pattern: str) -> list[Match]:
+    def find_files(self, path: str, pattern: str, request_timeout: float | None = None) -> list[Match]:
         """Searches for files containing a pattern, similar to
         the grep command.
 
@@ -569,6 +579,10 @@ class FileSystem:
                 the search will be performed recursively. Relative paths are resolved based
                 on the sandbox working directory.
             pattern (str): Search pattern to match against file contents.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[Match]: List of matches found in files. Each Match object includes:
@@ -587,17 +601,22 @@ class FileSystem:
         return self._api_client.find_in_files(
             path=path,
             pattern=pattern,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get file info: ")
     @with_instrumentation()
-    def get_file_info(self, path: str) -> FileInfo:
+    def get_file_info(self, path: str, request_timeout: float | None = None) -> FileInfo:
         """Gets detailed information about a file or directory, including its
         size, permissions, and timestamps.
 
         Args:
             path (str): Path to the file or directory. Relative paths are resolved based
             on the sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             FileInfo: Detailed file information including:
@@ -624,11 +643,11 @@ class FileSystem:
                 print("Path is a directory")
             ```
         """
-        return self._api_client.get_file_info(path=path)
+        return self._api_client.get_file_info(path=path, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to list files: ")
     @with_instrumentation()
-    def list_files(self, path: str, depth: int | None = None) -> list[FileInfo]:
+    def list_files(self, path: str, depth: int | None = None, request_timeout: float | None = None) -> list[FileInfo]:
         """Lists files and directories in a given path and returns their information, similar to the ls -l command.
 
         Args:
@@ -637,6 +656,10 @@ class FileSystem:
             depth (int | None): How many levels deep to list. depth=1 (default) lists the
             directory's entries, depth=2 also includes their children, and so on. Must be >= 1.
             Each returned FileInfo carries a full `path` field.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[FileInfo]: List of file and directory information. Each FileInfo
@@ -659,11 +682,11 @@ class FileSystem:
         """
         if depth is not None and depth < 1:
             raise DaytonaError("depth must be at least 1")
-        return self._api_client.list_files(path=path, depth=depth)
+        return self._api_client.list_files(path=path, depth=depth, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to move files: ")
     @with_instrumentation()
-    def move_files(self, source: str, destination: str) -> None:
+    def move_files(self, source: str, destination: str, request_timeout: float | None = None) -> None:
         """Moves or renames a file or directory. The parent directory of the destination must exist.
 
         Args:
@@ -671,6 +694,10 @@ class FileSystem:
             based on the sandbox working directory.
             destination (str): Path to the destination. Relative paths are resolved based on
             the sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -696,11 +723,14 @@ class FileSystem:
         self._api_client.move_file(
             source=source,
             destination=destination,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to replace in files: ")
     @with_instrumentation()
-    def replace_in_files(self, files: list[str], pattern: str, new_value: str) -> list[ReplaceResult]:
+    def replace_in_files(
+        self, files: list[str], pattern: str, new_value: str, request_timeout: float | None = None
+    ) -> list[ReplaceResult]:
         """Performs search and replace operations across multiple files.
 
         Args:
@@ -708,6 +738,10 @@ class FileSystem:
             resolved based on the sandbox working directory.
             pattern (str): Pattern to search for.
             new_value (str): Text to replace matches with.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[ReplaceResult]: List of results indicating replacements made in
@@ -738,11 +772,13 @@ class FileSystem:
 
         replace_request = ReplaceRequest(files=files, new_value=new_value, pattern=pattern)
 
-        return self._api_client.replace_in_files(request=replace_request)
+        return self._api_client.replace_in_files(
+            request=replace_request, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to search files: ")
     @with_instrumentation()
-    def search_files(self, path: str, pattern: str) -> SearchFilesResponse:
+    def search_files(self, path: str, pattern: str, request_timeout: float | None = None) -> SearchFilesResponse:
         """Searches for files and directories whose names match the
         specified pattern. The pattern can be a simple string or a glob pattern.
 
@@ -751,6 +787,10 @@ class FileSystem:
             based on the sandbox working directory.
             pattern (str): Pattern to match against file names. Supports glob
                 patterns (e.g., "*.py" for Python files).
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             SearchFilesResponse: Search results containing:
@@ -771,12 +811,18 @@ class FileSystem:
         return self._api_client.search_files(
             path=path,
             pattern=pattern,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to set file permissions: ")
     @with_instrumentation()
     def set_file_permissions(
-        self, path: str, mode: str | None = None, owner: str | None = None, group: str | None = None
+        self,
+        path: str,
+        mode: str | None = None,
+        owner: str | None = None,
+        group: str | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Sets permissions and ownership for a file or directory. Any of the parameters can be None
         to leave that attribute unchanged.
@@ -788,6 +834,10 @@ class FileSystem:
                 (e.g., "644" for rw-r--r--).
             owner (str | None): User owner of the file.
             group (str | None): Group owner of the file.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -810,6 +860,7 @@ class FileSystem:
             mode=mode,
             owner=owner,
             group=group,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @overload

--- a/sdk-python/src/daytona/_sync/git.py
+++ b/sdk-python/src/daytona/_sync/git.py
@@ -27,6 +27,7 @@ from daytona_toolbox_api_client import (
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
+from .._utils.timeout import http_timeout
 from ..common.git import GitCommitResponse
 
 
@@ -69,7 +70,7 @@ class Git:
 
     @intercept_errors(message_prefix="Failed to add files: ")
     @with_instrumentation()
-    def add(self, path: str, files: list[str]) -> None:
+    def add(self, path: str, files: list[str], request_timeout: float | None = None) -> None:
         """Stages the specified files for the next commit, similar to
         running 'git add' on the command line.
 
@@ -77,6 +78,10 @@ class Git:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
             files (list[str]): List of file paths or directories to stage, relative to the repository root.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -93,16 +98,21 @@ class Git:
         """
         self._api_client.add_files(
             request=GitAddRequest(path=path, files=files),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to list branches: ")
     @with_instrumentation()
-    def branches(self, path: str) -> ListBranchResponse:
+    def branches(self, path: str, request_timeout: float | None = None) -> ListBranchResponse:
         """Lists branches in the repository.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ListBranchResponse: List of branches in the repository.
@@ -115,6 +125,7 @@ class Git:
         """
         return self._api_client.list_branches(
             path=path,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to clone repository: ")
@@ -129,6 +140,7 @@ class Git:
         password: str | None = None,
         insecure_skip_tls: bool | None = None,
         depth: int | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Clones a Git repository into the specified path. It supports
         cloning specific branches or commits, and can authenticate with the remote
@@ -148,6 +160,10 @@ class Git:
                 Use only for trusted internal Git servers with self-signed or private-CA certs;
                 credentials, if supplied, are transmitted over an unverified TLS connection.
             depth (int | None): Create a shallow clone truncated to the given number of commits.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -185,11 +201,20 @@ class Git:
                 insecure_skip_tls=insecure_skip_tls,
                 depth=depth,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to commit changes: ")
     @with_instrumentation()
-    def commit(self, path: str, message: str, author: str, email: str, allow_empty: bool = False) -> GitCommitResponse:
+    def commit(
+        self,
+        path: str,
+        message: str,
+        author: str,
+        email: str,
+        allow_empty: bool = False,
+        request_timeout: float | None = None,
+    ) -> GitCommitResponse:
         """Creates a new commit with the staged changes. Make sure to stage
         changes using the add() method before committing.
 
@@ -200,6 +225,10 @@ class Git:
             author (str): Name of the commit author.
             email (str): Email address of the commit author.
             allow_empty (bool, optional): Allow creating an empty commit when no changes are staged. Defaults to False.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -222,6 +251,7 @@ class Git:
                 email=email,
                 allow_empty=allow_empty,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
         return GitCommitResponse(sha=response.hash)
 
@@ -235,6 +265,7 @@ class Git:
         branch: str | None = None,
         remote: str | None = None,
         set_upstream: bool = False,
+        request_timeout: float | None = None,
     ) -> None:
         """Pushes all local commits on the current branch to the remote
         repository. If the remote repository requires authentication, provide
@@ -249,6 +280,10 @@ class Git:
             remote (str | None): Remote to push to. Defaults to "origin".
             set_upstream (bool, optional): Record the pushed branch as the upstream tracking
                 branch. Defaults to False.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -275,6 +310,7 @@ class Git:
                 remote=remote,
                 set_upstream=set_upstream,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to pull changes: ")
@@ -286,6 +322,7 @@ class Git:
         password: str | None = None,
         branch: str | None = None,
         remote: str | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Pulls changes from the remote repository. If the remote repository requires authentication,
         provide username and password/token.
@@ -297,6 +334,10 @@ class Git:
             password (str | None): Git password or token for authentication.
             branch (str | None): Branch to pull. Defaults to the current branch's upstream.
             remote (str | None): Remote to pull from. Defaults to "origin".
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -322,16 +363,21 @@ class Git:
                 branch=branch,
                 remote=remote,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get status: ")
     @with_instrumentation()
-    def status(self, path: str) -> GitStatus:
+    def status(self, path: str, request_timeout: float | None = None) -> GitStatus:
         """Gets the current Git repository status.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             GitStatus: Repository status information including:
@@ -351,17 +397,22 @@ class Git:
         """
         return self._api_client.get_status(
             path=path,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to checkout branch: ")
     @with_instrumentation()
-    def checkout_branch(self, path: str, branch: str) -> None:
+    def checkout_branch(self, path: str, branch: str, request_timeout: float | None = None) -> None:
         """Checkout branch in the repository.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
             branch (str): Name of the branch to checkout
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -374,17 +425,22 @@ class Git:
                 path=path,
                 branch=branch,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to create branch: ")
     @with_instrumentation()
-    def create_branch(self, path: str, name: str) -> None:
+    def create_branch(self, path: str, name: str, request_timeout: float | None = None) -> None:
         """Create branch in the repository.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
             name (str): Name of the new branch to create
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -397,17 +453,22 @@ class Git:
                 path=path,
                 name=name,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to delete branch: ")
     @with_instrumentation()
-    def delete_branch(self, path: str, name: str) -> None:
+    def delete_branch(self, path: str, name: str, request_timeout: float | None = None) -> None:
         """Delete branch in the repository.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
             name (str): Name of the branch to delete
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -420,11 +481,14 @@ class Git:
                 path=path,
                 name=name,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to initialize repository: ")
     @with_instrumentation()
-    def init(self, path: str, bare: bool = False, initial_branch: str | None = None) -> None:
+    def init(
+        self, path: str, bare: bool = False, initial_branch: str | None = None, request_timeout: float | None = None
+    ) -> None:
         """Initializes a new Git repository at the specified path.
 
         Args:
@@ -433,6 +497,10 @@ class Git:
             bare (bool, optional): Create a bare repository without a working tree. Defaults to False.
             initial_branch (str | None): Name of the initial branch. If not specified, uses the
                 Git default.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -445,6 +513,7 @@ class Git:
                 bare=bare,
                 initial_branch=initial_branch,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to reset: ")
@@ -455,6 +524,7 @@ class Git:
         mode: str | None = None,
         target: str | None = None,
         files: list[str] | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Resets the current HEAD to the specified state.
 
@@ -464,6 +534,10 @@ class Git:
             mode (str | None): Reset mode, one of "soft", "mixed" (default), "hard", "merge" or "keep".
             target (str | None): Revision to reset to. Defaults to HEAD.
             files (list[str] | None): Constrain the reset to the given paths.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -481,6 +555,7 @@ class Git:
                 target=target,
                 files=files,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to restore files: ")
@@ -492,6 +567,7 @@ class Git:
         staged: bool | None = None,
         worktree: bool | None = None,
         source: str | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Restores working tree files or unstages changes.
 
@@ -503,6 +579,10 @@ class Git:
             worktree (bool | None): Restore the working tree for the given files. Defaults to
                 True when neither staged nor worktree is provided.
             source (str | None): Restore file contents from the given revision instead of the index.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -521,6 +601,7 @@ class Git:
                 worktree=worktree,
                 source=source,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to add remote: ")
@@ -532,6 +613,7 @@ class Git:
         url: str,
         fetch: bool = False,
         overwrite: bool = False,
+        request_timeout: float | None = None,
     ) -> None:
         """Adds (or overwrites) a remote in the repository.
 
@@ -542,6 +624,10 @@ class Git:
             url (str): URL of the remote.
             fetch (bool, optional): Fetch from the remote immediately after adding it. Defaults to False.
             overwrite (bool, optional): Replace an existing remote with the same name. Defaults to False.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -556,16 +642,21 @@ class Git:
                 fetch=fetch,
                 overwrite=overwrite,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to list remotes: ")
     @with_instrumentation()
-    def remotes(self, path: str) -> ListRemotesResponse:
+    def remotes(self, path: str, request_timeout: float | None = None) -> ListRemotesResponse:
         """Lists the remotes configured in the repository.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             ListRemotesResponse: The configured remotes (name + URL).
@@ -579,17 +670,22 @@ class Git:
         """
         return self._api_client.list_remotes(
             path=path,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get remote: ")
     @with_instrumentation()
-    def remote_get(self, path: str, name: str) -> str | None:
+    def remote_get(self, path: str, name: str, request_timeout: float | None = None) -> str | None:
         """Gets the URL of a remote, or None when it does not exist.
 
         Args:
             path (str): Path to the Git repository root. Relative paths are resolved based on
             the sandbox working directory.
             name (str): Name of the remote.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             str | None: The remote URL, or None when the remote does not exist.
@@ -599,7 +695,7 @@ class Git:
             url = sandbox.git.remote_get("workspace/repo", "origin")
             ```
         """
-        response = self._api_client.list_remotes(path=path)
+        response = self._api_client.list_remotes(path=path, _request_timeout=http_timeout(request_timeout))
         for remote in response.remotes:
             if remote.name == name:
                 return remote.url
@@ -607,7 +703,9 @@ class Git:
 
     @intercept_errors(message_prefix="Failed to set config: ")
     @with_instrumentation()
-    def set_config(self, key: str, value: str, scope: str = "global", path: str | None = None) -> None:
+    def set_config(
+        self, key: str, value: str, scope: str = "global", path: str | None = None, request_timeout: float | None = None
+    ) -> None:
         """Sets a Git config value at the given scope.
 
         Args:
@@ -615,6 +713,10 @@ class Git:
             value (str): Config value.
             scope (str, optional): Config scope, one of "global" (default), "local" or "system".
             path (str | None): Repository path, required when scope is "local".
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -628,17 +730,24 @@ class Git:
                 value=value,
                 scope=scope,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get config: ")
     @with_instrumentation()
-    def get_config(self, key: str, scope: str = "global", path: str | None = None) -> str | None:
+    def get_config(
+        self, key: str, scope: str = "global", path: str | None = None, request_timeout: float | None = None
+    ) -> str | None:
         """Gets a Git config value at the given scope, or None when unset.
 
         Args:
             key (str): Config key in dotted form (e.g. "user.name").
             scope (str, optional): Config scope, one of "global" (default), "local" or "system".
             path (str | None): Repository path, required when scope is "local".
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             str | None: The config value, or None when the key is not set.
@@ -648,12 +757,21 @@ class Git:
             name = sandbox.git.get_config("user.name")
             ```
         """
-        response = self._api_client.get_git_config(key=key, scope=scope, path=path)
+        response = self._api_client.get_git_config(
+            key=key, scope=scope, path=path, _request_timeout=http_timeout(request_timeout)
+        )
         return response.value
 
     @intercept_errors(message_prefix="Failed to configure user: ")
     @with_instrumentation()
-    def configure_user(self, name: str, email: str, scope: str = "global", path: str | None = None) -> None:
+    def configure_user(
+        self,
+        name: str,
+        email: str,
+        scope: str = "global",
+        path: str | None = None,
+        request_timeout: float | None = None,
+    ) -> None:
         """Configures the Git user name and email at the given scope.
 
         Args:
@@ -661,6 +779,10 @@ class Git:
             email (str): User email (user.email).
             scope (str, optional): Config scope, one of "global" (default), "local" or "system".
             path (str | None): Repository path, required when scope is "local".
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -674,6 +796,7 @@ class Git:
                 email=email,
                 scope=scope,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to authenticate: ")
@@ -684,6 +807,7 @@ class Git:
         password: str,
         host: str | None = None,
         protocol: str | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Persists Git credentials globally so that subsequent operations against the
         given host authenticate automatically.
@@ -696,6 +820,10 @@ class Git:
             password (str): Git password or token.
             host (str | None): Host to authenticate against. Defaults to "github.com".
             protocol (str | None): Protocol to authenticate against. Defaults to "https".
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -709,4 +837,5 @@ class Git:
                 host=host,
                 protocol=protocol,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )

--- a/sdk-python/src/daytona/_sync/lsp_server.py
+++ b/sdk-python/src/daytona/_sync/lsp_server.py
@@ -17,6 +17,7 @@ from daytona_toolbox_api_client import (
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
+from .._utils.timeout import http_timeout
 from ..common.lsp_server import LspCompletionPosition, LspLanguageId, LspLanguageIdLiteral
 
 
@@ -45,11 +46,17 @@ class LspServer:
 
     @intercept_errors(message_prefix="Failed to start LSP server: ")
     @with_instrumentation()
-    def start(self) -> None:
+    def start(self, request_timeout: float | None = None) -> None:
         """Starts the language server.
 
         This method must be called before using any other LSP functionality.
         It initializes the language server for the specified language and project.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -63,15 +70,22 @@ class LspServer:
                 language_id=self._language_id,
                 path_to_project=self._path_to_project,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to stop LSP server: ")
     @with_instrumentation()
-    def stop(self) -> None:
+    def stop(self, request_timeout: float | None = None) -> None:
         """Stops the language server.
 
         This method should be called when the LSP server is no longer needed to
         free up system resources.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -84,11 +98,12 @@ class LspServer:
                 language_id=self._language_id,
                 path_to_project=self._path_to_project,
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to open file: ")
     @with_instrumentation()
-    def did_open(self, path: str) -> None:
+    def did_open(self, path: str, request_timeout: float | None = None) -> None:
         """Notifies the language server that a file has been opened.
 
         This method should be called when a file is opened in the editor to enable
@@ -98,6 +113,10 @@ class LspServer:
         Args:
             path (str): Path to the opened file. Relative paths are resolved based on the project path
             set in the LSP server constructor.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -112,11 +131,12 @@ class LspServer:
                 path_to_project=self._path_to_project,
                 uri=f"file://{path}",
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to close file: ")
     @with_instrumentation()
-    def did_close(self, path: str) -> None:
+    def did_close(self, path: str, request_timeout: float | None = None) -> None:
         """Notify the language server that a file has been closed.
 
         This method should be called when a file is closed in the editor to allow
@@ -125,6 +145,10 @@ class LspServer:
         Args:
             path (str): Path to the closed file. Relative paths are resolved based on the project path
             set in the LSP server constructor.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -138,16 +162,21 @@ class LspServer:
                 path_to_project=self._path_to_project,
                 uri=f"file://{path}",
             ),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get symbols from document: ")
     @with_instrumentation()
-    def document_symbols(self, path: str) -> list[LspSymbol]:
+    def document_symbols(self, path: str, request_timeout: float | None = None) -> list[LspSymbol]:
         """Gets symbol information (functions, classes, variables, etc.) from a document.
 
         Args:
             path (str): Path to the file to get symbols from. Relative paths are resolved based on the project path
             set in the LSP server constructor.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[LspSymbol]: List of symbols in the document. Each symbol includes:
@@ -167,32 +196,41 @@ class LspServer:
             language_id=self._language_id,
             path_to_project=self._path_to_project,
             uri=f"file://{path}",
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @deprecated(
         reason="Method is deprecated. Use `sandbox_symbols` instead. This method will be removed in a future version."
     )
     @with_instrumentation()
-    def workspace_symbols(self, query: str) -> list[LspSymbol]:
+    def workspace_symbols(self, query: str, request_timeout: float | None = None) -> list[LspSymbol]:
         """Searches for symbols matching the query string across all files
         in the Sandbox.
 
         Args:
             query (str): Search query to match against symbol names.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[LspSymbol]: List of matching symbols from all files.
         """
-        return self.sandbox_symbols(query)
+        return self.sandbox_symbols(query, request_timeout=request_timeout)
 
     @intercept_errors(message_prefix="Failed to get symbols from sandbox: ")
     @with_instrumentation()
-    def sandbox_symbols(self, query: str) -> list[LspSymbol]:
+    def sandbox_symbols(self, query: str, request_timeout: float | None = None) -> list[LspSymbol]:
         """Searches for symbols matching the query string across all files
         in the Sandbox.
 
         Args:
             query (str): Search query to match against symbol names.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[LspSymbol]: List of matching symbols from all files. Each symbol
@@ -213,17 +251,24 @@ class LspServer:
             language_id=self._language_id,
             path_to_project=self._path_to_project,
             query=query,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to get completions: ")
     @with_instrumentation()
-    def completions(self, path: str, position: LspCompletionPosition) -> CompletionList:
+    def completions(
+        self, path: str, position: LspCompletionPosition, request_timeout: float | None = None
+    ) -> CompletionList:
         """Gets completion suggestions at a position in a file.
 
         Args:
             path (str): Path to the file. Relative paths are resolved based on the project path
             set in the LSP server constructor.
             position (LspCompletionPosition): Cursor position to get completions for.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             CompletionList: List of completion suggestions. The list includes:
@@ -253,4 +298,5 @@ class LspServer:
                 uri=f"file://{path}",
                 position=LspPosition(line=position.line, character=position.character),
             ),
+            _request_timeout=http_timeout(request_timeout),
         )

--- a/sdk-python/src/daytona/_sync/process.py
+++ b/sdk-python/src/daytona/_sync/process.py
@@ -241,7 +241,7 @@ class Process:
 
     @intercept_errors(message_prefix="Failed to create session: ")
     @with_instrumentation()
-    def create_session(self, session_id: str) -> None:
+    def create_session(self, session_id: str, request_timeout: float | None = None) -> None:
         """Creates a new long-running background session in the Sandbox.
 
         Sessions are background processes that maintain state between commands, making them ideal for
@@ -250,6 +250,10 @@ class Process:
 
         Args:
             session_id (str): Unique identifier for the new session.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -262,14 +266,18 @@ class Process:
             ```
         """
         request = CreateSessionRequest(session_id=session_id)
-        self._api_client.create_session(request=request)
+        self._api_client.create_session(request=request, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to get session: ")
-    def get_session(self, session_id: str) -> Session:
+    def get_session(self, session_id: str, request_timeout: float | None = None) -> Session:
         """Gets a session in the Sandbox.
 
         Args:
             session_id (str): Unique identifier of the session to retrieve.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Session: Session information including:
@@ -283,11 +291,17 @@ class Process:
                 print(f"Command: {cmd.command}")
             ```
         """
-        return self._api_client.get_session(session_id=session_id)
+        return self._api_client.get_session(session_id=session_id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to get sandbox entrypoint session: ")
-    def get_entrypoint_session(self) -> Session:
+    def get_entrypoint_session(self, request_timeout: float | None = None) -> Session:
         """Gets the sandbox entrypoint session.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Session: Entrypoint session information including:
@@ -301,16 +315,20 @@ class Process:
                 print(f"Command: {cmd.command}")
             ```
         """
-        return self._api_client.get_entrypoint_session()
+        return self._api_client.get_entrypoint_session(_request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to get session command: ")
     @with_instrumentation()
-    def get_session_command(self, session_id: str, command_id: str) -> Command:
+    def get_session_command(self, session_id: str, command_id: str, request_timeout: float | None = None) -> Command:
         """Gets information about a specific command executed in a session.
 
         Args:
             session_id (str): Unique identifier of the session.
             command_id (str): Unique identifier of the command.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             Command: Command information including:
@@ -325,7 +343,9 @@ class Process:
                 print(f"Command {cmd.command} completed successfully")
             ```
         """
-        return self._api_client.get_session_command(session_id=session_id, command_id=command_id)
+        return self._api_client.get_session_command(
+            session_id=session_id, command_id=command_id, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to execute session command: ")
     @with_instrumentation()
@@ -388,12 +408,18 @@ class Process:
 
     @intercept_errors(message_prefix="Failed to get session command logs: ")
     @with_instrumentation()
-    def get_session_command_logs(self, session_id: str, command_id: str) -> SessionCommandLogsResponse:
+    def get_session_command_logs(
+        self, session_id: str, command_id: str, request_timeout: float | None = None
+    ) -> SessionCommandLogsResponse:
         """Get the logs for a command executed in a session.
 
         Args:
             session_id (str): Unique identifier of the session.
             command_id (str): Unique identifier of the command.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             SessionCommandLogsResponse: Command logs including:
@@ -411,7 +437,9 @@ class Process:
             print(f"Command stderr: {logs.stderr}")
             ```
         """
-        response = self._api_client.get_session_command_logs(session_id=session_id, command_id=command_id)
+        response = self._api_client.get_session_command_logs(
+            session_id=session_id, command_id=command_id, _request_timeout=http_timeout(request_timeout)
+        )
 
         return SessionCommandLogsResponse(output=response.output, stdout=response.stdout, stderr=response.stderr)
 
@@ -458,8 +486,14 @@ class Process:
 
     @intercept_errors(message_prefix="Failed to get entrypoint logs: ")
     @with_instrumentation()
-    def get_entrypoint_logs(self) -> SessionCommandLogsResponse:
+    def get_entrypoint_logs(self, request_timeout: float | None = None) -> SessionCommandLogsResponse:
         """Get the logs for the entrypoint session.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             SessionCommandLogsResponse: Command logs including:
@@ -474,7 +508,7 @@ class Process:
             print(f"Command stderr: {logs.stderr}")
             ```
         """
-        response = self._api_client.get_entrypoint_logs()
+        response = self._api_client.get_entrypoint_logs(_request_timeout=http_timeout(request_timeout))
 
         return SessionCommandLogsResponse(output=response.output, stdout=response.stdout, stderr=response.stderr)
 
@@ -508,22 +542,37 @@ class Process:
         await self._consume_log_websocket(url, headers, on_stdout, on_stderr)
 
     @intercept_errors(message_prefix="Failed to send session command input: ")
-    def send_session_command_input(self, session_id: str, command_id: str, data: str) -> None:
+    def send_session_command_input(
+        self, session_id: str, command_id: str, data: str, request_timeout: float | None = None
+    ) -> None:
         """Sends input data to a command executed in a session.
 
         Args:
             session_id (str): Unique identifier of the session.
             command_id (str): Unique identifier of the command.
             data (str): Input data to send.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
         self._api_client.send_input(
-            session_id=session_id, command_id=command_id, request=SessionSendInputRequest(data=data)
+            session_id=session_id,
+            command_id=command_id,
+            request=SessionSendInputRequest(data=data),
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to list sessions: ")
     @with_instrumentation()
-    def list_sessions(self) -> list[Session]:
+    def list_sessions(self, request_timeout: float | None = None) -> list[Session]:
         """Lists all sessions in the Sandbox.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[Session]: List of all sessions in the Sandbox.
@@ -536,16 +585,20 @@ class Process:
                 print(f"  Commands: {len(session.commands)}")
             ```
         """
-        return self._api_client.list_sessions()
+        return self._api_client.list_sessions(_request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to delete session: ")
     @with_instrumentation()
-    def delete_session(self, session_id: str) -> None:
+    def delete_session(self, session_id: str, request_timeout: float | None = None) -> None:
         """Terminates and removes a session from the Sandbox, cleaning up any resources
         associated with it.
 
         Args:
             session_id (str): Unique identifier of the session to delete.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -557,7 +610,7 @@ class Process:
             sandbox.process.delete_session("temp-session")
             ```
         """
-        self._api_client.delete_session(session_id=session_id)
+        self._api_client.delete_session(session_id=session_id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to create PTY session: ")
     @with_instrumentation()
@@ -718,10 +771,16 @@ class Process:
 
     @intercept_errors(message_prefix="Failed to list PTY sessions: ")
     @with_instrumentation()
-    def list_pty_sessions(self) -> list[PtySessionInfo]:
+    def list_pty_sessions(self, request_timeout: float | None = None) -> list[PtySessionInfo]:
         """Lists all PTY sessions in the Sandbox.
 
         Retrieves information about all PTY sessions in this Sandbox.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             list[PtySessionInfo]: List of PTY session information objects containing
@@ -738,11 +797,11 @@ class Process:
                 print(f"Created: {session.created_at}")
             ```
         """
-        return (self._api_client.list_pty_sessions()).sessions
+        return (self._api_client.list_pty_sessions(_request_timeout=http_timeout(request_timeout))).sessions
 
     @intercept_errors(message_prefix="Failed to get PTY session info: ")
     @with_instrumentation()
-    def get_pty_session_info(self, session_id: str) -> PtySessionInfo:
+    def get_pty_session_info(self, session_id: str, request_timeout: float | None = None) -> PtySessionInfo:
         """Gets detailed information about a specific PTY session.
 
         Retrieves comprehensive information about a PTY session including its current state,
@@ -750,6 +809,10 @@ class Process:
 
         Args:
             session_id: Unique identifier of the PTY session to retrieve information for.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             PtySessionInfo: Detailed information about the PTY session including ID, state,
@@ -769,11 +832,11 @@ class Process:
             print(f"Terminal Size: {session_info.cols}x{session_info.rows}")
             ```
         """
-        return self._api_client.get_pty_session(session_id=session_id)
+        return self._api_client.get_pty_session(session_id=session_id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to kill PTY session: ")
     @with_instrumentation()
-    def kill_pty_session(self, session_id: str) -> None:
+    def kill_pty_session(self, session_id: str, request_timeout: float | None = None) -> None:
         """Kills a PTY session and terminates its associated process.
 
         Forcefully terminates the PTY session and cleans up all associated resources.
@@ -782,6 +845,10 @@ class Process:
 
         Args:
             session_id: Unique identifier of the PTY session to kill.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaError: If the PTY session doesn't exist or cannot be killed.
@@ -797,11 +864,13 @@ class Process:
                 print(f"PTY session: {pty_session.id}")
             ```
         """
-        _ = self._api_client.delete_pty_session(session_id=session_id)
+        _ = self._api_client.delete_pty_session(session_id=session_id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to resize PTY session: ")
     @with_instrumentation()
-    def resize_pty_session(self, session_id: str, pty_size: PtySize) -> PtySessionInfo:
+    def resize_pty_session(
+        self, session_id: str, pty_size: PtySize, request_timeout: float | None = None
+    ) -> PtySessionInfo:
         """Resizes a PTY session's terminal dimensions.
 
         Changes the terminal size of an active PTY session. This is useful when the
@@ -811,6 +880,10 @@ class Process:
         Args:
             session_id: Unique identifier of the PTY session to resize.
             pty_size: New terminal dimensions containing the desired columns and rows.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             PtySessionInfo: Updated session information reflecting the new terminal size.
@@ -835,4 +908,5 @@ class Process:
         return self._api_client.resize_pty_session(
             session_id=session_id,
             request=PtyResizeRequest(cols=pty_size.cols, rows=pty_size.rows),
+            _request_timeout=http_timeout(request_timeout),
         )

--- a/sdk-python/src/daytona/_sync/sandbox.py
+++ b/sdk-python/src/daytona/_sync/sandbox.py
@@ -175,8 +175,14 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to refresh sandbox data: ")
     @with_instrumentation()
-    def refresh_data(self) -> None:
+    def refresh_data(self, request_timeout: float | None = None) -> None:
         """Refreshes the Sandbox data from the API.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -186,7 +192,7 @@ class Sandbox(SandboxDto):
             print(f"Resources: {sandbox.cpu} CPU, {sandbox.memory} GiB RAM")
             ```
         """
-        instance = self._sandbox_api.get_sandbox(self.id)
+        instance = self._sandbox_api.get_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
         self.__process_sandbox_dto(instance)
 
     @intercept_errors(message_prefix="Failed to get user home directory: ")
@@ -261,13 +267,17 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set labels: ")
     @with_instrumentation()
-    def set_labels(self, labels: dict[str, str]) -> dict[str, str]:
+    def set_labels(self, labels: dict[str, str], request_timeout: float | None = None) -> dict[str, str]:
         """Sets labels for the Sandbox.
 
         Labels are key-value pairs that can be used to organize and identify Sandboxes.
 
         Args:
             labels (dict[str, str]): Dictionary of key-value pairs representing Sandbox labels.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             dict[str, str]: Dictionary containing the updated Sandbox labels.
@@ -282,7 +292,11 @@ class Sandbox(SandboxDto):
             print(f"Updated labels: {new_labels}")
             ```
         """
-        self.labels = (self._sandbox_api.replace_labels(self.id, SandboxLabels(labels=labels))).labels
+        self.labels = (
+            self._sandbox_api.replace_labels(
+                self.id, SandboxLabels(labels=labels), _request_timeout=http_timeout(request_timeout)
+            )
+        ).labels
         return self.labels
 
     @intercept_errors(message_prefix="Failed to start sandbox: ")
@@ -446,7 +460,7 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set auto-stop interval: ")
     @with_instrumentation()
-    def set_autostop_interval(self, interval: int) -> None:
+    def set_autostop_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-stop interval for the Sandbox.
 
         The Sandbox will automatically stop after being idle (no new events) for the specified interval.
@@ -456,6 +470,10 @@ class Sandbox(SandboxDto):
         Args:
             interval (int): Number of minutes of inactivity before auto-stopping.
                 Set to 0 to disable auto-stop. Defaults to 15.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaValidationError: If interval is negative
@@ -471,12 +489,12 @@ class Sandbox(SandboxDto):
         if interval < 0:
             raise DaytonaValidationError("Auto-stop interval must be a non-negative integer")
 
-        _ = self._sandbox_api.set_autostop_interval(self.id, interval)
+        _ = self._sandbox_api.set_autostop_interval(self.id, interval, _request_timeout=http_timeout(request_timeout))
         self.auto_stop_interval = interval
 
     @intercept_errors(message_prefix="Failed to set auto-archive interval: ")
     @with_instrumentation()
-    def set_auto_archive_interval(self, interval: int) -> None:
+    def set_auto_archive_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-archive interval for the Sandbox.
 
         The Sandbox will automatically archive after being continuously stopped for the specified interval.
@@ -484,6 +502,10 @@ class Sandbox(SandboxDto):
         Args:
             interval (int): Number of minutes after which a continuously stopped Sandbox will be auto-archived.
                 Set to 0 for the maximum interval. Default is 7 days.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaValidationError: If interval is negative
@@ -499,12 +521,14 @@ class Sandbox(SandboxDto):
         if interval < 0:
             raise DaytonaValidationError("Auto-archive interval must be a non-negative integer")
 
-        _ = self._sandbox_api.set_auto_archive_interval(self.id, interval)
+        _ = self._sandbox_api.set_auto_archive_interval(
+            self.id, interval, _request_timeout=http_timeout(request_timeout)
+        )
         self.auto_archive_interval = interval
 
     @intercept_errors(message_prefix="Failed to set auto-delete interval: ")
     @with_instrumentation()
-    def set_auto_delete_interval(self, interval: int) -> None:
+    def set_auto_delete_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-delete interval for the Sandbox.
 
         The Sandbox will automatically delete after being continuously stopped for the specified interval.
@@ -513,6 +537,10 @@ class Sandbox(SandboxDto):
             interval (int): Number of minutes after which a continuously stopped Sandbox will be auto-deleted.
                 Set to negative value to disable auto-delete. Set to 0 to delete immediately upon stopping.
                 By default, auto-delete is disabled.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
@@ -524,7 +552,9 @@ class Sandbox(SandboxDto):
             sandbox.set_auto_delete_interval(-1)
             ```
         """
-        _ = self._sandbox_api.set_auto_delete_interval(self.id, interval)
+        _ = self._sandbox_api.set_auto_delete_interval(
+            self.id, interval, _request_timeout=http_timeout(request_timeout)
+        )
         self.auto_delete_interval = interval
 
     @intercept_errors(message_prefix="Failed to update network settings: ")
@@ -535,6 +565,7 @@ class Sandbox(SandboxDto):
         network_block_all: bool | None = None,
         network_allow_list: str | None = None,
         domain_allow_list: str | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         """Updates outbound network policy on the runner (block all, restore access, or CIDR allow list).
 
@@ -543,6 +574,10 @@ class Sandbox(SandboxDto):
                 outbound access (and clears a stored allow list).
             network_allow_list: Comma-separated IPv4 CIDRs to allow; implies not blocking all.
             domain_allow_list: Comma-separated domains to allow; implies not blocking all.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Raises:
             DaytonaValidationError: If neither argument is set.
@@ -563,7 +598,9 @@ class Sandbox(SandboxDto):
             network_allow_list=network_allow_list,
             domain_allow_list=domain_allow_list,
         )
-        updated = self._sandbox_api.update_network_settings(self.id, body)
+        updated = self._sandbox_api.update_network_settings(
+            self.id, body, _request_timeout=http_timeout(request_timeout)
+        )
         self.network_block_all = updated.network_block_all
         self.network_allow_list = updated.network_allow_list
         self.domain_allow_list = updated.domain_allow_list
@@ -613,13 +650,17 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to get preview link: ")
     @with_instrumentation()
-    def get_preview_link(self, port: int) -> PortPreviewUrl:
+    def get_preview_link(self, port: int, request_timeout: float | None = None) -> PortPreviewUrl:
         """Retrieves the preview link for the sandbox at the specified port. If the port is closed,
         it will be opened automatically. For private sandboxes, a token is included to grant access
         to the URL.
 
         Args:
             port (int): The port to open the preview link on.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             PortPreviewUrl: The response object for the preview link, which includes the `url`
@@ -632,43 +673,63 @@ class Sandbox(SandboxDto):
             print(f"Token: {preview_link.token}")
             ```
         """
-        return self._sandbox_api.get_port_preview_url(self.id, port)
+        return self._sandbox_api.get_port_preview_url(self.id, port, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to create signed preview url: ")
-    def create_signed_preview_url(self, port: int, expires_in_seconds: int | None = None) -> SignedPortPreviewUrl:
+    def create_signed_preview_url(
+        self, port: int, expires_in_seconds: int | None = None, request_timeout: float | None = None
+    ) -> SignedPortPreviewUrl:
         """Creates a signed preview URL for the sandbox at the specified port.
 
         Args:
             port (int): The port to open the preview link on.
             expires_in_seconds (int | None): The number of seconds the signed preview
                 url will be valid for. Defaults to 60 seconds.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Returns:
             SignedPortPreviewUrl: The response object for the signed preview url.
         """
-        return self._sandbox_api.get_signed_port_preview_url(self.id, port, expires_in_seconds=expires_in_seconds)
+        return self._sandbox_api.get_signed_port_preview_url(
+            self.id, port, expires_in_seconds=expires_in_seconds, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to expire signed preview url: ")
-    def expire_signed_preview_url(self, port: int, token: str) -> None:
+    def expire_signed_preview_url(self, port: int, token: str, request_timeout: float | None = None) -> None:
         """Expires a signed preview URL for the sandbox at the specified port.
 
         Args:
             port (int): The port to expire the signed preview url on.
             token (str): The token to expire the signed preview url on.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
-        self._sandbox_api.expire_signed_port_preview_url(self.id, port, token)
+        self._sandbox_api.expire_signed_port_preview_url(
+            self.id, port, token, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to archive sandbox: ")
     @with_instrumentation()
-    def archive(self) -> None:
+    def archive(self, request_timeout: float | None = None) -> None:
         """Archives the sandbox, making it inactive and preserving its state. When sandboxes are
         archived, the entire filesystem state is moved to cost-effective object storage, making it
         possible to keep sandboxes available for an extended period. The tradeoff between archived
         and stopped states is that starting an archived sandbox takes more time, depending on its size.
         Sandbox must be stopped before archiving.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = self._sandbox_api.archive_sandbox(self.id)
-        self.refresh_data()
+        _ = self._sandbox_api.archive_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
+        self.refresh_data(request_timeout=request_timeout)
 
     @intercept_errors(message_prefix="Failed to resize sandbox: ")
     @with_timeout()
@@ -747,47 +808,69 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to create SSH access: ")
     @with_instrumentation()
-    def create_ssh_access(self, expires_in_minutes: int | None = None) -> SshAccessDto:
+    def create_ssh_access(
+        self, expires_in_minutes: int | None = None, request_timeout: float | None = None
+    ) -> SshAccessDto:
         """Creates an SSH access token for the sandbox.
 
         Args:
             expires_in_minutes (int | None): The number of minutes the SSH access token will be valid for.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
-        return self._sandbox_api.create_ssh_access(self.id, expires_in_minutes=expires_in_minutes)
+        return self._sandbox_api.create_ssh_access(
+            self.id, expires_in_minutes=expires_in_minutes, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to revoke SSH access: ")
     @with_instrumentation()
-    def revoke_ssh_access(self, token: str) -> None:
+    def revoke_ssh_access(self, token: str, request_timeout: float | None = None) -> None:
         """Revokes an SSH access token for the sandbox.
 
         Args:
             token (str): The token to revoke.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = self._sandbox_api.revoke_ssh_access(self.id, token)
+        _ = self._sandbox_api.revoke_ssh_access(self.id, token, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to validate SSH access: ")
     @with_instrumentation()
-    def validate_ssh_access(self, token: str) -> SshAccessValidationDto:
+    def validate_ssh_access(self, token: str, request_timeout: float | None = None) -> SshAccessValidationDto:
         """Validates an SSH access token for the sandbox.
 
         Args:
             token (str): The token to validate.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
         """
-        return self._sandbox_api.validate_ssh_access(token)
+        return self._sandbox_api.validate_ssh_access(token, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to refresh sandbox activity: ")
-    def refresh_activity(self) -> None:
+    def refresh_activity(self, request_timeout: float | None = None) -> None:
         """Refreshes the sandbox activity to reset the timer for automated lifecycle management actions.
 
         This method updates the sandbox's last activity timestamp without changing its state.
         It is useful for keeping long-running sessions alive while there is still user activity.
+
+        Args:
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
 
         Example:
             ```python
             sandbox.refresh_activity()
             ```
         """
-        self._sandbox_api.update_last_activity(self.id)
+        self._sandbox_api.update_last_activity(self.id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to fork sandbox: ")
     @with_timeout()

--- a/sdk-python/src/daytona/_utils/errors.py
+++ b/sdk-python/src/daytona/_utils/errors.py
@@ -10,6 +10,7 @@ from typing import Any, NoReturn, TypeVar, Union, cast
 
 import aiohttp
 import httpx
+import urllib3.exceptions
 
 from daytona_api_client.exceptions import (
     BadRequestException,
@@ -99,6 +100,10 @@ TRANSPORT_ERROR_TO_DAYTONA_ERROR: tuple[tuple[type[BaseException], type[DaytonaE
     (aiohttp.ClientOSError, DaytonaConnectionError),
     (httpx.TimeoutException, DaytonaTimeoutError),
     (httpx.NetworkError, DaytonaConnectionError),
+    # urllib3's TimeoutError (raised by the generated sync clients on `_request_timeout`
+    # expiry, e.g. ReadTimeoutError/ConnectTimeoutError) extends urllib3's HTTPError,
+    # NOT the builtin TimeoutError, so it needs its own mapping entry.
+    (urllib3.exceptions.TimeoutError, DaytonaTimeoutError),
     (TimeoutError, DaytonaTimeoutError),
     # ConnectionError covers ConnectionRefusedError, ConnectionResetError, etc.
     # It intentionally does not catch the broader OSError family.

--- a/sdk-python/src/daytona/_utils/timeout.py
+++ b/sdk-python/src/daytona/_utils/timeout.py
@@ -80,7 +80,9 @@ def http_timeout(timeout: float | None) -> float | None:
     """Calculate HTTP client timeout to prevent race condition with decorator timeout.
 
     For sub-second timeouts, uses ceil() to match signal.alarm rounding behavior.
-    For timeouts >= 1 second, returns unchanged (natural execution overhead is sufficient).
+    For timeouts >= 1 second, keeps the value. The result is always returned as a
+    ``float`` because the generated async API client validates ``_request_timeout``
+    as a strict float and would reject an ``int``.
 
     This prevents a race condition where:
     - User specifies timeout=0.2s
@@ -88,30 +90,37 @@ def http_timeout(timeout: float | None) -> float | None:
     - HTTP client times out at 0.2s first → raises DaytonaError (wrong!)
 
     With this fix:
-    - timeout=0.2 → HTTP timeout: 1s (matches decorator) → DaytonaTimeoutError
-    - timeout=5.0 → HTTP timeout: 5s (unchanged) → DaytonaTimeoutError
+    - timeout=0.2 → HTTP timeout: 1.0s (matches decorator) → DaytonaTimeoutError
+    - timeout=5.0 → HTTP timeout: 5.0s (unchanged) → DaytonaTimeoutError
 
     Args:
         timeout: User's desired timeout in seconds, or None for no timeout
 
     Returns:
         - None if timeout is None or 0
-        - ceil(timeout) if timeout < 1 (matches signal rounding)
-        - timeout unchanged if timeout >= 1 (natural overhead is sufficient)
+        - float(ceil(timeout)) if 0 < timeout < 1 (matches signal rounding)
+        - float(timeout) if timeout >= 1
+
+    Raises:
+        DaytonaValidationError: If timeout is negative or non-finite (NaN/inf).
 
     Example:
         >>> http_timeout(0.2)
-        1
+        1.0
         >>> http_timeout(0.9)
-        1
+        1.0
         >>> http_timeout(5.0)
         5.0
         >>> http_timeout(None)
         None
     """
-    if not timeout:
+    if timeout is None:
         return None
-    return math.ceil(timeout) if timeout < 1 else timeout
+    if not math.isfinite(timeout) or timeout < 0:
+        raise DaytonaValidationError("Timeout must be a finite non-negative number")
+    if timeout == 0:
+        return None
+    return float(math.ceil(timeout)) if timeout < 1 else float(timeout)
 
 
 class _ThreadingTimeout:

--- a/sdk-python/tests/test_async_code_interpreter.py
+++ b/sdk-python/tests/test_async_code_interpreter.py
@@ -187,4 +187,4 @@ class TestAsyncCodeInterpreterContextManagement:
 
         await interpreter.delete_context(SimpleNamespace(id="ctx-123"))
 
-        api_client.delete_interpreter_context.assert_awaited_once_with(id="ctx-123")
+        api_client.delete_interpreter_context.assert_awaited_once_with(id="ctx-123", _request_timeout=None)

--- a/sdk-python/tests/test_async_computer_use.py
+++ b/sdk-python/tests/test_async_computer_use.py
@@ -85,7 +85,7 @@ class TestAsyncComputerUse:
         ).size_bytes == 123
         assert (await computer_use.screenshot.take_compressed_region(region)).size_bytes == 456
 
-        api_client.take_screenshot.assert_awaited_once_with(show_cursor=True)
+        api_client.take_screenshot.assert_awaited_once_with(show_cursor=True, _request_timeout=None)
 
     @pytest.mark.asyncio
     async def test_display_and_recording_methods_delegate_to_api(self, tmp_path: Path):
@@ -168,7 +168,7 @@ class TestAsyncComputerUse:
         assert (await computer_use.get_process_logs("xvfb")).logs == ["line"]
         assert (await computer_use.get_process_errors("xvfb")).errors == ["err"]
 
-        api_client.get_process_status.assert_awaited_once_with(process_name="xvfb")
+        api_client.get_process_status.assert_awaited_once_with(process_name="xvfb", _request_timeout=None)
 
     @pytest.mark.asyncio
     async def test_accessibility_methods_delegate_to_api(self):
@@ -193,8 +193,8 @@ class TestAsyncComputerUse:
         await computer_use.accessibility.invoke_node("node-2", action="click")
         await computer_use.accessibility.set_node_value("node-3", "hello")
 
-        api_client.get_accessibility_tree.assert_any_await(scope=None, pid=None, max_depth=None)
-        api_client.get_accessibility_tree.assert_any_await(scope="pid", pid=123, max_depth=0)
+        api_client.get_accessibility_tree.assert_any_await(scope=None, pid=None, max_depth=None, _request_timeout=None)
+        api_client.get_accessibility_tree.assert_any_await(scope="pid", pid=123, max_depth=0, _request_timeout=None)
         find_request = api_client.find_accessibility_nodes.call_args.kwargs["request"]
         assert find_request.to_dict() == {
             "scope": "all",

--- a/sdk-python/tests/test_async_lsp_server.py
+++ b/sdk-python/tests/test_async_lsp_server.py
@@ -76,6 +76,7 @@ class TestAsyncLspServer:
             language_id="python",
             path_to_project="/workspace/project",
             uri="file://app.py",
+            _request_timeout=None,
         )
 
     @pytest.mark.asyncio
@@ -90,6 +91,7 @@ class TestAsyncLspServer:
             language_id="python",
             path_to_project="/workspace/project",
             query="User",
+            _request_timeout=None,
         )
 
     @pytest.mark.asyncio
@@ -107,6 +109,7 @@ class TestAsyncLspServer:
             language_id="python",
             path_to_project="/workspace/project",
             query="Thing",
+            _request_timeout=None,
         )
 
     @pytest.mark.asyncio

--- a/sdk-python/tests/test_async_sandbox.py
+++ b/sdk-python/tests/test_async_sandbox.py
@@ -144,9 +144,9 @@ class TestAsyncSandboxOperations:
         await sandbox.revoke_ssh_access("token")
         await sandbox.refresh_activity()
 
-        mock_async_sandbox_api.get_port_preview_url.assert_awaited_once_with(sandbox.id, 3000)
-        mock_async_sandbox_api.revoke_ssh_access.assert_awaited_once_with(sandbox.id, "token")
-        mock_async_sandbox_api.update_last_activity.assert_awaited_once_with(sandbox.id)
+        mock_async_sandbox_api.get_port_preview_url.assert_awaited_once_with(sandbox.id, 3000, _request_timeout=None)
+        mock_async_sandbox_api.revoke_ssh_access.assert_awaited_once_with(sandbox.id, "token", _request_timeout=None)
+        mock_async_sandbox_api.update_last_activity.assert_awaited_once_with(sandbox.id, _request_timeout=None)
 
     @pytest.mark.asyncio
     async def test_update_secrets(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):

--- a/sdk-python/tests/test_code_interpreter.py
+++ b/sdk-python/tests/test_code_interpreter.py
@@ -185,4 +185,4 @@ class TestCodeInterpreterContextManagement:
 
         interpreter.delete_context(SimpleNamespace(id="ctx-123"))
 
-        api_client.delete_interpreter_context.assert_called_once_with(id="ctx-123")
+        api_client.delete_interpreter_context.assert_called_once_with(id="ctx-123", _request_timeout=None)

--- a/sdk-python/tests/test_computer_use.py
+++ b/sdk-python/tests/test_computer_use.py
@@ -93,10 +93,18 @@ class TestComputerUse:
         )
         assert computer_use.screenshot.take_compressed_region(region).size_bytes == 456
 
-        api_client.take_screenshot.assert_called_once_with(show_cursor=True)
-        api_client.take_region_screenshot.assert_called_once_with(height=200, width=300, y=20, x=10, show_cursor=False)
+        api_client.take_screenshot.assert_called_once_with(show_cursor=True, _request_timeout=None)
+        api_client.take_region_screenshot.assert_called_once_with(
+            height=200, width=300, y=20, x=10, show_cursor=False, _request_timeout=None
+        )
         compressed_kwargs = api_client.take_compressed_screenshot.call_args_list[1].kwargs
-        assert compressed_kwargs == {"scale": 0.5, "quality": 90, "format": "jpeg", "show_cursor": True}
+        assert compressed_kwargs == {
+            "scale": 0.5,
+            "quality": 90,
+            "format": "jpeg",
+            "show_cursor": True,
+            "_request_timeout": None,
+        }
         compressed_region_kwargs = api_client.take_compressed_region_screenshot.call_args.kwargs
         assert compressed_region_kwargs["width"] == 300
 
@@ -123,7 +131,7 @@ class TestComputerUse:
 
         assert api_client.start_recording.call_args.kwargs["request"].label == "label"
         assert api_client.stop_recording.call_args.kwargs["request"].id == "rec-1"
-        api_client.delete_recording.assert_called_once_with(id="rec-1")
+        api_client.delete_recording.assert_called_once_with(id="rec-1", _request_timeout=None)
 
         stream_response = MagicMock()
         stream_response.__enter__.return_value = stream_response
@@ -170,8 +178,8 @@ class TestComputerUse:
         assert computer_use.get_process_logs("xvfb").logs == ["line"]
         assert computer_use.get_process_errors("xvfb").errors == ["err"]
 
-        api_client.get_process_status.assert_called_once_with(process_name="xvfb")
-        api_client.restart_process.assert_called_once_with(process_name="xvfb")
+        api_client.get_process_status.assert_called_once_with(process_name="xvfb", _request_timeout=None)
+        api_client.restart_process.assert_called_once_with(process_name="xvfb", _request_timeout=None)
 
     def test_accessibility_methods_delegate_to_api(self):
         computer_use, api_client = _make_computer_use()
@@ -198,8 +206,8 @@ class TestComputerUse:
         computer_use.accessibility.invoke_node("node-2", action="click")
         computer_use.accessibility.set_node_value("node-3", "hello")
 
-        api_client.get_accessibility_tree.assert_any_call(scope=None, pid=None, max_depth=None)
-        api_client.get_accessibility_tree.assert_any_call(scope="pid", pid=123, max_depth=0)
+        api_client.get_accessibility_tree.assert_any_call(scope=None, pid=None, max_depth=None, _request_timeout=None)
+        api_client.get_accessibility_tree.assert_any_call(scope="pid", pid=123, max_depth=0, _request_timeout=None)
         find_request = api_client.find_accessibility_nodes.call_args.kwargs["request"]
         assert find_request.to_dict() == {
             "scope": "all",

--- a/sdk-python/tests/test_errors.py
+++ b/sdk-python/tests/test_errors.py
@@ -116,3 +116,29 @@ class TestErrorFactories:
 
         assert isinstance(error, DaytonaNotFoundError)
         assert error.error_code == "NOT_FOUND"
+
+
+class TestTransportErrorMapping:
+    def test_urllib3_read_timeout_maps_to_daytona_timeout_error(self):
+        import urllib3.exceptions
+
+        from daytona._utils.errors import intercept_errors
+
+        @intercept_errors(message_prefix="Failed to add files: ")
+        def raises_urllib3_read_timeout():
+            raise urllib3.exceptions.ReadTimeoutError(None, "/process/session", "Read timed out. (read timeout=1.0)")
+
+        with pytest.raises(DaytonaTimeoutError, match="Failed to add files: "):
+            raises_urllib3_read_timeout()
+
+    def test_urllib3_connect_timeout_maps_to_daytona_timeout_error(self):
+        import urllib3.exceptions
+
+        from daytona._utils.errors import intercept_errors
+
+        @intercept_errors(message_prefix="Failed to get session: ")
+        def raises_urllib3_connect_timeout():
+            raise urllib3.exceptions.ConnectTimeoutError("Connection timed out")
+
+        with pytest.raises(DaytonaTimeoutError, match="Failed to get session: "):
+            raises_urllib3_connect_timeout()

--- a/sdk-python/tests/test_filesystem.py
+++ b/sdk-python/tests/test_filesystem.py
@@ -153,19 +153,19 @@ class TestSyncFileSystem:
         fs, api = self._make_fs()
         api.create_folder.return_value = None
         fs.create_folder("workspace/data", "755")
-        api.create_folder.assert_called_once_with(path="workspace/data", mode="755")
+        api.create_folder.assert_called_once_with(path="workspace/data", mode="755", _request_timeout=None)
 
     def test_delete_file(self):
         fs, api = self._make_fs()
         api.delete_file.return_value = None
         fs.delete_file("workspace/file.txt")
-        api.delete_file.assert_called_once_with(path="workspace/file.txt", recursive=False)
+        api.delete_file.assert_called_once_with(path="workspace/file.txt", recursive=False, _request_timeout=None)
 
     def test_delete_file_recursive(self):
         fs, api = self._make_fs()
         api.delete_file.return_value = None
         fs.delete_file("workspace/dir", recursive=True)
-        api.delete_file.assert_called_once_with(path="workspace/dir", recursive=True)
+        api.delete_file.assert_called_once_with(path="workspace/dir", recursive=True, _request_timeout=None)
 
     def test_find_files(self):
         fs, api = self._make_fs()
@@ -176,7 +176,7 @@ class TestSyncFileSystem:
         api.find_in_files.return_value = [mock_match]
         result = fs.find_files("workspace/src", "TODO:")
         assert len(result) == 1
-        api.find_in_files.assert_called_once_with(path="workspace/src", pattern="TODO:")
+        api.find_in_files.assert_called_once_with(path="workspace/src", pattern="TODO:", _request_timeout=None)
 
     def test_get_file_info(self):
         fs, api = self._make_fs()
@@ -202,7 +202,7 @@ class TestSyncFileSystem:
         fs, api = self._make_fs()
         api.move_file.return_value = None
         fs.move_files("old/path.txt", "new/path.txt")
-        api.move_file.assert_called_once_with(source="old/path.txt", destination="new/path.txt")
+        api.move_file.assert_called_once_with(source="old/path.txt", destination="new/path.txt", _request_timeout=None)
 
     def test_replace_in_files(self):
         fs, api = self._make_fs()
@@ -226,7 +226,11 @@ class TestSyncFileSystem:
         api.set_file_permissions.return_value = None
         fs.set_file_permissions("workspace/script.sh", mode="755", owner="daytona")
         api.set_file_permissions.assert_called_once_with(
-            path="workspace/script.sh", mode="755", owner="daytona", group=None
+            path="workspace/script.sh",
+            mode="755",
+            owner="daytona",
+            group=None,
+            _request_timeout=None,
         )
 
     def test_download_file_returns_bytes(self):
@@ -413,13 +417,13 @@ class TestAsyncFileSystem:
     async def test_create_folder(self):
         fs, api = self._make_fs()
         await fs.create_folder("workspace/data", "755")
-        api.create_folder.assert_called_once_with(path="workspace/data", mode="755")
+        api.create_folder.assert_called_once_with(path="workspace/data", mode="755", _request_timeout=None)
 
     @pytest.mark.asyncio
     async def test_delete_file(self):
         fs, api = self._make_fs()
         await fs.delete_file("workspace/file.txt")
-        api.delete_file.assert_called_once_with(path="workspace/file.txt", recursive=False)
+        api.delete_file.assert_called_once_with(path="workspace/file.txt", recursive=False, _request_timeout=None)
 
     @pytest.mark.asyncio
     async def test_find_files(self):
@@ -448,7 +452,7 @@ class TestAsyncFileSystem:
     async def test_move_files(self):
         fs, api = self._make_fs()
         await fs.move_files("src.txt", "dst.txt")
-        api.move_file.assert_called_once_with(source="src.txt", destination="dst.txt")
+        api.move_file.assert_called_once_with(source="src.txt", destination="dst.txt", _request_timeout=None)
 
     @pytest.mark.asyncio
     async def test_search_files(self):
@@ -463,7 +467,9 @@ class TestAsyncFileSystem:
     async def test_set_file_permissions(self):
         fs, api = self._make_fs()
         await fs.set_file_permissions("script.sh", mode="755")
-        api.set_file_permissions.assert_called_once_with(path="script.sh", mode="755", owner=None, group=None)
+        api.set_file_permissions.assert_called_once_with(
+            path="script.sh", mode="755", owner=None, group=None, _request_timeout=None
+        )
 
     @pytest.mark.asyncio
     async def test_download_file_returns_bytes(self):

--- a/sdk-python/tests/test_lsp_server.py
+++ b/sdk-python/tests/test_lsp_server.py
@@ -68,6 +68,7 @@ class TestLspServer:
             language_id="python",
             path_to_project="/workspace/project",
             uri="file://app.py",
+            _request_timeout=None,
         )
 
     def test_sandbox_symbols_delegates(self):
@@ -81,6 +82,7 @@ class TestLspServer:
             language_id="python",
             path_to_project="/workspace/project",
             query="User",
+            _request_timeout=None,
         )
 
     def test_workspace_symbols_warns_and_delegates(self):
@@ -97,6 +99,7 @@ class TestLspServer:
             language_id="python",
             path_to_project="/workspace/project",
             query="Thing",
+            _request_timeout=None,
         )
 
     def test_completions_builds_position_request(self):

--- a/sdk-python/tests/test_process.py
+++ b/sdk-python/tests/test_process.py
@@ -115,7 +115,7 @@ class TestSyncProcessSessions:
     def test_delete_session(self):
         proc, api = self._make_process()
         proc.delete_session("my-session")
-        api.delete_session.assert_called_once_with(session_id="my-session")
+        api.delete_session.assert_called_once_with(session_id="my-session", _request_timeout=None)
 
     def test_get_entrypoint_session(self):
         proc, api = self._make_process()
@@ -190,7 +190,7 @@ class TestAsyncProcessExec:
         request = api.create_session.call_args.kwargs["request"]
         assert request.session_id == "my-session"
         await proc.delete_session("my-session")
-        api.delete_session.assert_called_once_with(session_id="my-session")
+        api.delete_session.assert_called_once_with(session_id="my-session", _request_timeout=None)
 
     @pytest.mark.asyncio
     async def test_execute_session_command(self):

--- a/sdk-python/tests/test_sandbox.py
+++ b/sdk-python/tests/test_sandbox.py
@@ -51,7 +51,7 @@ class TestSandboxLifecycleSettings:
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         sandbox.set_autostop_interval(30)
         assert sandbox.auto_stop_interval == 30
-        mock_sandbox_api.set_autostop_interval.assert_called_once_with(sandbox.id, 30)
+        mock_sandbox_api.set_autostop_interval.assert_called_once_with(sandbox.id, 30, _request_timeout=None)
 
     def test_negative_auto_archive_interval_raises(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
@@ -125,9 +125,9 @@ class TestSandboxOperations:
         sandbox.revoke_ssh_access("token")
         sandbox.refresh_activity()
 
-        mock_sandbox_api.get_port_preview_url.assert_called_once_with(sandbox.id, 3000)
-        mock_sandbox_api.revoke_ssh_access.assert_called_once_with(sandbox.id, "token")
-        mock_sandbox_api.update_last_activity.assert_called_once_with(sandbox.id)
+        mock_sandbox_api.get_port_preview_url.assert_called_once_with(sandbox.id, 3000, _request_timeout=None)
+        mock_sandbox_api.revoke_ssh_access.assert_called_once_with(sandbox.id, "token", _request_timeout=None)
+        mock_sandbox_api.update_last_activity.assert_called_once_with(sandbox.id, _request_timeout=None)
 
     def test_update_secrets(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)


### PR DESCRIPTION
### What
Adds an opt-in `request_timeout: float | None = None` parameter to every Python SDK
method that makes a plain HTTP request (sync + async trees), wired through as
`_request_timeout=http_timeout(request_timeout)`.

Covered: Process (session + PTY control), FileSystem, Git, ComputerUse, LSP,
CodeInterpreter (context ops), Sandbox, and `daytona.get` / `daytona.list`.

### Why
Control-plane and toolbox calls had no client-side read deadline (httpx default
`read=None`), so a non-responsive toolbox/proxy could hang calls indefinitely
(observed ~16-minute stalls). This lets callers bound the client-side wait.

### Naming: `request_timeout` vs `timeout`
The SDK already uses `timeout` for **operation** semantics — server-enforced on
`exec` / `code_run` (cancels the process), overall wait on lifecycle methods. The new
parameter is deliberately named `request_timeout` because it is **client-side only**:
it bounds how long the SDK waits for the HTTP response and does not cancel the
operation on the server. The two can coexist on the same method (as `exec` shows),
so adding server-side enforcement later is non-breaking.

### Notes
- Defaults to `None` — behavior unchanged unless a caller opts in.
- Positive sub-second values round up to 1s (uniform with existing timeout handling);
  `0` disables; negative/non-finite values are rejected.
- Skipped: websocket/streaming paths and methods that already have a working `timeout`.
- SDK reference docs regenerated.