### PR TITLE
fix(sdk-python): decode multipart download path labels

### DIFF
--- a/sdk-python/src/daytona/_async/filesystem.py
+++ b/sdk-python/src/daytona/_async/filesystem.py
@@ -35,6 +35,7 @@ from ..common.errors import DaytonaError
 from ..common.file_transfer import (
     create_multipart_parser,
     parse_content_type_boundary,
+    parse_content_disposition,
     raise_if_multipart_truncated,
     serialize_download_request,
 )
@@ -470,7 +471,7 @@ class AsyncFileSystem:
 
                 def on_header_end() -> None:
                     field = bytes(header_field).decode("utf-8", errors="ignore").lower()
-                    value = bytes(header_value).decode("utf-8", errors="ignore")
+                    value = bytes(header_value).decode("latin-1")
                     pending_headers.append((field, value))
                     header_field.clear()
                     header_value.clear()
@@ -510,9 +511,7 @@ class AsyncFileSystem:
                         elif event_tag == "headers_finished":
                             hdrs: dict[str, str] = event_payload
                             cd = hdrs.get("content-disposition", "")
-                            _, cd_params = parse_options_header(cd)
-                            name = cd_params.get(b"name", b"").decode("utf-8", errors="ignore")
-                            source = cd_params.get(b"filename", b"").decode("utf-8", errors="ignore") or None
+                            name, source = parse_content_disposition(cd)
                             if not source:
                                 raise DaytonaError("No source path found for this file")
                             part_content_type = hdrs.get("content-type")

--- a/sdk-python/src/daytona/_async/filesystem.py
+++ b/sdk-python/src/daytona/_async/filesystem.py
@@ -34,8 +34,8 @@ from .._utils.timeout import http_timeout
 from ..common.errors import DaytonaError
 from ..common.file_transfer import (
     create_multipart_parser,
-    parse_content_type_boundary,
     parse_content_disposition,
+    parse_content_type_boundary,
     raise_if_multipart_truncated,
     serialize_download_request,
 )

--- a/sdk-python/src/daytona/_sync/filesystem.py
+++ b/sdk-python/src/daytona/_sync/filesystem.py
@@ -29,8 +29,8 @@ from .._utils.timeout import http_timeout
 from ..common.errors import DaytonaError
 from ..common.file_transfer import (
     create_multipart_parser,
-    parse_content_type_boundary,
     parse_content_disposition,
+    parse_content_type_boundary,
     raise_if_multipart_truncated,
     serialize_download_request,
 )

--- a/sdk-python/src/daytona/_sync/filesystem.py
+++ b/sdk-python/src/daytona/_sync/filesystem.py
@@ -30,6 +30,7 @@ from ..common.errors import DaytonaError
 from ..common.file_transfer import (
     create_multipart_parser,
     parse_content_type_boundary,
+    parse_content_disposition,
     raise_if_multipart_truncated,
     serialize_download_request,
 )
@@ -454,7 +455,7 @@ class FileSystem:
 
                 def on_header_end() -> None:
                     field = bytes(header_field).decode("utf-8", errors="ignore").lower()
-                    value = bytes(header_value).decode("utf-8", errors="ignore")
+                    value = bytes(header_value).decode("latin-1")
                     part_headers[field] = value
                     header_field.clear()
                     header_value.clear()
@@ -462,9 +463,7 @@ class FileSystem:
                 def on_headers_finished() -> None:
                     nonlocal writer, mode, part_content_type, source
                     cd = part_headers.get("content-disposition", "")
-                    _, cd_params = parse_options_header(cd)
-                    name = cd_params.get(b"name", b"").decode("utf-8", errors="ignore")
-                    source = cd_params.get(b"filename", b"").decode("utf-8", errors="ignore") or None
+                    name, source = parse_content_disposition(cd)
                     if not source:
                         raise DaytonaError("No source path found for this file")
                     part_content_type = part_headers.get("content-type")

