### PR TITLE
chore: batch dependabot updates 2026-07-09

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -51,25 +51,25 @@ runs:
           exit 1
         fi
 
-    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       if: inputs.install-go == 'true'
       with:
         go-version-file: go.work
         cache: ${{ inputs.go-cache }}
         cache-dependency-path: "**/go.sum"
 
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       if: inputs.install-java == 'true'
       with:
         java-version: 21
         distribution: 'temurin'
 
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       if: inputs.install-python == 'true'
       with:
         python-version: '3.12'
 
-    - uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
+    - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       if: inputs.install-ruby == 'true'
       with:
         ruby-version: '3.4.5'
@@ -112,7 +112,7 @@ runs:
       shell: bash
       run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       if: inputs.run-yarn-install == 'true'
       with:
         path: ${{ steps.yarn-cache.outputs.dir }}
@@ -126,7 +126,7 @@ runs:
 
     - name: Cache Poetry virtualenv
       if: inputs.run-poetry-install == 'true'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .venv
         key: poetry-venv-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,15 +29,15 @@ jobs:
       # Set to "true" only after DNS for $DOMAIN points at GitHub Pages.
       EMIT_CNAME: 'false'
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Generate vanity site
         run: bash hack/go-vanity/generate-site.sh
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: hack/go-vanity/site
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/e2e_pr_tests.yaml
+++ b/.github/workflows/e2e_pr_tests.yaml
@@ -45,7 +45,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -69,7 +69,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -94,7 +94,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -117,7 +117,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -139,7 +139,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -166,7 +166,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -185,7 +185,7 @@ jobs:
         with:
           bun-version: latest
       - name: Install Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
         with:
           deno-version: v2.x
       - name: Install Azure Functions Core Tools

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -21,10 +21,10 @@ jobs:
     name: Go work
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.work
           cache: true
@@ -44,16 +44,16 @@ jobs:
       matrix:
         working-directory: [cli, sdk-go]
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.work
           cache: true
           cache-dependency-path: '**/go.sum'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a
         with:
           version: v2.6.2
           working-directory: ${{ matrix.working-directory }}
@@ -68,7 +68,7 @@ jobs:
     name: Python lint
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-toolchain
@@ -87,7 +87,7 @@ jobs:
     name: Format, lint, generate clients and docs
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-toolchain
@@ -118,7 +118,7 @@ jobs:
     name: TypeScript SDK type check
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -128,7 +128,7 @@ jobs:
       - name: Get yarn cache directory
         id: yarn-cache
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: yarn-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
@@ -144,7 +144,7 @@ jobs:
     name: Unit tests
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-toolchain
@@ -163,7 +163,7 @@ jobs:
     name: Build clients
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-toolchain
@@ -176,11 +176,11 @@ jobs:
     name: License headers
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: Check license headers
-        uses: apache/skywalking-eyes/header@ab3d1fe50d23f9c82eff489297167e2dde8ba6cb
+        uses: apache/skywalking-eyes/header@29bd646002b63bb4c0ed1648d1654c35fb8ff027
         with:
           token: ${{ github.token }}
           config: .licenserc.yaml
@@ -190,7 +190,7 @@ jobs:
     name: Yarnrc integrity check
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: Ensure PyYAML available

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -30,7 +30,7 @@ jobs:
             exit 1
           fi
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-tags: true
           fetch-depth: 0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
             exit 1
           fi
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -115,12 +115,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-tags: true
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.work
       - uses: ./.github/actions/install-gh-cli

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -73,7 +73,7 @@ jobs:
             exit 1
           fi
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-tags: true
           fetch-depth: 0


### PR DESCRIPTION
# Batch dependabot updates — 2026-07-09

**Branch:** `chore/batch-dependabot-2026-07-09` (2 commits, based on `origin/main` @ `d7c538ecc`)

**PR title:** `chore(deps): batch dependabot updates 2026-07-09`

## Summary

Batches the open dependabot github-actions updates into a single PR by cherry-picking each dependabot commit.

| Action | From | To |
|---|---|---|
| `actions/cache` | v5.0.5 | v6.1.0 (major) |
| `actions/checkout` | `df4cb1c0…` | `9c091bb2…` |
| `actions/setup-go` | v6.4.0 | v6.5.0 |
| `actions/setup-java` | v5.2.0 | v5.4.0 |
| `actions/setup-python` | v6.2.0 | v6.3.0 |
| `ruby/setup-ruby` | v1.308.0 | v1.316.0 |
| `denoland/setup-deno` | `667a34cd…` | `22d081ff…` |

Touches: `setup-toolchain/action.yml` + 6 workflows (`deploy-pages`, `e2e_pr_tests`, `pr_checks`, `prepare-release`, `release`, `sdk_publish`).

## Closes

Closes #3
Closes #36

## Excluded

**#8 (pip-prod group, 14 updates) is excluded** — do not merge as-is, two independent blockers:

1. **Breaks the Python version contract:** it raises the `urllib3` floor to `>=2.7.0`, which requires Python ≥ 3.10, while all Python packages declare `requires-python >= 3.9`. `poetry lock` fails to solve (`urllib3 is forbidden`).
2. **Fights the client generator:** the 4 bumped `pyproject.toml` files are generated; `hack/python-client/postprocess.sh` force-pins the urllib3 floor back to `2.1.0` on every `yarn generate:api-client`, so the next regeneration reverts the bump and the "generated clients out of date" CI gate fails.

Suggested follow-up for #8: bump the floors in the generator templates/postprocess (and decide whether to drop py3.9 first), and add a dependabot `ignore`/exclusion for generated client manifests so it stops proposing un-mergeable bumps there.

## Conflict resolutions during cherry-pick

- `default_image_publish.yaml` and `translate.yaml` (from #36): **kept deleted** — these workflows were intentionally removed on main by the monorepo-cruft cleanup (#46); bumps to deleted files are moot.
- `e2e_pr_tests.yaml` merged cleanly into the rewritten parallel-e2e version of the file.

## Validation

- `actionlint` clean on all changed workflow files (composite-action false positives and the known `blacksmith-*` runner-label warning aside).
- All YAML parses.
- Every action resolves to a **single consistent SHA** across the repo (no split pins).
- `poetry lock` solves with **zero lock drift** after excluding #8.
- No Go/Node/Python dependency changes remain in the batch → no build-level validation required.

## Risk notes

- `actions/cache` v5 → v6 is a **major** bump; used in `pr_checks.yaml` + `setup-toolchain/action.yml`. Cache actions have historically been drop-in across majors, but the first CI run on this PR is the real verification — watch the cache save/restore steps.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch updates GitHub Actions across workflows to keep CI current and pins consistent. Major bumps to `actions/checkout` v7 and `actions/cache` v6; closes #3 and #36.

- **Dependencies**
  - Major: `actions/checkout` v7.0.0, `actions/cache` v6.1.0
  - Others: `actions/setup-go` v6.5.0, `actions/setup-java` v5.4.0, `actions/setup-python` v6.3.0, `ruby/setup-ruby` v1.316.0, `actions/upload-pages-artifact` v5.0.0, `actions/deploy-pages` v5.0.0, `denoland/setup-deno` v2.0.5, `golangci/golangci-lint-action` v9.3.0, `apache/skywalking-eyes/header` updated

- **Migration**
  - No app code changes. First CI run may warm caches; watch `actions/cache` restore/save steps.

<sup>Written for commit 8483368e6e42f7e174bca61f8d80ae63740b31fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

