### PR TITLE
ci: create release PRs with daytonaBot token

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -44,7 +44,7 @@ jobs:
           # Bots and automation cannot sign -- exempt them. Explicit logins only:
           # a `bot*` wildcard would let a human register a matching username
           # (e.g. "bottle") and bypass the CLA gate.
-          allowlist: 'dependabot[bot],renovate[bot],github-actions[bot]'
+          allowlist: 'dependabot[bot],renovate[bot],github-actions[bot],daytonaBot'
           # Lock the PR conversation after merge so a signature comment can't be
           # deleted/revoked after the fact.
           lock-pullrequest-aftermerge: true

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -48,6 +48,11 @@ jobs:
       - name: Push branch and create PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gh prefers GH_TOKEN over GITHUB_TOKEN: the PR is created as
+          # daytonaBot so it works with "Allow GitHub Actions to create and
+          # approve pull requests" disabled, and PR checks trigger on it
+          # (GITHUB_TOKEN-created PRs never trigger workflows).
+          GH_TOKEN: ${{ secrets.GITHUBBOT_TOKEN }}
         run: |
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
           git push origin "prepare-release-$VERSION"

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -54,6 +54,12 @@ jobs:
           # (GITHUB_TOKEN-created PRs never trigger workflows).
           GH_TOKEN: ${{ secrets.GITHUBBOT_TOKEN }}
         run: |
+          # Fail fast: with an empty GH_TOKEN, gh silently falls back to
+          # GITHUB_TOKEN, and that PR would trigger no CI.
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::GITHUBBOT_TOKEN is unavailable; refusing to create the release PR with GITHUB_TOKEN"
+            exit 1
+          fi
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
           git push origin "prepare-release-$VERSION"
           gh pr create \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,6 +131,12 @@ jobs:
           git config --global user.email "daytona-release@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
       - name: Sync go.sum and create PR
+        env:
+          # gh prefers GH_TOKEN over GITHUB_TOKEN: the PR is created as
+          # daytonaBot so it works with "Allow GitHub Actions to create and
+          # approve pull requests" disabled, and PR checks trigger on it
+          # (GITHUB_TOKEN-created PRs never trigger workflows).
+          GH_TOKEN: ${{ secrets.GITHUBBOT_TOKEN }}
         run: |
           git checkout -b "sync-gosum-$VERSION"
           GONOSUMDB=github.com/daytona/clients go work sync

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,6 +138,12 @@ jobs:
           # (GITHUB_TOKEN-created PRs never trigger workflows).
           GH_TOKEN: ${{ secrets.GITHUBBOT_TOKEN }}
         run: |
+          # Fail fast: with an empty GH_TOKEN, gh silently falls back to
+          # GITHUB_TOKEN, and that PR would trigger no CI.
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::GITHUBBOT_TOKEN is unavailable; refusing to create the sync PR with GITHUB_TOKEN"
+            exit 1
+          fi
           git checkout -b "sync-gosum-$VERSION"
           GONOSUMDB=github.com/daytona/clients go work sync
           git add -A


### PR DESCRIPTION
Release automation opens PRs with the default `GITHUB_TOKEN`. PRs created that way never trigger `pull_request` workflows, so release PRs get no CI, and it blocks disabling the repo setting "Allow GitHub Actions to create and approve pull requests".

This switches `gh pr create` in `prepare-release` and `release` (`sync_gosum`) to `GITHUBBOT_TOKEN` (daytonaBot) via `GH_TOKEN`. Branch pushes and tag pushes stay on `GITHUB_TOKEN`. daytonaBot is added to the CLA allowlist so its PRs pass the gate.

To confirm before merge: the `GITHUBBOT_TOKEN` PAT must cover `daytona/clients` (PR create). Today it is only exercised against `daytonaio/homebrew-cli`, so if it is a fine-grained PAT scoped to that repo it needs `daytona/clients` added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release PRs are now opened with the `daytonaBot` token via `GH_TOKEN` so `pull_request` workflows run, and we fail fast if `GITHUBBOT_TOKEN` is missing to avoid CI‑less PRs. `daytonaBot` is added to the CLA allowlist; branch/tag pushes still use `GITHUB_TOKEN`.

- **Migration**
  - Ensure `GITHUBBOT_TOKEN` has PR scope for `daytona/clients`.

<sup>Written for commit 96b3fadc0683cd893c404bc0e008554026087a3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