--- a/sdk-python/src/daytona/common/file_transfer.py
+++ b/sdk-python/src/daytona/common/file_transfer.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import urllib.parse
+
 from collections.abc import Callable, Mapping
 from typing import Any
 
@@ -11,6 +13,100 @@ from python_multipart.multipart import MultipartParser, MultipartState, parse_op
 from daytona_toolbox_api_client import FilesDownloadRequest
 
 from .errors import DaytonaError
+
+
+def _parse_content_disposition_parameters(header: str) -> dict[str, str]:
+    """Parse Content-Disposition parameters without mangling file paths.
+
+    Each part of a bulk-download response identifies its file by echoing the
+    requested path in the Content-Disposition header, and we match parts back
+    to requests by exact string comparison — so the path must survive parsing
+    byte-for-byte. python_multipart's parse_options_header cannot guarantee
+    that: it strips a backslash-containing filename down to its basename
+    (an IE-era upload compatibility behavior), turning a requested
+    ``C:\\Windows\\Temp\\x`` into ``x`` and breaking the lookup.
+
+    This parser preserves the parameter values instead: ``filename*`` remains
+    RFC 5987 percent-encoded for the caller to decode as the lossless form, and
+    quoted ``filename`` has quoted-pair escapes removed without path
+    normalization.
+    """
+    parameters: dict[str, str] = {}
+    position = header.find(";")
+    length = len(header)
+
+    while position >= 0 and position < length:
+        position += 1
+        while position < length and header[position].isspace():
+            position += 1
+
+        name_start = position
+        while position < length and header[position] not in "=;":
+            position += 1
+        if position >= length or header[position] != "=":
+            position = header.find(";", position)
+            continue
+
+        name = header[name_start:position].strip().lower()
+        position += 1
+        while position < length and header[position].isspace():
+            position += 1
+
+        if position < length and header[position] == '"':
+            position += 1
+            value_chars: list[str] = []
+            while position < length:
+                char = header[position]
+                if char == "\\" and position + 1 < length:
+                    position += 1
+                    value_chars.append(header[position])
+                elif char == '"':
+                    position += 1
+                    break
+                else:
+                    value_chars.append(char)
+                position += 1
+            value = "".join(value_chars)
+            while position < length and header[position] != ";":
+                position += 1
+        else:
+            value_start = position
+            while position < length and header[position] != ";":
+                position += 1
+            value = header[value_start:position].strip()
+
+        if name and name not in parameters:
+            parameters[name] = value
+
+    return parameters
+
+
+def parse_content_disposition(header: str) -> tuple[str | None, str | None]:
+    """Return the multipart field name and decoded filename label."""
+    parameters = _parse_content_disposition_parameters(header)
+    name = parameters.get("name")
+    extended_filename = parameters.get("filename*")
+    if extended_filename is None:
+        return name, parameters.get("filename")
+
+    extended_parts = extended_filename.split("'", 2)
+    if len(extended_parts) != 3 or extended_parts[0].lower() != "utf-8":
+        raise DaytonaError("Invalid Content-Disposition filename* parameter")
+
+    encoded_filename = extended_parts[2]
+    for index, char in enumerate(encoded_filename):
+        if char == "%" and (
+            index + 2 >= len(encoded_filename)
+            or encoded_filename[index + 1] not in "0123456789abcdefABCDEF"
+            or encoded_filename[index + 2] not in "0123456789abcdefABCDEF"
+        ):
+            raise DaytonaError("Invalid Content-Disposition filename* parameter")
+
+    try:
+        filename = urllib.parse.unquote_to_bytes(encoded_filename).decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise DaytonaError("Invalid Content-Disposition filename* parameter") from exc
+    return name, filename
 
 
 def serialize_download_request(api_client: Any, remote_path: str) -> tuple[str, str, dict[str, str], Any]:

--- a/sdk-python/src/daytona/common/file_transfer.py
+++ b/sdk-python/src/daytona/common/file_transfer.py
@@ -35,7 +35,7 @@ def _parse_content_disposition_parameters(header: str) -> dict[str, str]:
     position = header.find(";")
     length = len(header)
 
-    while position >= 0 and position < length:
+    while 0 <= position < length:
         position += 1
         while position < length and header[position].isspace():
             position += 1

--- a/sdk-python/src/daytona/common/file_transfer.py
+++ b/sdk-python/src/daytona/common/file_transfer.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import urllib.parse
-
 from collections.abc import Callable, Mapping
 from typing import Any
 

--- a/sdk-python/tests/test_filesystem.py
+++ b/sdk-python/tests/test_filesystem.py
@@ -45,14 +45,17 @@ def _daemon_content_disposition(
     filename: str,
     *,
     include_filename_star: bool = True,
+    filename_star: str | None = None,
 ) -> str:
     """Mirror the daemon's quoted fallback and RFC 5987 filename."""
     fallback = "".join(char if ord(char) <= 0xFF else "_" for char in filename)
     quoted = fallback.replace("\\", "\\\\").replace('"', '\\"')
     disposition = f'form-data; name="{name}"; filename="{quoted}"'
     if include_filename_star:
-        encoded = urllib.parse.quote(filename, safe="!#$&+-.^_`|~")
-        disposition += f"; filename*=utf-8''{encoded}"
+        if filename_star is None:
+            encoded = urllib.parse.quote(filename, safe="!#$&+-.^_`|~")
+            filename_star = f"utf-8''{encoded}"
+        disposition += f"; filename*={filename_star}"
     return disposition
 
 
@@ -61,6 +64,7 @@ def _build_multipart_response(
     parts: list[tuple[str, str, bytes, str]],  # (name, filename, payload, content_type)
     *,
     include_filename_star: bool = True,
+    filename_star: str | None = None,
 ) -> bytes:
     body = bytearray()
     for name, filename, payload, content_type in parts:
@@ -69,12 +73,20 @@ def _build_multipart_response(
             name,
             filename,
             include_filename_star=include_filename_star,
+            filename_star=filename_star,
         )
         body += f"Content-Disposition: {content_disposition}\r\n".encode("latin-1")
         body += f"Content-Type: {content_type}\r\n".encode("utf-8")
         body += b"\r\n" + payload + b"\r\n"
     body += b"--" + boundary + b"--\r\n"
     return bytes(body)
+
+
+_INVALID_FILENAME_STARS = (
+    "utf-8''workspace%2Fbad%GG.txt",
+    "iso-8859-1''workspace%2Fbad.txt",
+    "utf-8''workspace%2Fbad%FF.txt",
+)
 
 
 class _Response:
@@ -567,6 +579,28 @@ class TestSyncFileSystem:
         assert results[0].error is None
         assert results[0].result == b"fallback payload"
 
+    @pytest.mark.parametrize("filename_star", _INVALID_FILENAME_STARS)
+    def test_download_files_rejects_invalid_filename_star(self, filename_star: str):
+        from daytona._sync.filesystem import FileSystem
+        from daytona.common.filesystem import FileDownloadRequest
+
+        mock_api = MagicMock()
+        source = "workspace/bad.txt"
+        boundary = b"sync-bulk-boundary"
+        multipart_body = _build_multipart_response(
+            boundary,
+            [("file", source, b"payload", "application/octet-stream")],
+            filename_star=filename_star,
+        )
+        client = _SyncStreamClient(_SyncStreamResponse([multipart_body], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [source]})
+        )
+        fs = FileSystem(mock_api, http_client=client)
+
+        with pytest.raises(DaytonaError, match=r"Invalid Content-Disposition filename\* parameter"):
+            fs.download_files([FileDownloadRequest(source=source)])
+
 
 class TestAsyncFileSystem:
     def _make_fs(self):
@@ -951,6 +985,30 @@ class TestAsyncFileSystem:
         assert results[0].source == source
         assert results[0].error is None
         assert results[0].result == b"fallback payload"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("filename_star", _INVALID_FILENAME_STARS)
+    async def test_download_files_rejects_invalid_filename_star(self, filename_star: str):
+        from daytona._async.filesystem import AsyncFileSystem
+        from daytona.common.filesystem import FileDownloadRequest
+
+        mock_api = AsyncMock()
+        source = "workspace/bad.txt"
+        boundary = b"async-bulk-boundary"
+        multipart_body = _build_multipart_response(
+            boundary,
+            [("file", source, b"payload", "application/octet-stream")],
+            filename_star=filename_star,
+        )
+        client = _AsyncStreamClient(_AsyncStreamResponse([multipart_body], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [source]})
+        )
+        mock_api.api_client.http_session = client
+        fs = AsyncFileSystem(mock_api)
+
+        with pytest.raises(DaytonaError, match=r"Invalid Content-Disposition filename\* parameter"):
+            await fs.download_files([FileDownloadRequest(source=source)])
 
     @pytest.mark.asyncio
     async def test_upload_file_stream_accepts_async_iterable(self):

--- a/sdk-python/tests/test_filesystem.py
+++ b/sdk-python/tests/test_filesystem.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import urllib.parse
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -37,6 +38,43 @@ def _build_multipart_body(
             b"\r\n--" + boundary + b"--\r\n",
         ]
     )
+
+
+def _daemon_content_disposition(
+    name: str,
+    filename: str,
+    *,
+    include_filename_star: bool = True,
+) -> str:
+    """Mirror the daemon's quoted fallback and RFC 5987 filename."""
+    fallback = "".join(char if ord(char) <= 0xFF else "_" for char in filename)
+    quoted = fallback.replace("\\", "\\\\").replace('"', '\\"')
+    disposition = f'form-data; name="{name}"; filename="{quoted}"'
+    if include_filename_star:
+        encoded = urllib.parse.quote(filename, safe="!#$&+-.^_`|~")
+        disposition += f"; filename*=utf-8''{encoded}"
+    return disposition
+
+
+def _build_multipart_response(
+    boundary: bytes,
+    parts: list[tuple[str, str, bytes, str]],  # (name, filename, payload, content_type)
+    *,
+    include_filename_star: bool = True,
+) -> bytes:
+    body = bytearray()
+    for name, filename, payload, content_type in parts:
+        body += b"--" + boundary + b"\r\n"
+        content_disposition = _daemon_content_disposition(
+            name,
+            filename,
+            include_filename_star=include_filename_star,
+        )
+        body += f"Content-Disposition: {content_disposition}\r\n".encode("latin-1")
+        body += f"Content-Type: {content_type}\r\n".encode("utf-8")
+        body += b"\r\n" + payload + b"\r\n"
+    body += b"--" + boundary + b"--\r\n"
+    return bytes(body)
 
 
 class _Response:
@@ -405,6 +443,130 @@ class TestSyncFileSystem:
         with pytest.raises(DaytonaError, match=r"[Tt]runcated"):
             list(fs.download_file_stream(remote_path))
 
+    def test_download_files_matches_windows_backslash_paths(self):
+        from daytona._sync.filesystem import FileSystem
+        from daytona.common.filesystem import FileDownloadRequest
+
+        mock_api = MagicMock()
+        source = "C:\\Windows\\Temp\\x"
+        boundary = b"sync-bulk-boundary"
+        multipart_body = _build_multipart_response(
+            boundary,
+            [("file", source, b"windows payload", "application/octet-stream")],
+        )
+        client = _SyncStreamClient(_SyncStreamResponse([multipart_body], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [source]})
+        )
+        fs = FileSystem(mock_api, http_client=client)
+
+        results = fs.download_files([FileDownloadRequest(source=source)])
+
+        assert len(results) == 1
+        assert results[0].source == source
+        assert results[0].error is None
+        assert results[0].result == b"windows payload"
+
+    def test_download_files_matches_non_ascii_filename_star(self):
+        from daytona._sync.filesystem import FileSystem
+        from daytona.common.filesystem import FileDownloadRequest
+
+        mock_api = MagicMock()
+        source = "workspace/文件.txt"
+        boundary = b"sync-bulk-boundary"
+        multipart_body = _build_multipart_response(
+            boundary,
+            [("file", source, b"unicode payload", "application/octet-stream")],
+        )
+        assert b'filename="workspace/__.txt"' in multipart_body
+        client = _SyncStreamClient(_SyncStreamResponse([multipart_body], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [source]})
+        )
+        fs = FileSystem(mock_api, http_client=client)
+
+        results = fs.download_files([FileDownloadRequest(source=source)])
+
+        assert results[0].source == source
+        assert results[0].error is None
+        assert results[0].result == b"unicode payload"
+
+    def test_download_files_mixed_success_and_error_parts_by_label(self, tmp_path):
+        from daytona._sync.filesystem import FileSystem
+        from daytona.common.filesystem import FileDownloadErrorDetails, FileDownloadRequest
+
+        mock_api = MagicMock()
+        ok_source = "C:\\Users\\me\\ok.txt"
+        missing_source = "C:\\Users\\me\\missing.txt"
+        posix_source = "workspace/data.txt"
+        destination = tmp_path / "ok.txt"
+        boundary = b"sync-bulk-boundary"
+        multipart_body = _build_multipart_response(
+            boundary,
+            [
+                ("file", posix_source, b"third", "text/plain"),
+                (
+                    "error",
+                    missing_source,
+                    b'{"message":"missing","statusCode":404,"code":"not_found"}',
+                    "application/json; charset=utf-8",
+                ),
+                ("file", ok_source, b"first", "application/octet-stream"),
+            ],
+        )
+        client = _SyncStreamClient(_SyncStreamResponse([multipart_body], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=(
+                "POST",
+                "https://download",
+                {},
+                {"paths": [ok_source, missing_source, posix_source]},
+            )
+        )
+        fs = FileSystem(mock_api, http_client=client)
+
+        results = fs.download_files(
+            [
+                FileDownloadRequest(source=ok_source, destination=str(destination)),
+                FileDownloadRequest(source=missing_source),
+                FileDownloadRequest(source=posix_source),
+            ]
+        )
+
+        assert results[0].error is None
+        assert results[0].result == str(destination)
+        assert destination.read_bytes() == b"first"
+        assert results[1].error == "missing"
+        assert results[1].error_details == FileDownloadErrorDetails(
+            message="missing", status_code=404, error_code="not_found"
+        )
+        assert results[2].error is None
+        assert results[2].result == b"third"
+
+    def test_download_files_falls_back_to_quoted_filename(self):
+        from daytona._sync.filesystem import FileSystem
+        from daytona.common.filesystem import FileDownloadRequest
+
+        mock_api = MagicMock()
+        source = 'workspace/café\\a"b.txt'
+        boundary = b"sync-bulk-boundary"
+        multipart_body = _build_multipart_response(
+            boundary,
+            [("file", source, b"fallback payload", "application/octet-stream")],
+            include_filename_star=False,
+        )
+        client = _SyncStreamClient(_SyncStreamResponse([multipart_body], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [source]})
+        )
+        fs = FileSystem(mock_api, http_client=client)
+
+        results = fs.download_files([FileDownloadRequest(source=source)])
+
+        assert results[0].source == source
+        assert results[0].error is None
+        assert results[0].result == b"fallback payload"
+
 
 class TestAsyncFileSystem:
     def _make_fs(self):
@@ -657,6 +819,138 @@ class TestAsyncFileSystem:
         with pytest.raises(DaytonaError, match=r"[Tt]runcated"):
             async for _ in stream:
                 pass
+
+    @pytest.mark.asyncio
+    async def test_download_files_matches_windows_backslash_paths(self):
+        from daytona._async.filesystem import AsyncFileSystem
+        from daytona.common.filesystem import FileDownloadRequest
+
+        mock_api = AsyncMock()
+        source = "C:\\Windows\\Temp\\x"
+        boundary = b"async-bulk-boundary"
+        multipart_body = _build_multipart_response(
+            boundary,
+            [("file", source, b"windows payload", "application/octet-stream")],
+        )
+        client = _AsyncStreamClient(_AsyncStreamResponse([multipart_body], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [source]})
+        )
+        mock_api.api_client.http_session = client
+        fs = AsyncFileSystem(mock_api)
+
+        results = await fs.download_files([FileDownloadRequest(source=source)])
+
+        assert len(results) == 1
+        assert results[0].source == source
+        assert results[0].error is None
+        assert results[0].result == b"windows payload"
+
+    @pytest.mark.asyncio
+    async def test_download_files_matches_non_ascii_filename_star(self):
+        from daytona._async.filesystem import AsyncFileSystem
+        from daytona.common.filesystem import FileDownloadRequest
+
+        mock_api = AsyncMock()
+        source = "workspace/文件.txt"
+        boundary = b"async-bulk-boundary"
+        multipart_body = _build_multipart_response(
+            boundary,
+            [("file", source, b"unicode payload", "application/octet-stream")],
+        )
+        assert b'filename="workspace/__.txt"' in multipart_body
+        client = _AsyncStreamClient(_AsyncStreamResponse([multipart_body], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [source]})
+        )
+        mock_api.api_client.http_session = client
+        fs = AsyncFileSystem(mock_api)
+
+        results = await fs.download_files([FileDownloadRequest(source=source)])
+
+        assert results[0].source == source
+        assert results[0].error is None
+        assert results[0].result == b"unicode payload"
+
+    @pytest.mark.asyncio
+    async def test_download_files_mixed_success_and_error_parts_by_label(self, tmp_path):
+        from daytona._async.filesystem import AsyncFileSystem
+        from daytona.common.filesystem import FileDownloadErrorDetails, FileDownloadRequest
+
+        mock_api = AsyncMock()
+        ok_source = "C:\\Users\\me\\ok.txt"
+        missing_source = "C:\\Users\\me\\missing.txt"
+        posix_source = "workspace/data.txt"
+        destination = tmp_path / "ok.txt"
+        boundary = b"async-bulk-boundary"
+        multipart_body = _build_multipart_response(
+            boundary,
+            [
+                ("file", posix_source, b"third", "text/plain"),
+                (
+                    "error",
+                    missing_source,
+                    b'{"message":"missing","statusCode":404,"code":"not_found"}',
+                    "application/json; charset=utf-8",
+                ),
+                ("file", ok_source, b"first", "application/octet-stream"),
+            ],
+        )
+        client = _AsyncStreamClient(_AsyncStreamResponse([multipart_body], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=(
+                "POST",
+                "https://download",
+                {},
+                {"paths": [ok_source, missing_source, posix_source]},
+            )
+        )
+        mock_api.api_client.http_session = client
+        fs = AsyncFileSystem(mock_api)
+
+        results = await fs.download_files(
+            [
+                FileDownloadRequest(source=ok_source, destination=str(destination)),
+                FileDownloadRequest(source=missing_source),
+                FileDownloadRequest(source=posix_source),
+            ]
+        )
+
+        assert results[0].error is None
+        assert results[0].result == str(destination)
+        assert destination.read_bytes() == b"first"
+        assert results[1].error == "missing"
+        assert results[1].error_details == FileDownloadErrorDetails(
+            message="missing", status_code=404, error_code="not_found"
+        )
+        assert results[2].error is None
+        assert results[2].result == b"third"
+
+    @pytest.mark.asyncio
+    async def test_download_files_falls_back_to_quoted_filename(self):
+        from daytona._async.filesystem import AsyncFileSystem
+        from daytona.common.filesystem import FileDownloadRequest
+
+        mock_api = AsyncMock()
+        source = 'workspace/café\\a"b.txt'
+        boundary = b"async-bulk-boundary"
+        multipart_body = _build_multipart_response(
+            boundary,
+            [("file", source, b"fallback payload", "application/octet-stream")],
+            include_filename_star=False,
+        )
+        client = _AsyncStreamClient(_AsyncStreamResponse([multipart_body], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [source]})
+        )
+        mock_api.api_client.http_session = client
+        fs = AsyncFileSystem(mock_api)
+
+        results = await fs.download_files([FileDownloadRequest(source=source)])
+
+        assert results[0].source == source
+        assert results[0].error is None
+        assert results[0].result == b"fallback payload"
 
     @pytest.mark.asyncio
     async def test_upload_file_stream_accepts_async_iterable(self):


### PR DESCRIPTION
`fs.download_file` fails on Windows sandboxes when the remote path uses backslashes:

```python
sandbox.fs.download_file(r"C:\Windows\Temp\x")
# DaytonaError: Failed to download files: 'x'
```

The same file downloads fine spelled `C:/Windows/Temp/x`, and uploads accept backslash paths — only downloads break.

**Root cause.** The bulk-download response is multipart; each part echoes the requested path in its `Content-Disposition` so the SDK can match parts back to requests by exact string lookup. That header was parsed with `python_multipart.parse_options_header`, which deliberately strips a backslash-containing filename down to its basename:

```python
>>> parse_options_header(r'form-data; name="file"; filename="C:\\Windows\\Temp\\x"')
# filename → b'x'
```

The lookup for `'x'` then raises `KeyError` — the cryptic `'x'` in the error message is that KeyError leaking through the error-prefix decorator.

**Fix:** Parse `Content-Disposition` in the SDK instead, preferring the RFC 5987 `filename*` parameter the daemon already sends (percent-encoded, so it round-trips any path byte-exactly) and falling back to plain `filename` with quoted-pair unescaping. Preferring `filename*` also fixes a second latent bug: plain `filename` is Latin-1-only and the daemon substitutes `_` for characters outside it, so non-ASCII paths could never match either. Part header values are now decoded as Latin-1 (per HTTP) rather than UTF-8-with-ignore, which silently dropped bytes.

An alternative considered and rejected: matching parts to requests positionally (the daemon writes one part per requested path, in order). It would sidestep header parsing entirely, but gives up self-identifying parts and would silently mis-pair files if the response order ever changed.

**Verification.** `pytest tests/test_filesystem.py` — 45 passed. New coverage: backslash and forward-slash paths, non-ASCII paths via `filename*`, the `filename`-only fallback, mixed success/error parts, and malformed `filename*` rejection, for both the sync and async clients.
<!-- devin-review-badge-beta-begin -->

---

<a href="https://daytona.beta.devinenterprise.com/review/daytona/clients/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-beta-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-beta-light.svg?v=1" alt="Open in Devin Review (Beta)">
  </picture>
</a>
<!-- devin-review-badge-beta-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bulk download path matching by correctly decoding multipart Content-Disposition labels, so Windows backslash and non-ASCII paths download reliably in both sync and async clients.

- **Bug Fixes**
  - Added a safe Content-Disposition parser in `daytona.common.file_transfer` that prefers RFC 5987 `filename*`, falls back to quoted `filename`, and strictly validates percent-encoding to reject malformed labels while preserving exact paths (including backslashes).
  - Decode part header values as Latin-1 (per HTTP) to prevent byte loss and enable exact label matching.
  - Added tests covering backslash paths, `filename*` (including malformed), `filename` fallback, mixed success/error parts, and truncated responses in sync and async clients.

<sup>Written for commit e1846860dfcb0e906820d12511ac8650a52533b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

