### PR TITLE
feat(api-client, sdk): track sandbox snapshot captures by ID

### DIFF
--- a/api-client-go/api/openapi.yaml
+++ b/api-client-go/api/openapi.yaml
@@ -2633,12 +2633,14 @@ paths:
               $ref: "#/components/schemas/CreateSandboxSnapshot"
         required: true
       responses:
-        "200":
+        "202":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Sandbox"
+                $ref: "#/components/schemas/SnapshotDto"
           description: Snapshot creation has been initiated
+        "409":
+          description: A snapshot with the requested name already exists
       security:
       - bearer: []
       - oauth2:
@@ -14964,6 +14966,7 @@ components:
     SnapshotState:
       enum:
       - building
+      - capturing
       - pending
       - pulling
       - active
@@ -15097,9 +15100,9 @@ components:
       type: object
     PaginatedSnapshots:
       example:
-        total: 2.3021358869347655
-        totalPages: 9.301444243932576
-        page: 7.061401241503109
+        total: 0.8008281904610115
+        totalPages: 1.4658129805029452
+        page: 6.027456183070403
         items:
         - imageName: imageName
           buildInfo: ""

--- a/api-client-go/api_sandbox.go
+++ b/api-client-go/api_sandbox.go
@@ -73,8 +73,8 @@ type SandboxAPI interface {
 	CreateSandboxSnapshot(ctx context.Context, sandboxIdOrName string) SandboxAPICreateSandboxSnapshotRequest
 
 	// CreateSandboxSnapshotExecute executes the request
-	//  @return Sandbox
-	CreateSandboxSnapshotExecute(r SandboxAPICreateSandboxSnapshotRequest) (*Sandbox, *http.Response, error)
+	//  @return SnapshotDto
+	CreateSandboxSnapshotExecute(r SandboxAPICreateSandboxSnapshotRequest) (*SnapshotDto, *http.Response, error)
 
 	/*
 	CreateSshAccess Create SSH access for sandbox
@@ -985,7 +985,7 @@ func (r SandboxAPICreateSandboxSnapshotRequest) XDaytonaOrganizationID(xDaytonaO
 	return r
 }
 
-func (r SandboxAPICreateSandboxSnapshotRequest) Execute() (*Sandbox, *http.Response, error) {
+func (r SandboxAPICreateSandboxSnapshotRequest) Execute() (*SnapshotDto, *http.Response, error) {
 	return r.ApiService.CreateSandboxSnapshotExecute(r)
 }
 
@@ -1005,13 +1005,13 @@ func (a *SandboxAPIService) CreateSandboxSnapshot(ctx context.Context, sandboxId
 }
 
 // Execute executes the request
-//  @return Sandbox
-func (a *SandboxAPIService) CreateSandboxSnapshotExecute(r SandboxAPICreateSandboxSnapshotRequest) (*Sandbox, *http.Response, error) {
+//  @return SnapshotDto
+func (a *SandboxAPIService) CreateSandboxSnapshotExecute(r SandboxAPICreateSandboxSnapshotRequest) (*SnapshotDto, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
 		formFiles            []formFile
-		localVarReturnValue  *Sandbox
+		localVarReturnValue  *SnapshotDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SandboxAPIService.CreateSandboxSnapshot")

--- a/api-client-go/model_snapshot_state.go
+++ b/api-client-go/model_snapshot_state.go
@@ -21,6 +21,7 @@ type SnapshotState string
 // List of SnapshotState
 const (
 	SNAPSHOTSTATE_BUILDING SnapshotState = "building"
+	SNAPSHOTSTATE_CAPTURING SnapshotState = "capturing"
 	SNAPSHOTSTATE_PENDING SnapshotState = "pending"
 	SNAPSHOTSTATE_PULLING SnapshotState = "pulling"
 	SNAPSHOTSTATE_ACTIVE SnapshotState = "active"
@@ -34,6 +35,7 @@ const (
 // All allowed values of SnapshotState enum
 var AllowedSnapshotStateEnumValues = []SnapshotState{
 	"building",
+	"capturing",
 	"pending",
 	"pulling",
 	"active",

--- a/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
@@ -49,6 +49,7 @@ import io.daytona.api.client.model.SandboxListSortDirection;
 import io.daytona.api.client.model.SandboxListSortField;
 import io.daytona.api.client.model.SandboxState;
 import io.daytona.api.client.model.SignedPortPreviewUrl;
+import io.daytona.api.client.model.SnapshotDto;
 import io.daytona.api.client.model.SshAccessDto;
 import io.daytona.api.client.model.SshAccessValidationDto;
 import io.daytona.api.client.model.ToolboxProxyUrl;
@@ -521,7 +522,8 @@ public class SandboxApi {
      <table border="1">
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 202 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with the requested name already exists </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createSandboxSnapshotCall(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
@@ -597,17 +599,18 @@ public class SandboxApi {
      * @param sandboxIdOrName  (required)
      * @param createSandboxSnapshot  (required)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
-     * @return Sandbox
+     * @return SnapshotDto
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table border="1">
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 202 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with the requested name already exists </td><td>  -  </td></tr>
      </table>
      */
-    public Sandbox createSandboxSnapshot(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
-        ApiResponse<Sandbox> localVarResp = createSandboxSnapshotWithHttpInfo(sandboxIdOrName, createSandboxSnapshot, xDaytonaOrganizationID);
+    public SnapshotDto createSandboxSnapshot(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
+        ApiResponse<SnapshotDto> localVarResp = createSandboxSnapshotWithHttpInfo(sandboxIdOrName, createSandboxSnapshot, xDaytonaOrganizationID);
         return localVarResp.getData();
     }
 
@@ -617,18 +620,19 @@ public class SandboxApi {
      * @param sandboxIdOrName  (required)
      * @param createSandboxSnapshot  (required)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
-     * @return ApiResponse&lt;Sandbox&gt;
+     * @return ApiResponse&lt;SnapshotDto&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table border="1">
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 202 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with the requested name already exists </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Sandbox> createSandboxSnapshotWithHttpInfo(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
+    public ApiResponse<SnapshotDto> createSandboxSnapshotWithHttpInfo(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
         okhttp3.Call localVarCall = createSandboxSnapshotValidateBeforeCall(sandboxIdOrName, createSandboxSnapshot, xDaytonaOrganizationID, null);
-        Type localVarReturnType = new TypeToken<Sandbox>(){}.getType();
+        Type localVarReturnType = new TypeToken<SnapshotDto>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
@@ -645,13 +649,14 @@ public class SandboxApi {
      <table border="1">
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 202 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with the requested name already exists </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createSandboxSnapshotAsync(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback<Sandbox> _callback) throws ApiException {
+    public okhttp3.Call createSandboxSnapshotAsync(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback<SnapshotDto> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = createSandboxSnapshotValidateBeforeCall(sandboxIdOrName, createSandboxSnapshot, xDaytonaOrganizationID, _callback);
-        Type localVarReturnType = new TypeToken<Sandbox>(){}.getType();
+        Type localVarReturnType = new TypeToken<SnapshotDto>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }

--- a/api-client-java/src/main/java/io/daytona/api/client/model/SnapshotState.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/SnapshotState.java
@@ -31,6 +31,8 @@ public enum SnapshotState {
   
   BUILDING("building"),
   
+  CAPTURING("capturing"),
+  
   PENDING("pending"),
   
   PULLING("pulling"),

--- a/api-client-java/src/test/java/io/daytona/api/client/api/SandboxApiTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/api/SandboxApiTest.java
@@ -36,6 +36,7 @@ import io.daytona.api.client.model.SandboxListSortDirection;
 import io.daytona.api.client.model.SandboxListSortField;
 import io.daytona.api.client.model.SandboxState;
 import io.daytona.api.client.model.SignedPortPreviewUrl;
+import io.daytona.api.client.model.SnapshotDto;
 import io.daytona.api.client.model.SshAccessDto;
 import io.daytona.api.client.model.SshAccessValidationDto;
 import io.daytona.api.client.model.ToolboxProxyUrl;
@@ -109,7 +110,7 @@ public class SandboxApiTest {
         String sandboxIdOrName = null;
         CreateSandboxSnapshot createSandboxSnapshot = null;
         String xDaytonaOrganizationID = null;
-        Sandbox response = api.createSandboxSnapshot(sandboxIdOrName, createSandboxSnapshot, xDaytonaOrganizationID);
+        SnapshotDto response = api.createSandboxSnapshot(sandboxIdOrName, createSandboxSnapshot, xDaytonaOrganizationID);
         // TODO: test validations
     }
 

--- a/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
+++ b/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
@@ -40,6 +40,7 @@ from daytona_api_client_async.models.sandbox_list_sort_direction import SandboxL
 from daytona_api_client_async.models.sandbox_list_sort_field import SandboxListSortField
 from daytona_api_client_async.models.sandbox_state import SandboxState
 from daytona_api_client_async.models.signed_port_preview_url import SignedPortPreviewUrl
+from daytona_api_client_async.models.snapshot_dto import SnapshotDto
 from daytona_api_client_async.models.ssh_access_dto import SshAccessDto
 from daytona_api_client_async.models.ssh_access_validation_dto import SshAccessValidationDto
 from daytona_api_client_async.models.toolbox_proxy_url import ToolboxProxyUrl
@@ -920,7 +921,7 @@ class SandboxApi:
         _content_type: Optional[StrictStr] = None,
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> Sandbox:
+    ) -> SnapshotDto:
         """Create a snapshot from a sandbox
 
 
@@ -963,7 +964,8 @@ class SandboxApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "Sandbox",
+            '202': "SnapshotDto",
+            '409': None,
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -994,7 +996,7 @@ class SandboxApi:
         _content_type: Optional[StrictStr] = None,
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> ApiResponse[Sandbox]:
+    ) -> ApiResponse[SnapshotDto]:
         """Create a snapshot from a sandbox
 
 
@@ -1037,7 +1039,8 @@ class SandboxApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "Sandbox",
+            '202': "SnapshotDto",
+            '409': None,
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -1111,7 +1114,8 @@ class SandboxApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "Sandbox",
+            '202': "SnapshotDto",
+            '409': None,
         }
         response_data = await self.api_client.call_api(
             *_param,

--- a/api-client-python-async/daytona_api_client_async/models/snapshot_state.py
+++ b/api-client-python-async/daytona_api_client_async/models/snapshot_state.py
@@ -28,6 +28,7 @@ class SnapshotState(str, Enum):
     allowed enum values
     """
     BUILDING = 'building'
+    CAPTURING = 'capturing'
     PENDING = 'pending'
     PULLING = 'pulling'
     ACTIVE = 'active'

--- a/api-client-python/daytona_api_client/api/sandbox_api.py
+++ b/api-client-python/daytona_api_client/api/sandbox_api.py
@@ -40,6 +40,7 @@ from daytona_api_client.models.sandbox_list_sort_direction import SandboxListSor
 from daytona_api_client.models.sandbox_list_sort_field import SandboxListSortField
 from daytona_api_client.models.sandbox_state import SandboxState
 from daytona_api_client.models.signed_port_preview_url import SignedPortPreviewUrl
+from daytona_api_client.models.snapshot_dto import SnapshotDto
 from daytona_api_client.models.ssh_access_dto import SshAccessDto
 from daytona_api_client.models.ssh_access_validation_dto import SshAccessValidationDto
 from daytona_api_client.models.toolbox_proxy_url import ToolboxProxyUrl
@@ -920,7 +921,7 @@ class SandboxApi:
         _content_type: Optional[StrictStr] = None,
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> Sandbox:
+    ) -> SnapshotDto:
         """Create a snapshot from a sandbox
 
 
@@ -963,7 +964,8 @@ class SandboxApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "Sandbox",
+            '202': "SnapshotDto",
+            '409': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -994,7 +996,7 @@ class SandboxApi:
         _content_type: Optional[StrictStr] = None,
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> ApiResponse[Sandbox]:
+    ) -> ApiResponse[SnapshotDto]:
         """Create a snapshot from a sandbox
 
 
@@ -1037,7 +1039,8 @@ class SandboxApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "Sandbox",
+            '202': "SnapshotDto",
+            '409': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -1111,7 +1114,8 @@ class SandboxApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "Sandbox",
+            '202': "SnapshotDto",
+            '409': None,
         }
         response_data = self.api_client.call_api(
             *_param,

--- a/api-client-python/daytona_api_client/models/snapshot_state.py
+++ b/api-client-python/daytona_api_client/models/snapshot_state.py
@@ -28,6 +28,7 @@ class SnapshotState(str, Enum):
     allowed enum values
     """
     BUILDING = 'building'
+    CAPTURING = 'capturing'
     PENDING = 'pending'
     PULLING = 'pulling'
     ACTIVE = 'active'

--- a/api-client-ruby/lib/daytona_api_client/api/sandbox_api.rb
+++ b/api-client-ruby/lib/daytona_api_client/api/sandbox_api.rb
@@ -221,7 +221,7 @@ module DaytonaApiClient
     # @param create_sandbox_snapshot [CreateSandboxSnapshot] 
     # @param [Hash] opts the optional parameters
     # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID
-    # @return [Sandbox]
+    # @return [SnapshotDto]
     def create_sandbox_snapshot(sandbox_id_or_name, create_sandbox_snapshot, opts = {})
       data, _status_code, _headers = create_sandbox_snapshot_with_http_info(sandbox_id_or_name, create_sandbox_snapshot, opts)
       data
@@ -232,7 +232,7 @@ module DaytonaApiClient
     # @param create_sandbox_snapshot [CreateSandboxSnapshot] 
     # @param [Hash] opts the optional parameters
     # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID
-    # @return [Array<(Sandbox, Integer, Hash)>] Sandbox data, response status code and response headers
+    # @return [Array<(SnapshotDto, Integer, Hash)>] SnapshotDto data, response status code and response headers
     def create_sandbox_snapshot_with_http_info(sandbox_id_or_name, create_sandbox_snapshot, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: SandboxApi.create_sandbox_snapshot ...'
@@ -269,7 +269,7 @@ module DaytonaApiClient
       post_body = opts[:debug_body] || @api_client.object_to_http_body(create_sandbox_snapshot)
 
       # return_type
-      return_type = opts[:debug_return_type] || 'Sandbox'
+      return_type = opts[:debug_return_type] || 'SnapshotDto'
 
       # auth_names
       auth_names = opts[:debug_auth_names] || ['bearer', 'oauth2']

--- a/api-client-ruby/lib/daytona_api_client/models/snapshot_state.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/snapshot_state.rb
@@ -16,6 +16,7 @@ require 'time'
 module DaytonaApiClient
   class SnapshotState
     BUILDING = "building".freeze
+    CAPTURING = "capturing".freeze
     PENDING = "pending".freeze
     PULLING = "pulling".freeze
     ACTIVE = "active".freeze
@@ -26,7 +27,7 @@ module DaytonaApiClient
     UNKNOWN_DEFAULT_OPEN_API = "unknown_default_open_api".freeze
 
     def self.all_vars
-      @all_vars ||= [BUILDING, PENDING, PULLING, ACTIVE, INACTIVE, ERROR, BUILD_FAILED, REMOVING, UNKNOWN_DEFAULT_OPEN_API].freeze
+      @all_vars ||= [BUILDING, CAPTURING, PENDING, PULLING, ACTIVE, INACTIVE, ERROR, BUILD_FAILED, REMOVING, UNKNOWN_DEFAULT_OPEN_API].freeze
     end
 
     # Builds the enum from string

--- a/api-client/src/api/sandbox-api.ts
+++ b/api-client/src/api/sandbox-api.ts
@@ -62,6 +62,8 @@ import type { SandboxState } from '../models';
 // @ts-ignore
 import type { SignedPortPreviewUrl } from '../models';
 // @ts-ignore
+import type { SnapshotDto } from '../models';
+// @ts-ignore
 import type { SshAccessDto } from '../models';
 // @ts-ignore
 import type { SshAccessValidationDto } from '../models';
@@ -2509,7 +2511,7 @@ export const SandboxApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async createSandboxSnapshot(sandboxIdOrName: string, createSandboxSnapshot: CreateSandboxSnapshot, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Sandbox>> {
+        async createSandboxSnapshot(sandboxIdOrName: string, createSandboxSnapshot: CreateSandboxSnapshot, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SnapshotDto>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.createSandboxSnapshot(sandboxIdOrName, createSandboxSnapshot, xDaytonaOrganizationID, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['SandboxApi.createSandboxSnapshot']?.[localVarOperationServerIndex]?.url;
@@ -3207,7 +3209,7 @@ export const SandboxApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createSandboxSnapshot(sandboxIdOrName: string, createSandboxSnapshot: CreateSandboxSnapshot, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): AxiosPromise<Sandbox> {
+        createSandboxSnapshot(sandboxIdOrName: string, createSandboxSnapshot: CreateSandboxSnapshot, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): AxiosPromise<SnapshotDto> {
             return localVarFp.createSandboxSnapshot(sandboxIdOrName, createSandboxSnapshot, xDaytonaOrganizationID, options).then((request) => request(axios, basePath));
         },
         /**

--- a/api-client/src/models/snapshot-state.ts
+++ b/api-client/src/models/snapshot-state.ts
@@ -17,6 +17,7 @@
 
 export const SnapshotState = {
     BUILDING: 'building',
+    CAPTURING: 'capturing',
     PENDING: 'pending',
     PULLING: 'pulling',
     ACTIVE: 'active',

--- a/artifacts/sdk-docs/go-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/go-sdk/daytona.mdx
@@ -4460,7 +4460,7 @@ func (s *Sandbox) ExperimentalCreateSnapshot(ctx context.Context, name string) e
 
 ExperimentalCreateSnapshot creates a snapshot from the current state of the sandbox with a default timeout of 60 seconds.
 
-This captures the sandbox's filesystem into a reusable snapshot that can be used to create new sandboxes. The sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
+This captures the sandbox's filesystem into a reusable snapshot that can be used to create new sandboxes. The method waits for the accepted snapshot to become active.
 
 Example:
 

--- a/artifacts/sdk-docs/java-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/java-sdk/sandbox.mdx
@@ -440,12 +440,11 @@ public void experimentalCreateSnapshot(String name, long timeoutSeconds)
 ```
 
 Creates a snapshot from the current state of this Sandbox.
-The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
 
 **Parameters**:
 
 - `name` _String_ - name for the new snapshot
-- `timeoutSeconds` _long_ - reserved timeout parameter for parity with other SDKs
+- `timeoutSeconds` _long_ - maximum time to wait; 0 disables the timeout
 
 **Throws**:
 

--- a/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
@@ -1117,16 +1117,19 @@ def experimental_create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
 ```
 
 Creates a snapshot from the current state of the Sandbox.
-The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
 
 **Parameters**:
 
 - `name` _String_ - Name for the new snapshot
-- `timeout` _Numeric_ - Maximum wait time in seconds (defaults to 60 s)
+- `timeout` _Numeric_ - Maximum wait time in seconds (defaults to 60 s; 0 disables the timeout)
 
 **Returns**:
 
 - `void`
+
+**Raises**:
+
+- `Sdk:Error` -
 
 #### pause()
 

--- a/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
@@ -71,6 +71,7 @@ new Sandbox(
    clientConfig: Configuration, 
    axiosInstance: AxiosInstance, 
    sandboxApi: SandboxApi, 
+   snapshotsApi: SnapshotsApi, 
    getAnalyticsApiUrl: () => Promise<string>): Sandbox
 ```
 
@@ -82,6 +83,7 @@ Creates a new Sandbox instance
 - `clientConfig` _Configuration_
 - `axiosInstance` _AxiosInstance_
 - `sandboxApi` _SandboxApi_
+- `snapshotsApi` _SnapshotsApi_
 - `getAnalyticsApiUrl` _\(\) =\> Promise\<string\>_
 
 

--- a/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
@@ -100,8 +100,8 @@ _experimental_createSnapshot(name: string, timeout?: number): Promise<void>
 Creates a snapshot from the current state of the Sandbox.
 
 This captures the Sandbox's filesystem into a reusable snapshot that can be
-used to create new Sandboxes. The Sandbox will temporarily enter a
-'snapshotting' state and return to its previous state when complete.
+used to create new Sandboxes. The method waits for the accepted snapshot
+to become active.
 
 **Parameters**:
 

--- a/openapi-specs/api.json
+++ b/openapi-specs/api.json
@@ -3801,15 +3801,18 @@
           }
         },
         "responses": {
-          "200": {
+          "202": {
             "description": "Snapshot creation has been initiated",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Sandbox"
+                  "$ref": "#/components/schemas/SnapshotDto"
                 }
               }
             }
+          },
+          "409": {
+            "description": "A snapshot with the requested name already exists"
           }
         },
         "security": [
@@ -19482,6 +19485,7 @@
         "type": "string",
         "enum": [
           "building",
+          "capturing",
           "pending",
           "pulling",
           "active",

--- a/sdk-go/pkg/daytona/sandbox.go
+++ b/sdk-go/pkg/daytona/sandbox.go
@@ -1359,8 +1359,8 @@ func (s *Sandbox) doExperimentalForkWithTimeout(ctx context.Context, name *strin
 // with a default timeout of 60 seconds.
 //
 // This captures the sandbox's filesystem into a reusable snapshot that can be
-// used to create new sandboxes. The sandbox will temporarily enter a
-// 'snapshotting' state and return to its previous state when complete.
+// used to create new sandboxes. The method waits for the accepted snapshot
+// to become active.
 //
 // Example:
 //
@@ -1400,40 +1400,72 @@ func (s *Sandbox) doExperimentalCreateSnapshotWithTimeout(ctx context.Context, n
 	req := apiclient.NewCreateSandboxSnapshot(name)
 
 	authCtx := s.client.getAuthContext(ctx)
-	_, httpResp, err := s.client.apiClient.SandboxAPI.CreateSandboxSnapshot(authCtx, s.ID).CreateSandboxSnapshot(*req).Execute()
+	accepted, httpResp, err := s.client.apiClient.SandboxAPI.CreateSandboxSnapshot(authCtx, s.ID).CreateSandboxSnapshot(*req).Execute()
 	if err != nil {
 		return errors.ConvertAPIError(err, httpResp)
 	}
-
-	if err := s.RefreshData(ctx); err != nil {
-		return err
+	if accepted == nil || accepted.GetId() == "" {
+		return errors.NewDaytonaError("Failed to create snapshot. Didn't receive a snapshot ID from the server API.", 0, nil)
 	}
 
-	return s.waitForSnapshotComplete(ctx)
+	return s.waitForSnapshotComplete(ctx, accepted.GetId())
 }
 
-func (s *Sandbox) waitForSnapshotComplete(ctx context.Context) error {
+func (s *Sandbox) waitForSnapshotComplete(ctx context.Context, snapshotID string) error {
 	checkInterval := 100 * time.Millisecond
 	startTime := time.Now()
 
-	for s.State == apiclient.SANDBOXSTATE_SNAPSHOTTING {
-		if err := s.RefreshData(ctx); err != nil {
-			return err
+	for {
+		snapshot, httpResp, err := s.client.apiClient.SnapshotsAPI.GetSnapshot(
+			s.client.getAuthContext(ctx),
+			snapshotID,
+		).Execute()
+		if err != nil {
+			return errors.ConvertAPIError(err, httpResp)
 		}
-
-		if s.State == apiclient.SANDBOXSTATE_ERROR || s.State == apiclient.SANDBOXSTATE_BUILD_FAILED {
+		if snapshot == nil || snapshot.GetId() != snapshotID {
 			return errors.NewDaytonaError(
-				fmt.Sprintf("Sandbox %s snapshot failed with state: %s", s.ID, s.State), 0, nil,
+				fmt.Sprintf("Snapshot lookup for %s returned an invalid response", snapshotID), 0, nil,
 			)
 		}
 
-		if s.State != apiclient.SANDBOXSTATE_SNAPSHOTTING {
+		switch snapshot.GetState() {
+		case apiclient.SNAPSHOTSTATE_ACTIVE:
+			_ = s.RefreshData(ctx)
 			return nil
+		case apiclient.SNAPSHOTSTATE_ERROR, apiclient.SNAPSHOTSTATE_BUILD_FAILED:
+			var errorReason string
+			if reason, ok := snapshot.GetErrorReasonOk(); ok && reason != nil {
+				errorReason = *reason
+			}
+			return errors.NewDaytonaError(
+				fmt.Sprintf(
+					"Snapshot %s failed with state: %s, error reason: %s",
+					snapshot.GetId(),
+					snapshot.GetState(),
+					errorReason,
+				),
+				0,
+				nil,
+			)
 		}
 
 		select {
 		case <-ctx.Done():
-			return errors.NewDaytonaError("Sandbox snapshot did not complete within the timeout period", 0, nil)
+			if ctx.Err() == context.DeadlineExceeded {
+				return errors.NewDaytonaTimeoutError(
+					fmt.Sprintf("Timed out waiting for snapshot %s; capture continues on the server", snapshotID),
+				)
+			}
+			return errors.NewDaytonaError(
+				fmt.Sprintf(
+					"Stopped waiting for snapshot %s: %v; capture continues on the server",
+					snapshotID,
+					ctx.Err(),
+				),
+				0,
+				nil,
+			)
 		case <-time.After(checkInterval):
 		}
 
@@ -1441,7 +1473,6 @@ func (s *Sandbox) waitForSnapshotComplete(ctx context.Context) error {
 			checkInterval = min(time.Duration(float64(checkInterval)*1.1), 1*time.Second)
 		}
 	}
-	return nil
 }
 
 // Pause pauses the Sandbox, freezing all running processes.

--- a/sdk-go/pkg/daytona/sandbox_test.go
+++ b/sdk-go/pkg/daytona/sandbox_test.go
@@ -574,10 +574,10 @@ func TestSandboxExperimentalOperations(t *testing.T) {
 
 	t.Run("create snapshot reports accepted snapshot failure", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.Method == http.MethodPost:
+			switch r.Method {
+			case http.MethodPost:
 				writeJSONResponse(t, w, http.StatusAccepted, testSnapshotPayload("snapshot-id", "snap-name", apiclient.SNAPSHOTSTATE_CAPTURING))
-			case r.Method == http.MethodGet:
+			case http.MethodGet:
 				payload := testSnapshotPayload("snapshot-id", "snap-name", apiclient.SNAPSHOTSTATE_ERROR)
 				payload["errorReason"] = "capture failed"
 				writeJSONResponse(t, w, http.StatusOK, payload)

--- a/sdk-go/pkg/daytona/sandbox_test.go
+++ b/sdk-go/pkg/daytona/sandbox_test.go
@@ -545,21 +545,23 @@ func TestSandboxExperimentalOperations(t *testing.T) {
 		assert.Equal(t, "forked", forked.ID)
 	})
 
-	t.Run("create snapshot waits until snapshotting finishes", func(t *testing.T) {
-		var getCount int
+	t.Run("create snapshot polls accepted snapshot ID until active", func(t *testing.T) {
+		var snapshotGetCount int
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.Method {
-			case http.MethodPost:
-				w.WriteHeader(http.StatusOK)
-			case http.MethodGet:
-				getCount++
-				state := apiclient.SANDBOXSTATE_SNAPSHOTTING
-				if getCount > 1 {
-					state = apiclient.SANDBOXSTATE_STARTED
+			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/sandbox/sb/snapshot":
+				writeJSONResponse(t, w, http.StatusAccepted, testSnapshotPayload("snapshot-id", "snap-name", apiclient.SNAPSHOTSTATE_CAPTURING))
+			case r.Method == http.MethodGet && r.URL.Path == "/snapshots/snapshot-id":
+				snapshotGetCount++
+				state := apiclient.SNAPSHOTSTATE_CAPTURING
+				if snapshotGetCount > 1 {
+					state = apiclient.SNAPSHOTSTATE_ACTIVE
 				}
-				writeJSONResponse(t, w, http.StatusOK, testSandboxPayload("sb", "sandbox", state))
+				writeJSONResponse(t, w, http.StatusOK, testSnapshotPayload("snapshot-id", "snap-name", state))
+			case r.Method == http.MethodGet && r.URL.Path == "/sandbox/sb":
+				writeJSONResponse(t, w, http.StatusOK, testSandboxPayload("sb", "sandbox", apiclient.SANDBOXSTATE_STARTED))
 			default:
-				w.WriteHeader(http.StatusOK)
+				http.NotFound(w, r)
 			}
 		}))
 		defer server.Close()
@@ -567,6 +569,45 @@ func TestSandboxExperimentalOperations(t *testing.T) {
 		client := createTestClientWithServer(t, server)
 		sandbox := newSandboxForTest(client, "sb", "sandbox", apiclient.SANDBOXSTATE_STARTED, "us", 0, -1, false, nil)
 		require.NoError(t, sandbox.ExperimentalCreateSnapshotWithTimeout(context.Background(), "snap-name", 2*time.Second))
+		assert.Equal(t, 2, snapshotGetCount)
+	})
+
+	t.Run("create snapshot reports accepted snapshot failure", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost:
+				writeJSONResponse(t, w, http.StatusAccepted, testSnapshotPayload("snapshot-id", "snap-name", apiclient.SNAPSHOTSTATE_CAPTURING))
+			case r.Method == http.MethodGet:
+				payload := testSnapshotPayload("snapshot-id", "snap-name", apiclient.SNAPSHOTSTATE_ERROR)
+				payload["errorReason"] = "capture failed"
+				writeJSONResponse(t, w, http.StatusOK, payload)
+			}
+		}))
+		defer server.Close()
+
+		client := createTestClientWithServer(t, server)
+		sandbox := newSandboxForTest(client, "sb", "sandbox", apiclient.SANDBOXSTATE_STARTED, "us", 0, -1, false, nil)
+		err := sandbox.ExperimentalCreateSnapshotWithTimeout(context.Background(), "snap-name", 2*time.Second)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Snapshot snapshot-id failed with state: error, error reason: capture failed")
+	})
+
+	t.Run("create snapshot timeout leaves server capture running", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			state := apiclient.SNAPSHOTSTATE_CAPTURING
+			status := http.StatusOK
+			if r.Method == http.MethodPost {
+				status = http.StatusAccepted
+			}
+			writeJSONResponse(t, w, status, testSnapshotPayload("snapshot-id", "snap-name", state))
+		}))
+		defer server.Close()
+
+		client := createTestClientWithServer(t, server)
+		sandbox := newSandboxForTest(client, "sb", "sandbox", apiclient.SANDBOXSTATE_STARTED, "us", 0, -1, false, nil)
+		err := sandbox.ExperimentalCreateSnapshotWithTimeout(context.Background(), "snap-name", 10*time.Millisecond)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Timed out waiting for snapshot snapshot-id; capture continues on the server")
 	})
 }
 

--- a/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
@@ -4,8 +4,11 @@
 package io.daytona.sdk;
 
 import io.daytona.api.client.api.SandboxApi;
+import io.daytona.api.client.api.SnapshotsApi;
 import io.daytona.api.client.model.BuildInfo;
 import io.daytona.api.client.model.CreateSandboxSnapshot;
+import io.daytona.api.client.model.SnapshotDto;
+import io.daytona.api.client.model.SnapshotState;
 import io.daytona.api.client.model.ForkSandbox;
 import io.daytona.analytics.api.client.model.ModelsMetricPoint;
 import io.daytona.api.client.model.MetricDataPoint;
@@ -18,6 +21,8 @@ import io.daytona.api.client.model.ToolboxProxyUrl;
 import io.daytona.api.client.model.UpdateSandboxNetworkSettings;
 import io.daytona.api.client.model.UpdateSandboxSecrets;
 import io.daytona.sdk.exception.DaytonaException;
+import io.daytona.sdk.exception.DaytonaTimeoutException;
+import io.daytona.sdk.exception.DaytonaValidationException;
 import io.daytona.sdk.model.SandboxMetrics;
 import io.daytona.toolbox.client.api.SystemApi;
 import io.daytona.toolbox.client.model.SystemMetrics;
@@ -30,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Represents a Daytona Sandbox instance.
@@ -51,6 +57,7 @@ public class Sandbox {
             List.copyOf(SANDBOX_METRIC_FIELD_BY_NAME.keySet());
 
     private final SandboxApi sandboxApi;
+    private final SnapshotsApi snapshotsApi;
     private final DaytonaConfig config;
     private final io.daytona.toolbox.client.ApiClient toolboxApiClient;
     private final io.daytona.toolbox.client.api.InfoApi infoApi;
@@ -109,6 +116,7 @@ public class Sandbox {
     Sandbox(SandboxApi sandboxApi, DaytonaConfig config, io.daytona.api.client.model.Sandbox data,
             java.util.function.Supplier<String> analyticsApiUrlProvider) {
         this.sandboxApi = sandboxApi;
+        this.snapshotsApi = new SnapshotsApi(sandboxApi.getApiClient());
         this.config = config;
         this.apiKey = config.getApiKey();
         this.analyticsApiUrlProvider = analyticsApiUrlProvider;
@@ -127,6 +135,7 @@ public class Sandbox {
     Sandbox(SandboxApi sandboxApi, DaytonaConfig config, SandboxListItem data,
             java.util.function.Supplier<String> analyticsApiUrlProvider) {
         this.sandboxApi = sandboxApi;
+        this.snapshotsApi = new SnapshotsApi(sandboxApi.getApiClient());
         this.config = config;
         this.apiKey = config.getApiKey();
         this.analyticsApiUrlProvider = analyticsApiUrlProvider;
@@ -753,38 +762,63 @@ public class Sandbox {
 
     /**
      * Creates a snapshot from the current state of this Sandbox.
-     * The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
      *
      * @param name name for the new snapshot
-     * @param timeoutSeconds reserved timeout parameter for parity with other SDKs
+     * @param timeoutSeconds maximum time to wait; 0 disables the timeout
      * @throws DaytonaException if the snapshot operation fails
      */
     public void experimentalCreateSnapshot(String name, long timeoutSeconds) {
+        if (timeoutSeconds < 0) {
+            throw new DaytonaValidationException("Timeout must be a non-negative number");
+        }
+
+        long startedAt = System.nanoTime();
         CreateSandboxSnapshot req = new CreateSandboxSnapshot();
         req.setName(name);
-        ExceptionMapper.callMain(() -> sandboxApi.createSandboxSnapshot(id, req, null));
-        refreshData();
-        waitForSnapshotComplete(timeoutSeconds);
+        SnapshotDto accepted = ExceptionMapper.callMain(() -> sandboxApi.createSandboxSnapshot(id, req, null));
+        String snapshotId = accepted == null ? null : accepted.getId();
+        if (snapshotId == null || snapshotId.isEmpty()) {
+            throw new DaytonaException("Failed to create snapshot. Didn't receive a snapshot ID from the server API.");
+        }
+
+        long deadline = timeoutSeconds == 0
+                ? Long.MAX_VALUE
+                : startedAt + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        waitForSnapshotComplete(snapshotId, deadline);
     }
 
-    private void waitForSnapshotComplete(long timeoutSeconds) {
-        long startedAt = System.currentTimeMillis();
-        while ("snapshotting".equalsIgnoreCase(state)) {
-            refreshData();
-            if ("error".equalsIgnoreCase(state) || "build_failed".equalsIgnoreCase(state)) {
-                throw new DaytonaException("Sandbox snapshot failed with state: " + state);
+    private void waitForSnapshotComplete(String snapshotId, long deadline) {
+        while (true) {
+            if (System.nanoTime() >= deadline) {
+                throw new DaytonaTimeoutException(
+                        "Timed out waiting for snapshot " + snapshotId + "; capture continues on the server");
             }
-            if (!"snapshotting".equalsIgnoreCase(state)) {
+
+            SnapshotDto snapshot = ExceptionMapper.callMain(() -> snapshotsApi.getSnapshot(snapshotId, null));
+            if (snapshot == null || !snapshotId.equals(snapshot.getId())) {
+                throw new DaytonaException("Snapshot lookup for " + snapshotId + " returned an invalid response");
+            }
+
+            if (snapshot.getState() == SnapshotState.ACTIVE) {
+                try {
+                    refreshData();
+                } catch (DaytonaException ignored) {
+                    // Best-effort local cleanup after definitive server success.
+                }
                 return;
             }
-            if (timeoutSeconds > 0 && (System.currentTimeMillis() - startedAt) > timeoutSeconds * 1000L) {
-                throw new DaytonaException("Sandbox snapshot did not complete before timeout");
+            if (snapshot.getState() == SnapshotState.ERROR || snapshot.getState() == SnapshotState.BUILD_FAILED) {
+                throw new DaytonaException(
+                        "Snapshot " + snapshot.getId() + " failed with state: " + snapshot.getState()
+                                + ", error reason: " + snapshot.getErrorReason());
             }
+
             try {
                 Thread.sleep(250);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new DaytonaException("Interrupted while waiting for snapshot complete", e);
+                throw new DaytonaException(
+                        "Stopped waiting for snapshot " + snapshotId + "; capture continues on the server", e);
             }
         }
     }

--- a/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
@@ -674,6 +674,12 @@ class E2ETest {
         assertThat(response.getResult()).contains("restarted");
     }
 
+    @Test
+    @Order(23)
+    void snapshotCapturePollsTheAcceptedSnapshotToActive() {
+        sandbox.experimentalCreateSnapshot(unique("sdk-java-capture"), 3);
+    }
+
     private io.daytona.api.client.model.Sandbox fetchSandboxDto() throws Exception {
         return sandboxApi.getSandbox(sandbox.getId(), null, null);
     }

--- a/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
@@ -674,12 +674,6 @@ class E2ETest {
         assertThat(response.getResult()).contains("restarted");
     }
 
-    @Test
-    @Order(23)
-    void snapshotCapturePollsTheAcceptedSnapshotToActive() {
-        sandbox.experimentalCreateSnapshot(unique("sdk-java-capture"), 3);
-    }
-
     private io.daytona.api.client.model.Sandbox fetchSandboxDto() throws Exception {
         return sandboxApi.getSandbox(sandbox.getId(), null, null);
     }

--- a/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
@@ -102,11 +102,16 @@ class E2ETest {
         lspFilePath = lspProjectDir + "/sample.py";
         createdVolumeName = unique("e2e-vol");
 
-        CreateSandboxFromSnapshotParams params = new CreateSandboxFromSnapshotParams();
-        params.setName(sandboxName);
-        params.setLanguage("python");
-        params.setLabels(Collections.singletonMap("purpose", "e2e-test"));
-        sandbox = daytona.create(params, 60);
+        String existingSandboxId = System.getenv("DAYTONA_EXISTING_SANDBOX_ID");
+        if (existingSandboxId != null && !existingSandboxId.isEmpty()) {
+            sandbox = daytona.get(existingSandboxId);
+        } else {
+            CreateSandboxFromSnapshotParams params = new CreateSandboxFromSnapshotParams();
+            params.setName(sandboxName);
+            params.setLanguage("python");
+            params.setLabels(Collections.singletonMap("purpose", "e2e-test"));
+            sandbox = daytona.create(params, 60);
+        }
 
         toolboxFileSystemApi = new FileSystemApi(sandbox.getToolboxApiClient());
         toolboxGitApi = new GitApi(sandbox.getToolboxApiClient());
@@ -672,6 +677,12 @@ class E2ETest {
         ExecuteResponse response = sandbox.getProcess().executeCommand("echo restarted");
         assertThat(response.getExitCode()).isEqualTo(0);
         assertThat(response.getResult()).contains("restarted");
+    }
+
+    @Test
+    @Order(23)
+    void snapshotCapturePollsTheAcceptedSnapshotToActive() {
+        sandbox.experimentalCreateSnapshot(unique("sdk-java-capture"), 3);
     }
 
     private io.daytona.api.client.model.Sandbox fetchSandboxDto() throws Exception {

--- a/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
@@ -5,9 +5,12 @@ package io.daytona.sdk;
 
 import io.daytona.api.client.ApiClient;
 import io.daytona.api.client.api.SandboxApi;
+import io.daytona.api.client.api.SnapshotsApi;
 import io.daytona.api.client.model.CreateSandboxSnapshot;
 import io.daytona.api.client.model.ForkSandbox;
 import io.daytona.api.client.model.SandboxState;
+import io.daytona.api.client.model.SnapshotDto;
+import io.daytona.api.client.model.SnapshotState;
 import io.daytona.api.client.model.ToolboxProxyUrl;
 import io.daytona.api.client.model.UpdateSandboxSecrets;
 import io.daytona.sdk.exception.DaytonaBadRequestException;
@@ -52,6 +55,8 @@ class SandboxTest {
 
     @Mock
     private SandboxApi sandboxApi;
+    @Mock
+    private SnapshotsApi snapshotsApi;
 
     @Mock
     private InfoApi infoApi;
@@ -64,6 +69,7 @@ class SandboxTest {
     @BeforeEach
     void setUp() {
         sandbox = new Sandbox(sandboxApi, TestSupport.config(), TestSupport.mainSandbox("sb-1", SandboxState.STARTED), () -> null);
+        TestSupport.setField(sandbox, "snapshotsApi", snapshotsApi);
     }
 
     @Test
@@ -304,15 +310,19 @@ class SandboxTest {
     @Test
     void experimentalForkAndSnapshotDelegate() {
         when(sandboxApi.forkSandbox(eq("sb-1"), any(ForkSandbox.class), isNull())).thenReturn(TestSupport.mainSandbox("sb-2", SandboxState.STARTED));
-        io.daytona.api.client.model.Sandbox snapshotting = TestSupport.mainSandbox("sb-1", SandboxState.SNAPSHOTTING);
-        io.daytona.api.client.model.Sandbox started = TestSupport.mainSandbox("sb-1", SandboxState.STARTED);
-        when(sandboxApi.getSandbox("sb-1", null, null)).thenReturn(snapshotting, started);
+        when(sandboxApi.createSandboxSnapshot(eq("sb-1"), any(CreateSandboxSnapshot.class), isNull()))
+                .thenReturn(snapshot("snapshot-id", SnapshotState.CAPTURING, null));
+        when(snapshotsApi.getSnapshot("snapshot-id", null))
+                .thenReturn(snapshot("snapshot-id", SnapshotState.ACTIVE, null));
+        when(sandboxApi.getSandbox("sb-1", null, null))
+                .thenReturn(TestSupport.mainSandbox("sb-1", SandboxState.STARTED));
 
         Sandbox forked = sandbox.experimentalFork("forked", 1);
         sandbox.experimentalCreateSnapshot("snap-1", 1);
 
         assertThat(forked.getId()).isEqualTo("sb-2");
         verify(sandboxApi).createSandboxSnapshot(eq("sb-1"), any(CreateSandboxSnapshot.class), isNull());
+        verify(snapshotsApi).getSnapshot("snapshot-id", null);
     }
 
     @Test
@@ -328,21 +338,26 @@ class SandboxTest {
 
     @Test
     void experimentalCreateSnapshotFailsForErrorState() {
-        io.daytona.api.client.model.Sandbox snapshotting = TestSupport.mainSandbox("sb-1", SandboxState.SNAPSHOTTING);
-        io.daytona.api.client.model.Sandbox error = TestSupport.mainSandbox("sb-1", SandboxState.ERROR);
-        when(sandboxApi.getSandbox("sb-1", null, null)).thenReturn(snapshotting, error);
+        when(sandboxApi.createSandboxSnapshot(eq("sb-1"), any(CreateSandboxSnapshot.class), isNull()))
+                .thenReturn(snapshot("snapshot-id", SnapshotState.CAPTURING, null));
+        when(snapshotsApi.getSnapshot("snapshot-id", null))
+                .thenReturn(snapshot("snapshot-id", SnapshotState.ERROR, "capture failed"));
 
         assertThatThrownBy(() -> sandbox.experimentalCreateSnapshot("snap-err", 1))
-                .hasMessageContaining("Sandbox snapshot failed with state: error");
+                .hasMessageContaining(
+                        "Snapshot snapshot-id failed with state: error, error reason: capture failed");
     }
 
     @Test
-    void experimentalCreateSnapshotTimesOutWhenSnapshottingPersists() {
-        io.daytona.api.client.model.Sandbox snapshotting = TestSupport.mainSandbox("sb-1", SandboxState.SNAPSHOTTING);
-        when(sandboxApi.getSandbox("sb-1", null, null)).thenReturn(snapshotting, snapshotting, snapshotting, snapshotting, snapshotting);
+    void experimentalCreateSnapshotTimesOutWhileServerCaptureContinues() {
+        when(sandboxApi.createSandboxSnapshot(eq("sb-1"), any(CreateSandboxSnapshot.class), isNull()))
+                .thenReturn(snapshot("snapshot-id", SnapshotState.CAPTURING, null));
+        when(snapshotsApi.getSnapshot("snapshot-id", null))
+                .thenReturn(snapshot("snapshot-id", SnapshotState.CAPTURING, null));
 
         assertThatThrownBy(() -> sandbox.experimentalCreateSnapshot("snap-timeout", 1))
-                .hasMessageContaining("Sandbox snapshot did not complete before timeout");
+                .hasMessageContaining(
+                        "Timed out waiting for snapshot snapshot-id; capture continues on the server");
     }
 
     @ParameterizedTest
@@ -354,6 +369,14 @@ class SandboxTest {
         assertThatThrownBy(() -> sandbox.start(1))
                 .isInstanceOf(type)
                 .hasMessage("mapped");
+    }
+
+    private static SnapshotDto snapshot(String id, SnapshotState state, String errorReason) {
+        SnapshotDto snapshot = new SnapshotDto();
+        snapshot.setId(id);
+        snapshot.setState(state);
+        snapshot.setErrorReason(errorReason);
+        return snapshot;
     }
 
     private static Stream<Arguments> mappedMainApiExceptions() {

--- a/sdk-python/src/daytona/_async/sandbox.py
+++ b/sdk-python/src/daytona/_async/sandbox.py
@@ -20,15 +20,17 @@ from daytona_api_client_async import (
     ForkSandbox,
     PortPreviewUrl,
     ResizeSandbox,
-    Sandbox as SandboxDto,
+)
+from daytona_api_client_async import Sandbox as SandboxDto
+from daytona_api_client_async import (
     SandboxApi,
     SandboxLabels,
     SandboxListItem,
     SandboxState,
     SandboxVolume,
     SignedPortPreviewUrl,
-    SnapshotState,
     SnapshotsApi,
+    SnapshotState,
     SshAccessDto,
     SshAccessValidationDto,
     UpdateSandboxNetworkSettings,
@@ -52,7 +54,12 @@ from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from .._utils.timeout import http_timeout, with_timeout
 from ..common.daytona import CODE_TOOLBOX_LANGUAGE_LABEL
-from ..common.errors import DaytonaError, DaytonaNotFoundError, DaytonaTimeoutError, DaytonaValidationError
+from ..common.errors import (
+    DaytonaError,
+    DaytonaNotFoundError,
+    DaytonaTimeoutError,
+    DaytonaValidationError,
+)
 from ..common.lsp_server import LspLanguageId, LspLanguageIdLiteral
 from ..common.sandbox import (
     SANDBOX_METRIC_NAMES,
@@ -148,7 +155,9 @@ class AsyncSandbox(SandboxDto):
         self.__process_sandbox_dto(sandbox_dto)
         self._sandbox_api: SandboxApi = sandbox_api
         self._snapshots_api: SnapshotsApi = SnapshotsApi(self._sandbox_api.api_client)
-        self._analytics_api_url_provider: Callable[[], Awaitable[str | None]] | None = analytics_api_url_provider
+        self._analytics_api_url_provider: Callable[
+            [], Awaitable[str | None]
+        ] | None = analytics_api_url_provider
         # Wrap the toolbox API client to inject the sandbox ID into the resource path
         self._toolbox_api: ToolboxApiClientProxy[ApiClient] = ToolboxApiClientProxy(
             toolbox_api, self.id, self.toolbox_proxy_url, pool_tracker
@@ -202,7 +211,9 @@ class AsyncSandbox(SandboxDto):
             print(f"Resources: {sandbox.cpu} CPU, {sandbox.memory} GiB RAM")
             ```
         """
-        instance = await self._sandbox_api.get_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
+        instance = await self._sandbox_api.get_sandbox(
+            self.id, _request_timeout=http_timeout(request_timeout)
+        )
         self.__process_sandbox_dto(instance)
 
     @intercept_errors(message_prefix="Failed to get user home directory: ")
@@ -260,11 +271,15 @@ class AsyncSandbox(SandboxDto):
         Returns:
             SandboxMetrics: The current CPU, memory, and disk usage sample for the Sandbox.
         """
-        return sandbox_metrics_from_system_metrics(await self._system_api.get_system_metrics())
+        return sandbox_metrics_from_system_metrics(
+            await self._system_api.get_system_metrics()
+        )
 
     @intercept_errors(message_prefix="Failed to get sandbox metrics: ")
     @with_instrumentation()
-    async def get_metrics(self, start: datetime | None = None, end: datetime | None = None) -> list[SandboxMetrics]:
+    async def get_metrics(
+        self, start: datetime | None = None, end: datetime | None = None
+    ) -> list[SandboxMetrics]:
         """Gets historical time-series resource usage metrics for the Sandbox.
 
         When the deployment runs a dedicated Analytics API, metrics are fetched from it
@@ -281,7 +296,11 @@ class AsyncSandbox(SandboxDto):
         if end is None:
             end = datetime.now(timezone.utc)
         if start is None:
-            start = datetime.fromisoformat(self.created_at.replace("Z", "+00:00")) if self.created_at else end
+            start = (
+                datetime.fromisoformat(self.created_at.replace("Z", "+00:00"))
+                if self.created_at
+                else end
+            )
 
         analytics_api_url = await self._get_analytics_api_url()
         if analytics_api_url:
@@ -296,24 +315,32 @@ class AsyncSandbox(SandboxDto):
                 )
             finally:
                 await telemetry_api.api_client.close()  # pyright: ignore[reportUnusedCallResult]
-            return pivot_sandbox_metrics((p.metric_name, p.timestamp, p.value) for p in points)
+            return pivot_sandbox_metrics(
+                (p.metric_name, p.timestamp, p.value) for p in points
+            )
 
         response = await self._sandbox_api.get_sandbox_metrics(
             self.id, var_from=start, to=end, metric_names=SANDBOX_METRIC_NAMES
         )
         return pivot_sandbox_metrics(
-            (s.metric_name, dp.timestamp, dp.value) for s in response.series or [] for dp in s.data_points or []
+            (s.metric_name, dp.timestamp, dp.value)
+            for s in response.series or []
+            for dp in s.data_points or []
         )
 
     async def _get_analytics_api_url(self) -> str | None:
         if self._analytics_api_url_provider is not None:
             return await self._analytics_api_url_provider()
-        config = await ConfigApi(self._sandbox_api.api_client).config_controller_get_config()
+        config = await ConfigApi(
+            self._sandbox_api.api_client
+        ).config_controller_get_config()
         return config.analytics_api_url
 
     def _build_analytics_telemetry_api(self, analytics_api_url: str) -> TelemetryApi:
         client = AnalyticsApiClient(AnalyticsConfiguration(host=analytics_api_url))
-        client.default_headers["Authorization"] = self._sandbox_api.api_client.default_headers["Authorization"]
+        client.default_headers[
+            "Authorization"
+        ] = self._sandbox_api.api_client.default_headers["Authorization"]
         return TelemetryApi(client)
 
     @with_instrumentation()
@@ -346,7 +373,9 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set labels: ")
     @with_instrumentation()
-    async def set_labels(self, labels: dict[str, str], request_timeout: float | None = None) -> dict[str, str]:
+    async def set_labels(
+        self, labels: dict[str, str], request_timeout: float | None = None
+    ) -> dict[str, str]:
         """Sets labels for the Sandbox.
 
         Labels are key-value pairs that can be used to organize and identify Sandboxes.
@@ -373,7 +402,9 @@ class AsyncSandbox(SandboxDto):
         """
         self.labels = (
             await self._sandbox_api.replace_labels(
-                self.id, SandboxLabels(labels=labels), _request_timeout=http_timeout(request_timeout)
+                self.id,
+                SandboxLabels(labels=labels),
+                _request_timeout=http_timeout(request_timeout),
             )
         ).labels
         return self.labels
@@ -397,7 +428,9 @@ class AsyncSandbox(SandboxDto):
             print("Sandbox started successfully")
             ```
         """
-        sandbox = await self._sandbox_api.start_sandbox(self.id, _request_timeout=http_timeout(timeout))
+        sandbox = await self._sandbox_api.start_sandbox(
+            self.id, _request_timeout=http_timeout(timeout)
+        )
         self.__process_sandbox_dto(sandbox)
         # This method already handles a timeout, so we don't need to pass one to internal methods
         await self.wait_for_sandbox_start(timeout=0)
@@ -420,7 +453,9 @@ class AsyncSandbox(SandboxDto):
             print("Sandbox recovered successfully")
             ```
         """
-        sandbox = await self._sandbox_api.recover_sandbox(self.id, _request_timeout=http_timeout(timeout))
+        sandbox = await self._sandbox_api.recover_sandbox(
+            self.id, _request_timeout=http_timeout(timeout)
+        )
         self.__process_sandbox_dto(sandbox)
         # This method already handles a timeout, so we don't need to pass one to internal methods
         await self.wait_for_sandbox_start(timeout=0)
@@ -445,7 +480,9 @@ class AsyncSandbox(SandboxDto):
             print("Sandbox stopped successfully")
             ```
         """
-        _ = await self._sandbox_api.stop_sandbox(self.id, force=force, _request_timeout=http_timeout(timeout))
+        _ = await self._sandbox_api.stop_sandbox(
+            self.id, force=force, _request_timeout=http_timeout(timeout)
+        )
         await self.__refresh_data_safe()
         # This method already handles a timeout, so we don't need to pass one to internal methods
         await self.wait_for_sandbox_stop(timeout=0)
@@ -460,7 +497,9 @@ class AsyncSandbox(SandboxDto):
             timeout (float | None): Timeout (in seconds) for sandbox deletion. 0 means no timeout.
                 Default is 60 seconds.
         """
-        _ = await self._sandbox_api.delete_sandbox(self.id, _request_timeout=http_timeout(timeout))
+        _ = await self._sandbox_api.delete_sandbox(
+            self.id, _request_timeout=http_timeout(timeout)
+        )
         await self.__refresh_data_safe()
 
     @intercept_errors(message_prefix="Failure during waiting for sandbox to start: ")
@@ -468,7 +507,8 @@ class AsyncSandbox(SandboxDto):
     @with_instrumentation()
     async def wait_for_sandbox_start(
         self,
-        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float
+        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox to reach the 'started' state. Polls the Sandbox status until it
         reaches the 'started' state, encounters an error or times out.
@@ -489,9 +529,7 @@ class AsyncSandbox(SandboxDto):
                 return
 
             if self.state in ["error", "build_failed"]:
-                err_msg = (
-                    f"Sandbox {self.id} failed to start with state: {self.state}, error reason: {self.error_reason}"
-                )
+                err_msg = f"Sandbox {self.id} failed to start with state: {self.state}, error reason: {self.error_reason}"
                 raise DaytonaError(err_msg)
 
             await asyncio.sleep(check_interval)
@@ -503,7 +541,8 @@ class AsyncSandbox(SandboxDto):
     @with_instrumentation()
     async def wait_for_sandbox_stop(
         self,
-        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float
+        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox to reach the 'stopped' state. Polls the Sandbox status until it
         reaches the 'stopped' state, encounters an error or times out. It will wait up to 60 seconds
@@ -524,9 +563,7 @@ class AsyncSandbox(SandboxDto):
                 await self.__refresh_data_safe()
 
                 if self.state in ["error", "build_failed"]:
-                    err_msg = (
-                        f"Sandbox {self.id} failed to stop with status: {self.state}, error reason: {self.error_reason}"
-                    )
+                    err_msg = f"Sandbox {self.id} failed to stop with status: {self.state}, error reason: {self.error_reason}"
                     raise DaytonaError(err_msg)
             except Exception as e:
                 # If there's a validation error, continue waiting
@@ -539,7 +576,9 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set auto-stop interval: ")
     @with_instrumentation()
-    async def set_autostop_interval(self, interval: int, request_timeout: float | None = None) -> None:
+    async def set_autostop_interval(
+        self, interval: int, request_timeout: float | None = None
+    ) -> None:
         """Sets the auto-stop interval for the Sandbox.
 
         The Sandbox will automatically stop after being idle (no new events) for the specified interval.
@@ -566,7 +605,9 @@ class AsyncSandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError("Auto-stop interval must be a non-negative integer")
+            raise DaytonaValidationError(
+                "Auto-stop interval must be a non-negative integer"
+            )
 
         _ = await self._sandbox_api.set_autostop_interval(
             self.id, interval, _request_timeout=http_timeout(request_timeout)
@@ -597,14 +638,18 @@ class AsyncSandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError("Auto-pause interval must be a non-negative integer")
+            raise DaytonaValidationError(
+                "Auto-pause interval must be a non-negative integer"
+            )
 
         _ = await self._sandbox_api.set_auto_pause_interval(self.id, interval)
         self.auto_pause_interval = interval
 
     @intercept_errors(message_prefix="Failed to set auto-archive interval: ")
     @with_instrumentation()
-    async def set_auto_archive_interval(self, interval: int, request_timeout: float | None = None) -> None:
+    async def set_auto_archive_interval(
+        self, interval: int, request_timeout: float | None = None
+    ) -> None:
         """Sets the auto-archive interval for the Sandbox.
 
         The Sandbox will automatically archive after being continuously stopped for the specified interval.
@@ -629,7 +674,9 @@ class AsyncSandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError("Auto-archive interval must be a non-negative integer")
+            raise DaytonaValidationError(
+                "Auto-archive interval must be a non-negative integer"
+            )
 
         _ = await self._sandbox_api.set_auto_archive_interval(
             self.id, interval, _request_timeout=http_timeout(request_timeout)
@@ -638,7 +685,9 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set auto-delete interval: ")
     @with_instrumentation()
-    async def set_auto_delete_interval(self, interval: int, request_timeout: float | None = None) -> None:
+    async def set_auto_delete_interval(
+        self, interval: int, request_timeout: float | None = None
+    ) -> None:
         """Sets the auto-delete interval for the Sandbox.
 
         The Sandbox will automatically delete after being continuously stopped for the specified interval.
@@ -698,7 +747,11 @@ class AsyncSandbox(SandboxDto):
             await sandbox.update_network_settings(network_block_all=False)
             ```
         """
-        if network_block_all is None and network_allow_list is None and domain_allow_list is None:
+        if (
+            network_block_all is None
+            and network_allow_list is None
+            and domain_allow_list is None
+        ):
             raise DaytonaValidationError(
                 "At least one of network_block_all, network_allow_list or domain_allow_list must be set"
             )
@@ -734,13 +787,17 @@ class AsyncSandbox(SandboxDto):
             await sandbox.update_secrets({})  # detach all
             ```
         """
-        body = UpdateSandboxSecrets(secrets=[{env_var: secret_name} for env_var, secret_name in secrets.items()])
+        body = UpdateSandboxSecrets(
+            secrets=[{env_var: secret_name} for env_var, secret_name in secrets.items()]
+        )
         updated = await self._sandbox_api.update_sandbox_secrets(self.id, body)
         self.__process_sandbox_dto(updated)
 
     @intercept_errors(message_prefix="Failed to update environment: ")
     @with_instrumentation()
-    async def update_env(self, env: dict[str, str], *, unset: list[str] | None = None) -> None:
+    async def update_env(
+        self, env: dict[str, str], *, unset: list[str] | None = None
+    ) -> None:
         """Updates the Sandbox daemon's process environment.
 
         Newly spawned processes, sessions and PTYs inherit the change; already-running processes
@@ -760,7 +817,9 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to get preview link: ")
     @with_instrumentation()
-    async def get_preview_link(self, port: int, request_timeout: float | None = None) -> PortPreviewUrl:
+    async def get_preview_link(
+        self, port: int, request_timeout: float | None = None
+    ) -> PortPreviewUrl:
         """Retrieves the preview link for the sandbox at the specified port. If the port is closed,
         it will be opened automatically. For private sandboxes, a token is included to grant access
         to the URL.
@@ -789,7 +848,10 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to create signed preview url: ")
     async def create_signed_preview_url(
-        self, port: int, expires_in_seconds: int | None = None, request_timeout: float | None = None
+        self,
+        port: int,
+        expires_in_seconds: int | None = None,
+        request_timeout: float | None = None,
     ) -> SignedPortPreviewUrl:
         """Creates a signed preview URL for the sandbox at the specified port.
 
@@ -806,11 +868,16 @@ class AsyncSandbox(SandboxDto):
             SignedPortPreviewUrl: The response object for the signed preview url.
         """
         return await self._sandbox_api.get_signed_port_preview_url(
-            self.id, port, expires_in_seconds=expires_in_seconds, _request_timeout=http_timeout(request_timeout)
+            self.id,
+            port,
+            expires_in_seconds=expires_in_seconds,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to expire signed preview url: ")
-    async def expire_signed_preview_url(self, port: int, token: str, request_timeout: float | None = None) -> None:
+    async def expire_signed_preview_url(
+        self, port: int, token: str, request_timeout: float | None = None
+    ) -> None:
         """Expires a signed preview URL for the sandbox at the specified port.
 
         Args:
@@ -840,7 +907,9 @@ class AsyncSandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = await self._sandbox_api.archive_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
+        _ = await self._sandbox_api.archive_sandbox(
+            self.id, _request_timeout=http_timeout(request_timeout)
+        )
         await self.refresh_data(request_timeout=request_timeout)
 
     @intercept_errors(message_prefix="Failed to resize sandbox: ")
@@ -881,7 +950,9 @@ class AsyncSandbox(SandboxDto):
             memory=resources.memory,
             disk=resources.disk,
         )
-        sandbox = await self._sandbox_api.resize_sandbox(self.id, resize_request, _request_timeout=timeout or None)
+        sandbox = await self._sandbox_api.resize_sandbox(
+            self.id, resize_request, _request_timeout=timeout or None
+        )
         self.__process_sandbox_dto(sandbox)
         await self.wait_for_resize_complete(timeout=0)
 
@@ -890,7 +961,8 @@ class AsyncSandbox(SandboxDto):
     @with_instrumentation()
     async def wait_for_resize_complete(
         self,
-        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float
+        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox resize operation to complete. Polls the Sandbox status until
         the state is no longer 'resizing'.
@@ -921,7 +993,9 @@ class AsyncSandbox(SandboxDto):
     @intercept_errors(message_prefix="Failed to create SSH access: ")
     @with_instrumentation()
     async def create_ssh_access(
-        self, expires_in_minutes: int | None = None, request_timeout: float | None = None
+        self,
+        expires_in_minutes: int | None = None,
+        request_timeout: float | None = None,
     ) -> SshAccessDto:
         """Creates an SSH access token for the sandbox.
 
@@ -933,12 +1007,16 @@ class AsyncSandbox(SandboxDto):
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
         return await self._sandbox_api.create_ssh_access(
-            self.id, expires_in_minutes=expires_in_minutes, _request_timeout=http_timeout(request_timeout)
+            self.id,
+            expires_in_minutes=expires_in_minutes,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to revoke SSH access: ")
     @with_instrumentation()
-    async def revoke_ssh_access(self, token: str, request_timeout: float | None = None) -> None:
+    async def revoke_ssh_access(
+        self, token: str, request_timeout: float | None = None
+    ) -> None:
         """Revokes an SSH access token for the sandbox.
 
         Args:
@@ -948,11 +1026,15 @@ class AsyncSandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = await self._sandbox_api.revoke_ssh_access(self.id, token, _request_timeout=http_timeout(request_timeout))
+        _ = await self._sandbox_api.revoke_ssh_access(
+            self.id, token, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to validate SSH access: ")
     @with_instrumentation()
-    async def validate_ssh_access(self, token: str, request_timeout: float | None = None) -> SshAccessValidationDto:
+    async def validate_ssh_access(
+        self, token: str, request_timeout: float | None = None
+    ) -> SshAccessValidationDto:
         """Validates an SSH access token for the sandbox.
 
         Args:
@@ -962,7 +1044,9 @@ class AsyncSandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        return await self._sandbox_api.validate_ssh_access(token, _request_timeout=http_timeout(request_timeout))
+        return await self._sandbox_api.validate_ssh_access(
+            token, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to refresh sandbox activity: ")
     async def refresh_activity(self, request_timeout: float | None = None) -> None:
@@ -982,12 +1066,16 @@ class AsyncSandbox(SandboxDto):
             await sandbox.refresh_activity()
             ```
         """
-        await self._sandbox_api.update_last_activity(self.id, _request_timeout=http_timeout(request_timeout))
+        await self._sandbox_api.update_last_activity(
+            self.id, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to fork sandbox: ")
     @with_timeout()
     @with_instrumentation()
-    async def _experimental_fork(self, name: str | None = None, timeout: float | None = 60) -> "AsyncSandbox":
+    async def _experimental_fork(
+        self, name: str | None = None, timeout: float | None = 60
+    ) -> "AsyncSandbox":
         """Forks the Sandbox, creating a new Sandbox with an identical filesystem.
 
         The forked Sandbox is a copy-on-write clone of the original. It starts
@@ -1028,7 +1116,9 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to create snapshot: ")
     @with_instrumentation()
-    async def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
+    async def _experimental_create_snapshot(
+        self, name: str, timeout: float | None = 60
+    ) -> None:
         """Creates a snapshot from the current state of the Sandbox.
 
         This captures the Sandbox's filesystem into a reusable snapshot that can be
@@ -1052,11 +1142,15 @@ class AsyncSandbox(SandboxDto):
         loop = asyncio.get_running_loop()
         start_time = loop.time()
         accepted = await self._sandbox_api.create_sandbox_snapshot(
-            self.id, CreateSandboxSnapshot(name=name), _request_timeout=http_timeout(timeout)
+            self.id,
+            CreateSandboxSnapshot(name=name),
+            _request_timeout=http_timeout(timeout),
         )
         snapshot_id = accepted.id if accepted else None
         if not snapshot_id:
-            raise DaytonaError("Failed to create snapshot. Didn't receive a snapshot ID from the server API.")
+            raise DaytonaError(
+                "Failed to create snapshot. Didn't receive a snapshot ID from the server API."
+            )
 
         deadline = None if timeout in (None, 0) else start_time + timeout
         await self.__wait_for_snapshot_complete(snapshot_id, deadline)
@@ -1081,7 +1175,9 @@ class AsyncSandbox(SandboxDto):
             raise DaytonaError("Timeout must be a non-negative number")
 
         start_time = time.time()
-        _ = await self._sandbox_api.pause_sandbox(self.id, _request_timeout=timeout if timeout > 0 else None)
+        _ = await self._sandbox_api.pause_sandbox(
+            self.id, _request_timeout=timeout if timeout > 0 else None
+        )
         await self.refresh_data()
 
         elapsed = time.time() - start_time
@@ -1096,11 +1192,15 @@ class AsyncSandbox(SandboxDto):
                     f"Sandbox {self.id} pause failed with state: {self.state}, error reason: {self.error_reason}"
                 )
             if 0 < remaining <= time.time() - wait_start:
-                raise DaytonaError(f"Sandbox {self.id} failed to pause within {timeout} seconds")
+                raise DaytonaError(
+                    f"Sandbox {self.id} failed to pause within {timeout} seconds"
+                )
             await asyncio.sleep(check_interval)
             check_interval = min(check_interval * 1.5, 1.0)
 
-    async def __wait_for_snapshot_complete(self, snapshot_id: str, deadline: float | None) -> None:
+    async def __wait_for_snapshot_complete(
+        self, snapshot_id: str, deadline: float | None
+    ) -> None:
         check_interval = 0.1
         loop = asyncio.get_running_loop()
         start_time = loop.time()
@@ -1113,16 +1213,24 @@ class AsyncSandbox(SandboxDto):
 
             snapshot = await self._snapshots_api.get_snapshot(snapshot_id)
             if not snapshot or snapshot.id != snapshot_id:
-                raise DaytonaError(f"Snapshot lookup for {snapshot_id} returned an invalid response")
+                raise DaytonaError(
+                    f"Snapshot lookup for {snapshot_id} returned an invalid response"
+                )
 
             if snapshot.state == SnapshotState.ACTIVE:
                 try:
                     await self.refresh_data()
-                except Exception:  # Best-effort local cleanup after definitive server success.
+                except (
+                    Exception
+                ):  # Best-effort local cleanup after definitive server success.
                     pass
                 return
             if snapshot.state in (SnapshotState.ERROR, SnapshotState.BUILD_FAILED):
-                state = snapshot.state.value if isinstance(snapshot.state, SnapshotState) else snapshot.state
+                state = (
+                    snapshot.state.value
+                    if isinstance(snapshot.state, SnapshotState)
+                    else snapshot.state
+                )
                 raise DaytonaError(
                     f"Snapshot {snapshot.id} failed with state: {state}, error reason: {snapshot.error_reason}"
                 )
@@ -1150,7 +1258,9 @@ class AsyncSandbox(SandboxDto):
         self.backup_state: str | None = sandbox_dto.backup_state
         self.auto_stop_interval: float | int | None = sandbox_dto.auto_stop_interval
         self.auto_pause_interval: float | int | None = sandbox_dto.auto_pause_interval
-        self.auto_archive_interval: float | int | None = sandbox_dto.auto_archive_interval
+        self.auto_archive_interval: float | int | None = (
+            sandbox_dto.auto_archive_interval
+        )
         self.auto_delete_interval: float | int | None = sandbox_dto.auto_delete_interval
         self.created_at: str | None = sandbox_dto.created_at
         self.updated_at: str | None = sandbox_dto.updated_at
@@ -1159,7 +1269,11 @@ class AsyncSandbox(SandboxDto):
 
         # Fields only present in the full SandboxDto (not returned by list results
         if isinstance(sandbox_dto, SandboxDto):
-            self.env: dict[str, str] | None = sandbox_dto.env  # pyright: ignore[reportIncompatibleVariableOverride]
+            self.env: dict[
+                str, str
+            ] | None = (
+                sandbox_dto.env
+            )  # pyright: ignore[reportIncompatibleVariableOverride]
             self.network_block_all: bool | None = (  # pyright: ignore[reportIncompatibleVariableOverride]
                 sandbox_dto.network_block_all
             )

--- a/sdk-python/src/daytona/_async/sandbox.py
+++ b/sdk-python/src/daytona/_async/sandbox.py
@@ -20,15 +20,15 @@ from daytona_api_client_async import (
     ForkSandbox,
     PortPreviewUrl,
     ResizeSandbox,
-)
-from daytona_api_client_async import Sandbox as SandboxDto
-from daytona_api_client_async import (
+    Sandbox as SandboxDto,
     SandboxApi,
     SandboxLabels,
     SandboxListItem,
     SandboxState,
     SandboxVolume,
     SignedPortPreviewUrl,
+    SnapshotState,
+    SnapshotsApi,
     SshAccessDto,
     SshAccessValidationDto,
     UpdateSandboxNetworkSettings,
@@ -52,7 +52,7 @@ from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from .._utils.timeout import http_timeout, with_timeout
 from ..common.daytona import CODE_TOOLBOX_LANGUAGE_LABEL
-from ..common.errors import DaytonaError, DaytonaNotFoundError, DaytonaValidationError
+from ..common.errors import DaytonaError, DaytonaNotFoundError, DaytonaTimeoutError, DaytonaValidationError
 from ..common.lsp_server import LspLanguageId, LspLanguageIdLiteral
 from ..common.sandbox import (
     SANDBOX_METRIC_NAMES,
@@ -147,6 +147,7 @@ class AsyncSandbox(SandboxDto):
         super().__init__(**sandbox_dto.model_dump())
         self.__process_sandbox_dto(sandbox_dto)
         self._sandbox_api: SandboxApi = sandbox_api
+        self._snapshots_api: SnapshotsApi = SnapshotsApi(self._sandbox_api.api_client)
         self._analytics_api_url_provider: Callable[[], Awaitable[str | None]] | None = analytics_api_url_provider
         # Wrap the toolbox API client to inject the sandbox ID into the resource path
         self._toolbox_api: ToolboxApiClientProxy[ApiClient] = ToolboxApiClientProxy(
@@ -1026,14 +1027,13 @@ class AsyncSandbox(SandboxDto):
         return forked
 
     @intercept_errors(message_prefix="Failed to create snapshot: ")
-    @with_timeout()
     @with_instrumentation()
     async def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
         """Creates a snapshot from the current state of the Sandbox.
 
         This captures the Sandbox's filesystem into a reusable snapshot that can be
-        used to create new Sandboxes. The Sandbox will temporarily enter a
-        'snapshotting' state and return to its previous state when complete.
+        used to create new Sandboxes. The method waits for the accepted snapshot
+        to become active.
 
         Args:
             name (str): Name for the new snapshot.
@@ -1049,11 +1049,17 @@ class AsyncSandbox(SandboxDto):
             print("Snapshot created successfully")
             ```
         """
-        _ = await self._sandbox_api.create_sandbox_snapshot(
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
+        accepted = await self._sandbox_api.create_sandbox_snapshot(
             self.id, CreateSandboxSnapshot(name=name), _request_timeout=http_timeout(timeout)
         )
-        await self.refresh_data()
-        await self.__wait_for_snapshot_complete()
+        snapshot_id = accepted.id if accepted else None
+        if not snapshot_id:
+            raise DaytonaError("Failed to create snapshot. Didn't receive a snapshot ID from the server API.")
+
+        deadline = None if timeout in (None, 0) else start_time + timeout
+        await self.__wait_for_snapshot_complete(snapshot_id, deadline)
 
     @intercept_errors(message_prefix="Failed to pause sandbox")
     @with_instrumentation()
@@ -1094,23 +1100,35 @@ class AsyncSandbox(SandboxDto):
             await asyncio.sleep(check_interval)
             check_interval = min(check_interval * 1.5, 1.0)
 
-    async def __wait_for_snapshot_complete(self) -> None:
+    async def __wait_for_snapshot_complete(self, snapshot_id: str, deadline: float | None) -> None:
         check_interval = 0.1
-        start_time = asyncio.get_event_loop().time()
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
 
-        while self.state == "snapshotting":
-            await self.refresh_data()
-
-            if self.state in ["error", "build_failed"]:
-                raise DaytonaError(
-                    f"Sandbox {self.id} snapshot failed with state: {self.state}, error reason: {self.error_reason}"
+        while True:
+            if deadline is not None and loop.time() >= deadline:
+                raise DaytonaTimeoutError(
+                    f"Timed out waiting for snapshot {snapshot_id}; capture continues on the server"
                 )
 
-            if self.state != "snapshotting":
+            snapshot = await self._snapshots_api.get_snapshot(snapshot_id)
+            if not snapshot or snapshot.id != snapshot_id:
+                raise DaytonaError(f"Snapshot lookup for {snapshot_id} returned an invalid response")
+
+            if snapshot.state == SnapshotState.ACTIVE:
+                try:
+                    await self.refresh_data()
+                except Exception:  # Best-effort local cleanup after definitive server success.
+                    pass
                 return
+            if snapshot.state in (SnapshotState.ERROR, SnapshotState.BUILD_FAILED):
+                state = snapshot.state.value if isinstance(snapshot.state, SnapshotState) else snapshot.state
+                raise DaytonaError(
+                    f"Snapshot {snapshot.id} failed with state: {state}, error reason: {snapshot.error_reason}"
+                )
 
             await asyncio.sleep(check_interval)
-            if asyncio.get_event_loop().time() - start_time > 5:
+            if loop.time() - start_time > 5:
                 check_interval = min(check_interval * 1.1, 1.0)
 
     def __process_sandbox_dto(self, sandbox_dto: SandboxDto | SandboxListItem) -> None:

--- a/sdk-python/src/daytona/_async/sandbox.py
+++ b/sdk-python/src/daytona/_async/sandbox.py
@@ -54,12 +54,7 @@ from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from .._utils.timeout import http_timeout, with_timeout
 from ..common.daytona import CODE_TOOLBOX_LANGUAGE_LABEL
-from ..common.errors import (
-    DaytonaError,
-    DaytonaNotFoundError,
-    DaytonaTimeoutError,
-    DaytonaValidationError,
-)
+from ..common.errors import DaytonaError, DaytonaNotFoundError, DaytonaTimeoutError, DaytonaValidationError
 from ..common.lsp_server import LspLanguageId, LspLanguageIdLiteral
 from ..common.sandbox import (
     SANDBOX_METRIC_NAMES,
@@ -155,9 +150,7 @@ class AsyncSandbox(SandboxDto):
         self.__process_sandbox_dto(sandbox_dto)
         self._sandbox_api: SandboxApi = sandbox_api
         self._snapshots_api: SnapshotsApi = SnapshotsApi(self._sandbox_api.api_client)
-        self._analytics_api_url_provider: Callable[
-            [], Awaitable[str | None]
-        ] | None = analytics_api_url_provider
+        self._analytics_api_url_provider: Callable[[], Awaitable[str | None]] | None = analytics_api_url_provider
         # Wrap the toolbox API client to inject the sandbox ID into the resource path
         self._toolbox_api: ToolboxApiClientProxy[ApiClient] = ToolboxApiClientProxy(
             toolbox_api, self.id, self.toolbox_proxy_url, pool_tracker
@@ -211,9 +204,7 @@ class AsyncSandbox(SandboxDto):
             print(f"Resources: {sandbox.cpu} CPU, {sandbox.memory} GiB RAM")
             ```
         """
-        instance = await self._sandbox_api.get_sandbox(
-            self.id, _request_timeout=http_timeout(request_timeout)
-        )
+        instance = await self._sandbox_api.get_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
         self.__process_sandbox_dto(instance)
 
     @intercept_errors(message_prefix="Failed to get user home directory: ")
@@ -271,15 +262,11 @@ class AsyncSandbox(SandboxDto):
         Returns:
             SandboxMetrics: The current CPU, memory, and disk usage sample for the Sandbox.
         """
-        return sandbox_metrics_from_system_metrics(
-            await self._system_api.get_system_metrics()
-        )
+        return sandbox_metrics_from_system_metrics(await self._system_api.get_system_metrics())
 
     @intercept_errors(message_prefix="Failed to get sandbox metrics: ")
     @with_instrumentation()
-    async def get_metrics(
-        self, start: datetime | None = None, end: datetime | None = None
-    ) -> list[SandboxMetrics]:
+    async def get_metrics(self, start: datetime | None = None, end: datetime | None = None) -> list[SandboxMetrics]:
         """Gets historical time-series resource usage metrics for the Sandbox.
 
         When the deployment runs a dedicated Analytics API, metrics are fetched from it
@@ -296,11 +283,7 @@ class AsyncSandbox(SandboxDto):
         if end is None:
             end = datetime.now(timezone.utc)
         if start is None:
-            start = (
-                datetime.fromisoformat(self.created_at.replace("Z", "+00:00"))
-                if self.created_at
-                else end
-            )
+            start = datetime.fromisoformat(self.created_at.replace("Z", "+00:00")) if self.created_at else end
 
         analytics_api_url = await self._get_analytics_api_url()
         if analytics_api_url:
@@ -315,32 +298,24 @@ class AsyncSandbox(SandboxDto):
                 )
             finally:
                 await telemetry_api.api_client.close()  # pyright: ignore[reportUnusedCallResult]
-            return pivot_sandbox_metrics(
-                (p.metric_name, p.timestamp, p.value) for p in points
-            )
+            return pivot_sandbox_metrics((p.metric_name, p.timestamp, p.value) for p in points)
 
         response = await self._sandbox_api.get_sandbox_metrics(
             self.id, var_from=start, to=end, metric_names=SANDBOX_METRIC_NAMES
         )
         return pivot_sandbox_metrics(
-            (s.metric_name, dp.timestamp, dp.value)
-            for s in response.series or []
-            for dp in s.data_points or []
+            (s.metric_name, dp.timestamp, dp.value) for s in response.series or [] for dp in s.data_points or []
         )
 
     async def _get_analytics_api_url(self) -> str | None:
         if self._analytics_api_url_provider is not None:
             return await self._analytics_api_url_provider()
-        config = await ConfigApi(
-            self._sandbox_api.api_client
-        ).config_controller_get_config()
+        config = await ConfigApi(self._sandbox_api.api_client).config_controller_get_config()
         return config.analytics_api_url
 
     def _build_analytics_telemetry_api(self, analytics_api_url: str) -> TelemetryApi:
         client = AnalyticsApiClient(AnalyticsConfiguration(host=analytics_api_url))
-        client.default_headers[
-            "Authorization"
-        ] = self._sandbox_api.api_client.default_headers["Authorization"]
+        client.default_headers["Authorization"] = self._sandbox_api.api_client.default_headers["Authorization"]
         return TelemetryApi(client)
 
     @with_instrumentation()
@@ -373,9 +348,7 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set labels: ")
     @with_instrumentation()
-    async def set_labels(
-        self, labels: dict[str, str], request_timeout: float | None = None
-    ) -> dict[str, str]:
+    async def set_labels(self, labels: dict[str, str], request_timeout: float | None = None) -> dict[str, str]:
         """Sets labels for the Sandbox.
 
         Labels are key-value pairs that can be used to organize and identify Sandboxes.
@@ -428,9 +401,7 @@ class AsyncSandbox(SandboxDto):
             print("Sandbox started successfully")
             ```
         """
-        sandbox = await self._sandbox_api.start_sandbox(
-            self.id, _request_timeout=http_timeout(timeout)
-        )
+        sandbox = await self._sandbox_api.start_sandbox(self.id, _request_timeout=http_timeout(timeout))
         self.__process_sandbox_dto(sandbox)
         # This method already handles a timeout, so we don't need to pass one to internal methods
         await self.wait_for_sandbox_start(timeout=0)
@@ -453,9 +424,7 @@ class AsyncSandbox(SandboxDto):
             print("Sandbox recovered successfully")
             ```
         """
-        sandbox = await self._sandbox_api.recover_sandbox(
-            self.id, _request_timeout=http_timeout(timeout)
-        )
+        sandbox = await self._sandbox_api.recover_sandbox(self.id, _request_timeout=http_timeout(timeout))
         self.__process_sandbox_dto(sandbox)
         # This method already handles a timeout, so we don't need to pass one to internal methods
         await self.wait_for_sandbox_start(timeout=0)
@@ -480,9 +449,7 @@ class AsyncSandbox(SandboxDto):
             print("Sandbox stopped successfully")
             ```
         """
-        _ = await self._sandbox_api.stop_sandbox(
-            self.id, force=force, _request_timeout=http_timeout(timeout)
-        )
+        _ = await self._sandbox_api.stop_sandbox(self.id, force=force, _request_timeout=http_timeout(timeout))
         await self.__refresh_data_safe()
         # This method already handles a timeout, so we don't need to pass one to internal methods
         await self.wait_for_sandbox_stop(timeout=0)
@@ -497,9 +464,7 @@ class AsyncSandbox(SandboxDto):
             timeout (float | None): Timeout (in seconds) for sandbox deletion. 0 means no timeout.
                 Default is 60 seconds.
         """
-        _ = await self._sandbox_api.delete_sandbox(
-            self.id, _request_timeout=http_timeout(timeout)
-        )
+        _ = await self._sandbox_api.delete_sandbox(self.id, _request_timeout=http_timeout(timeout))
         await self.__refresh_data_safe()
 
     @intercept_errors(message_prefix="Failure during waiting for sandbox to start: ")
@@ -507,8 +472,7 @@ class AsyncSandbox(SandboxDto):
     @with_instrumentation()
     async def wait_for_sandbox_start(
         self,
-        timeout: float
-        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox to reach the 'started' state. Polls the Sandbox status until it
         reaches the 'started' state, encounters an error or times out.
@@ -529,7 +493,9 @@ class AsyncSandbox(SandboxDto):
                 return
 
             if self.state in ["error", "build_failed"]:
-                err_msg = f"Sandbox {self.id} failed to start with state: {self.state}, error reason: {self.error_reason}"
+                err_msg = (
+                    f"Sandbox {self.id} failed to start with state: {self.state}, error reason: {self.error_reason}"
+                )
                 raise DaytonaError(err_msg)
 
             await asyncio.sleep(check_interval)
@@ -541,8 +507,7 @@ class AsyncSandbox(SandboxDto):
     @with_instrumentation()
     async def wait_for_sandbox_stop(
         self,
-        timeout: float
-        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox to reach the 'stopped' state. Polls the Sandbox status until it
         reaches the 'stopped' state, encounters an error or times out. It will wait up to 60 seconds
@@ -563,7 +528,9 @@ class AsyncSandbox(SandboxDto):
                 await self.__refresh_data_safe()
 
                 if self.state in ["error", "build_failed"]:
-                    err_msg = f"Sandbox {self.id} failed to stop with status: {self.state}, error reason: {self.error_reason}"
+                    err_msg = (
+                        f"Sandbox {self.id} failed to stop with status: {self.state}, error reason: {self.error_reason}"
+                    )
                     raise DaytonaError(err_msg)
             except Exception as e:
                 # If there's a validation error, continue waiting
@@ -576,9 +543,7 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set auto-stop interval: ")
     @with_instrumentation()
-    async def set_autostop_interval(
-        self, interval: int, request_timeout: float | None = None
-    ) -> None:
+    async def set_autostop_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-stop interval for the Sandbox.
 
         The Sandbox will automatically stop after being idle (no new events) for the specified interval.
@@ -605,9 +570,7 @@ class AsyncSandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError(
-                "Auto-stop interval must be a non-negative integer"
-            )
+            raise DaytonaValidationError("Auto-stop interval must be a non-negative integer")
 
         _ = await self._sandbox_api.set_autostop_interval(
             self.id, interval, _request_timeout=http_timeout(request_timeout)
@@ -638,18 +601,14 @@ class AsyncSandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError(
-                "Auto-pause interval must be a non-negative integer"
-            )
+            raise DaytonaValidationError("Auto-pause interval must be a non-negative integer")
 
         _ = await self._sandbox_api.set_auto_pause_interval(self.id, interval)
         self.auto_pause_interval = interval
 
     @intercept_errors(message_prefix="Failed to set auto-archive interval: ")
     @with_instrumentation()
-    async def set_auto_archive_interval(
-        self, interval: int, request_timeout: float | None = None
-    ) -> None:
+    async def set_auto_archive_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-archive interval for the Sandbox.
 
         The Sandbox will automatically archive after being continuously stopped for the specified interval.
@@ -674,9 +633,7 @@ class AsyncSandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError(
-                "Auto-archive interval must be a non-negative integer"
-            )
+            raise DaytonaValidationError("Auto-archive interval must be a non-negative integer")
 
         _ = await self._sandbox_api.set_auto_archive_interval(
             self.id, interval, _request_timeout=http_timeout(request_timeout)
@@ -685,9 +642,7 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set auto-delete interval: ")
     @with_instrumentation()
-    async def set_auto_delete_interval(
-        self, interval: int, request_timeout: float | None = None
-    ) -> None:
+    async def set_auto_delete_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-delete interval for the Sandbox.
 
         The Sandbox will automatically delete after being continuously stopped for the specified interval.
@@ -747,11 +702,7 @@ class AsyncSandbox(SandboxDto):
             await sandbox.update_network_settings(network_block_all=False)
             ```
         """
-        if (
-            network_block_all is None
-            and network_allow_list is None
-            and domain_allow_list is None
-        ):
+        if network_block_all is None and network_allow_list is None and domain_allow_list is None:
             raise DaytonaValidationError(
                 "At least one of network_block_all, network_allow_list or domain_allow_list must be set"
             )
@@ -787,17 +738,13 @@ class AsyncSandbox(SandboxDto):
             await sandbox.update_secrets({})  # detach all
             ```
         """
-        body = UpdateSandboxSecrets(
-            secrets=[{env_var: secret_name} for env_var, secret_name in secrets.items()]
-        )
+        body = UpdateSandboxSecrets(secrets=[{env_var: secret_name} for env_var, secret_name in secrets.items()])
         updated = await self._sandbox_api.update_sandbox_secrets(self.id, body)
         self.__process_sandbox_dto(updated)
 
     @intercept_errors(message_prefix="Failed to update environment: ")
     @with_instrumentation()
-    async def update_env(
-        self, env: dict[str, str], *, unset: list[str] | None = None
-    ) -> None:
+    async def update_env(self, env: dict[str, str], *, unset: list[str] | None = None) -> None:
         """Updates the Sandbox daemon's process environment.
 
         Newly spawned processes, sessions and PTYs inherit the change; already-running processes
@@ -817,9 +764,7 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to get preview link: ")
     @with_instrumentation()
-    async def get_preview_link(
-        self, port: int, request_timeout: float | None = None
-    ) -> PortPreviewUrl:
+    async def get_preview_link(self, port: int, request_timeout: float | None = None) -> PortPreviewUrl:
         """Retrieves the preview link for the sandbox at the specified port. If the port is closed,
         it will be opened automatically. For private sandboxes, a token is included to grant access
         to the URL.
@@ -875,9 +820,7 @@ class AsyncSandbox(SandboxDto):
         )
 
     @intercept_errors(message_prefix="Failed to expire signed preview url: ")
-    async def expire_signed_preview_url(
-        self, port: int, token: str, request_timeout: float | None = None
-    ) -> None:
+    async def expire_signed_preview_url(self, port: int, token: str, request_timeout: float | None = None) -> None:
         """Expires a signed preview URL for the sandbox at the specified port.
 
         Args:
@@ -907,9 +850,7 @@ class AsyncSandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = await self._sandbox_api.archive_sandbox(
-            self.id, _request_timeout=http_timeout(request_timeout)
-        )
+        _ = await self._sandbox_api.archive_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
         await self.refresh_data(request_timeout=request_timeout)
 
     @intercept_errors(message_prefix="Failed to resize sandbox: ")
@@ -950,9 +891,7 @@ class AsyncSandbox(SandboxDto):
             memory=resources.memory,
             disk=resources.disk,
         )
-        sandbox = await self._sandbox_api.resize_sandbox(
-            self.id, resize_request, _request_timeout=timeout or None
-        )
+        sandbox = await self._sandbox_api.resize_sandbox(self.id, resize_request, _request_timeout=timeout or None)
         self.__process_sandbox_dto(sandbox)
         await self.wait_for_resize_complete(timeout=0)
 
@@ -961,8 +900,7 @@ class AsyncSandbox(SandboxDto):
     @with_instrumentation()
     async def wait_for_resize_complete(
         self,
-        timeout: float
-        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox resize operation to complete. Polls the Sandbox status until
         the state is no longer 'resizing'.
@@ -1014,9 +952,7 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to revoke SSH access: ")
     @with_instrumentation()
-    async def revoke_ssh_access(
-        self, token: str, request_timeout: float | None = None
-    ) -> None:
+    async def revoke_ssh_access(self, token: str, request_timeout: float | None = None) -> None:
         """Revokes an SSH access token for the sandbox.
 
         Args:
@@ -1026,15 +962,11 @@ class AsyncSandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = await self._sandbox_api.revoke_ssh_access(
-            self.id, token, _request_timeout=http_timeout(request_timeout)
-        )
+        _ = await self._sandbox_api.revoke_ssh_access(self.id, token, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to validate SSH access: ")
     @with_instrumentation()
-    async def validate_ssh_access(
-        self, token: str, request_timeout: float | None = None
-    ) -> SshAccessValidationDto:
+    async def validate_ssh_access(self, token: str, request_timeout: float | None = None) -> SshAccessValidationDto:
         """Validates an SSH access token for the sandbox.
 
         Args:
@@ -1044,9 +976,7 @@ class AsyncSandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        return await self._sandbox_api.validate_ssh_access(
-            token, _request_timeout=http_timeout(request_timeout)
-        )
+        return await self._sandbox_api.validate_ssh_access(token, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to refresh sandbox activity: ")
     async def refresh_activity(self, request_timeout: float | None = None) -> None:
@@ -1066,16 +996,12 @@ class AsyncSandbox(SandboxDto):
             await sandbox.refresh_activity()
             ```
         """
-        await self._sandbox_api.update_last_activity(
-            self.id, _request_timeout=http_timeout(request_timeout)
-        )
+        await self._sandbox_api.update_last_activity(self.id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to fork sandbox: ")
     @with_timeout()
     @with_instrumentation()
-    async def _experimental_fork(
-        self, name: str | None = None, timeout: float | None = 60
-    ) -> "AsyncSandbox":
+    async def _experimental_fork(self, name: str | None = None, timeout: float | None = 60) -> "AsyncSandbox":
         """Forks the Sandbox, creating a new Sandbox with an identical filesystem.
 
         The forked Sandbox is a copy-on-write clone of the original. It starts
@@ -1116,9 +1042,7 @@ class AsyncSandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to create snapshot: ")
     @with_instrumentation()
-    async def _experimental_create_snapshot(
-        self, name: str, timeout: float | None = 60
-    ) -> None:
+    async def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
         """Creates a snapshot from the current state of the Sandbox.
 
         This captures the Sandbox's filesystem into a reusable snapshot that can be
@@ -1148,9 +1072,7 @@ class AsyncSandbox(SandboxDto):
         )
         snapshot_id = accepted.id if accepted else None
         if not snapshot_id:
-            raise DaytonaError(
-                "Failed to create snapshot. Didn't receive a snapshot ID from the server API."
-            )
+            raise DaytonaError("Failed to create snapshot. Didn't receive a snapshot ID from the server API.")
 
         deadline = None if timeout in (None, 0) else start_time + timeout
         await self.__wait_for_snapshot_complete(snapshot_id, deadline)
@@ -1175,9 +1097,7 @@ class AsyncSandbox(SandboxDto):
             raise DaytonaError("Timeout must be a non-negative number")
 
         start_time = time.time()
-        _ = await self._sandbox_api.pause_sandbox(
-            self.id, _request_timeout=timeout if timeout > 0 else None
-        )
+        _ = await self._sandbox_api.pause_sandbox(self.id, _request_timeout=timeout if timeout > 0 else None)
         await self.refresh_data()
 
         elapsed = time.time() - start_time
@@ -1192,15 +1112,11 @@ class AsyncSandbox(SandboxDto):
                     f"Sandbox {self.id} pause failed with state: {self.state}, error reason: {self.error_reason}"
                 )
             if 0 < remaining <= time.time() - wait_start:
-                raise DaytonaError(
-                    f"Sandbox {self.id} failed to pause within {timeout} seconds"
-                )
+                raise DaytonaError(f"Sandbox {self.id} failed to pause within {timeout} seconds")
             await asyncio.sleep(check_interval)
             check_interval = min(check_interval * 1.5, 1.0)
 
-    async def __wait_for_snapshot_complete(
-        self, snapshot_id: str, deadline: float | None
-    ) -> None:
+    async def __wait_for_snapshot_complete(self, snapshot_id: str, deadline: float | None) -> None:
         check_interval = 0.1
         loop = asyncio.get_running_loop()
         start_time = loop.time()
@@ -1213,24 +1129,16 @@ class AsyncSandbox(SandboxDto):
 
             snapshot = await self._snapshots_api.get_snapshot(snapshot_id)
             if not snapshot or snapshot.id != snapshot_id:
-                raise DaytonaError(
-                    f"Snapshot lookup for {snapshot_id} returned an invalid response"
-                )
+                raise DaytonaError(f"Snapshot lookup for {snapshot_id} returned an invalid response")
 
             if snapshot.state == SnapshotState.ACTIVE:
                 try:
                     await self.refresh_data()
-                except (
-                    Exception
-                ):  # Best-effort local cleanup after definitive server success.
+                except Exception:  # Best-effort local cleanup after definitive server success.
                     pass
                 return
             if snapshot.state in (SnapshotState.ERROR, SnapshotState.BUILD_FAILED):
-                state = (
-                    snapshot.state.value
-                    if isinstance(snapshot.state, SnapshotState)
-                    else snapshot.state
-                )
+                state = snapshot.state.value
                 raise DaytonaError(
                     f"Snapshot {snapshot.id} failed with state: {state}, error reason: {snapshot.error_reason}"
                 )
@@ -1258,9 +1166,7 @@ class AsyncSandbox(SandboxDto):
         self.backup_state: str | None = sandbox_dto.backup_state
         self.auto_stop_interval: float | int | None = sandbox_dto.auto_stop_interval
         self.auto_pause_interval: float | int | None = sandbox_dto.auto_pause_interval
-        self.auto_archive_interval: float | int | None = (
-            sandbox_dto.auto_archive_interval
-        )
+        self.auto_archive_interval: float | int | None = sandbox_dto.auto_archive_interval
         self.auto_delete_interval: float | int | None = sandbox_dto.auto_delete_interval
         self.created_at: str | None = sandbox_dto.created_at
         self.updated_at: str | None = sandbox_dto.updated_at
@@ -1269,11 +1175,7 @@ class AsyncSandbox(SandboxDto):
 
         # Fields only present in the full SandboxDto (not returned by list results
         if isinstance(sandbox_dto, SandboxDto):
-            self.env: dict[
-                str, str
-            ] | None = (
-                sandbox_dto.env
-            )  # pyright: ignore[reportIncompatibleVariableOverride]
+            self.env: dict[str, str] | None = sandbox_dto.env  # pyright: ignore[reportIncompatibleVariableOverride]
             self.network_block_all: bool | None = (  # pyright: ignore[reportIncompatibleVariableOverride]
                 sandbox_dto.network_block_all
             )

--- a/sdk-python/src/daytona/_sync/sandbox.py
+++ b/sdk-python/src/daytona/_sync/sandbox.py
@@ -14,15 +14,22 @@ from pydantic import ConfigDict, PrivateAttr
 from daytona_analytics_api_client import ApiClient as AnalyticsApiClient
 from daytona_analytics_api_client import Configuration as AnalyticsConfiguration
 from daytona_analytics_api_client import TelemetryApi
-from daytona_api_client import BuildInfo, ConfigApi, CreateSandboxSnapshot, ForkSandbox, PortPreviewUrl, ResizeSandbox
-from daytona_api_client import Sandbox as SandboxDto
 from daytona_api_client import (
+    BuildInfo,
+    ConfigApi,
+    CreateSandboxSnapshot,
+    ForkSandbox,
+    PortPreviewUrl,
+    ResizeSandbox,
+    Sandbox as SandboxDto,
     SandboxApi,
     SandboxLabels,
     SandboxListItem,
     SandboxState,
     SandboxVolume,
     SignedPortPreviewUrl,
+    SnapshotState,
+    SnapshotsApi,
     SshAccessDto,
     SshAccessValidationDto,
     UpdateSandboxNetworkSettings,
@@ -46,7 +53,7 @@ from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from .._utils.timeout import http_timeout, with_timeout
 from ..common.daytona import CODE_TOOLBOX_LANGUAGE_LABEL
-from ..common.errors import DaytonaError, DaytonaNotFoundError, DaytonaValidationError
+from ..common.errors import DaytonaError, DaytonaNotFoundError, DaytonaTimeoutError, DaytonaValidationError
 from ..common.lsp_server import LspLanguageId, LspLanguageIdLiteral
 from ..common.sandbox import (
     SANDBOX_METRIC_NAMES,
@@ -148,6 +155,7 @@ class Sandbox(SandboxDto):
         super().__init__(**sandbox_dto.model_dump())
         self.__process_sandbox_dto(sandbox_dto)
         self._sandbox_api: SandboxApi = sandbox_api
+        self._snapshots_api: SnapshotsApi = SnapshotsApi(self._sandbox_api.api_client)
         self._analytics_api_url_provider: Callable[[], str | None] | None = analytics_api_url_provider
         self._http_client: httpx.Client = http_client
         # Wrap the toolbox API client to inject the sandbox ID into the resource path
@@ -1027,14 +1035,13 @@ class Sandbox(SandboxDto):
         return forked
 
     @intercept_errors(message_prefix="Failed to create snapshot: ")
-    @with_timeout()
     @with_instrumentation()
     def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
         """Creates a snapshot from the current state of the Sandbox.
 
         This captures the Sandbox's filesystem into a reusable snapshot that can be
-        used to create new Sandboxes. The Sandbox will temporarily enter a
-        'snapshotting' state and return to its previous state when complete.
+        used to create new Sandboxes. The method waits for the accepted snapshot
+        to become active.
 
         Args:
             name (str): Name for the new snapshot.
@@ -1050,11 +1057,16 @@ class Sandbox(SandboxDto):
             print("Snapshot created successfully")
             ```
         """
-        _ = self._sandbox_api.create_sandbox_snapshot(
+        start_time = time.monotonic()
+        accepted = self._sandbox_api.create_sandbox_snapshot(
             self.id, CreateSandboxSnapshot(name=name), _request_timeout=http_timeout(timeout)
         )
-        self.refresh_data()
-        self.__wait_for_snapshot_complete()
+        snapshot_id = accepted.id if accepted else None
+        if not snapshot_id:
+            raise DaytonaError("Failed to create snapshot. Didn't receive a snapshot ID from the server API.")
+
+        deadline = None if timeout in (None, 0) else start_time + timeout
+        self.__wait_for_snapshot_complete(snapshot_id, deadline)
 
     @intercept_errors(message_prefix="Failed to pause sandbox")
     @with_instrumentation()
@@ -1095,20 +1107,31 @@ class Sandbox(SandboxDto):
             time.sleep(check_interval)
             check_interval = min(check_interval * 1.5, 1.0)
 
-    def __wait_for_snapshot_complete(self) -> None:
+    def __wait_for_snapshot_complete(self, snapshot_id: str, deadline: float | None) -> None:
         check_interval = 0.1
         start_time = time.monotonic()
 
-        while self.state == "snapshotting":
-            self.refresh_data()
-
-            if self.state in ["error", "build_failed"]:
-                raise DaytonaError(
-                    f"Sandbox {self.id} snapshot failed with state: {self.state}, error reason: {self.error_reason}"
+        while True:
+            if deadline is not None and time.monotonic() >= deadline:
+                raise DaytonaTimeoutError(
+                    f"Timed out waiting for snapshot {snapshot_id}; capture continues on the server"
                 )
 
-            if self.state != "snapshotting":
+            snapshot = self._snapshots_api.get_snapshot(snapshot_id)
+            if not snapshot or snapshot.id != snapshot_id:
+                raise DaytonaError(f"Snapshot lookup for {snapshot_id} returned an invalid response")
+
+            if snapshot.state == SnapshotState.ACTIVE:
+                try:
+                    self.refresh_data()
+                except Exception:  # Best-effort local cleanup after definitive server success.
+                    pass
                 return
+            if snapshot.state in (SnapshotState.ERROR, SnapshotState.BUILD_FAILED):
+                state = snapshot.state.value if isinstance(snapshot.state, SnapshotState) else snapshot.state
+                raise DaytonaError(
+                    f"Snapshot {snapshot.id} failed with state: {state}, error reason: {snapshot.error_reason}"
+                )
 
             time.sleep(check_interval)
             if time.monotonic() - start_time > 5:

--- a/sdk-python/src/daytona/_sync/sandbox.py
+++ b/sdk-python/src/daytona/_sync/sandbox.py
@@ -21,15 +21,17 @@ from daytona_api_client import (
     ForkSandbox,
     PortPreviewUrl,
     ResizeSandbox,
-    Sandbox as SandboxDto,
+)
+from daytona_api_client import Sandbox as SandboxDto
+from daytona_api_client import (
     SandboxApi,
     SandboxLabels,
     SandboxListItem,
     SandboxState,
     SandboxVolume,
     SignedPortPreviewUrl,
-    SnapshotState,
     SnapshotsApi,
+    SnapshotState,
     SshAccessDto,
     SshAccessValidationDto,
     UpdateSandboxNetworkSettings,
@@ -53,7 +55,12 @@ from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from .._utils.timeout import http_timeout, with_timeout
 from ..common.daytona import CODE_TOOLBOX_LANGUAGE_LABEL
-from ..common.errors import DaytonaError, DaytonaNotFoundError, DaytonaTimeoutError, DaytonaValidationError
+from ..common.errors import (
+    DaytonaError,
+    DaytonaNotFoundError,
+    DaytonaTimeoutError,
+    DaytonaValidationError,
+)
 from ..common.lsp_server import LspLanguageId, LspLanguageIdLiteral
 from ..common.sandbox import (
     SANDBOX_METRIC_NAMES,
@@ -156,7 +163,9 @@ class Sandbox(SandboxDto):
         self.__process_sandbox_dto(sandbox_dto)
         self._sandbox_api: SandboxApi = sandbox_api
         self._snapshots_api: SnapshotsApi = SnapshotsApi(self._sandbox_api.api_client)
-        self._analytics_api_url_provider: Callable[[], str | None] | None = analytics_api_url_provider
+        self._analytics_api_url_provider: Callable[
+            [], str | None
+        ] | None = analytics_api_url_provider
         self._http_client: httpx.Client = http_client
         # Wrap the toolbox API client to inject the sandbox ID into the resource path
         self._toolbox_api: ToolboxApiClientProxy[ApiClient] = ToolboxApiClientProxy(
@@ -170,7 +179,9 @@ class Sandbox(SandboxDto):
             ProcessApi(self._toolbox_api),
             http_client=http_client,
         )
-        self._computer_use = ComputerUse(ComputerUseApi(self._toolbox_api), http_client=http_client)
+        self._computer_use = ComputerUse(
+            ComputerUseApi(self._toolbox_api), http_client=http_client
+        )
         self._code_interpreter = CodeInterpreter(
             InterpreterApi(self._toolbox_api),
             http_client=http_client,
@@ -218,7 +229,9 @@ class Sandbox(SandboxDto):
             print(f"Resources: {sandbox.cpu} CPU, {sandbox.memory} GiB RAM")
             ```
         """
-        instance = self._sandbox_api.get_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
+        instance = self._sandbox_api.get_sandbox(
+            self.id, _request_timeout=http_timeout(request_timeout)
+        )
         self.__process_sandbox_dto(instance)
 
     @intercept_errors(message_prefix="Failed to get user home directory: ")
@@ -276,11 +289,15 @@ class Sandbox(SandboxDto):
         Returns:
             SandboxMetrics: The current CPU, memory, and disk usage sample for the Sandbox.
         """
-        return sandbox_metrics_from_system_metrics(self._system_api.get_system_metrics())
+        return sandbox_metrics_from_system_metrics(
+            self._system_api.get_system_metrics()
+        )
 
     @intercept_errors(message_prefix="Failed to get sandbox metrics: ")
     @with_instrumentation()
-    def get_metrics(self, start: datetime | None = None, end: datetime | None = None) -> list[SandboxMetrics]:
+    def get_metrics(
+        self, start: datetime | None = None, end: datetime | None = None
+    ) -> list[SandboxMetrics]:
         """Gets historical time-series resource usage metrics for the Sandbox.
 
         When the deployment runs a dedicated Analytics API, metrics are fetched from it
@@ -297,7 +314,11 @@ class Sandbox(SandboxDto):
         if end is None:
             end = datetime.now(timezone.utc)
         if start is None:
-            start = datetime.fromisoformat(self.created_at.replace("Z", "+00:00")) if self.created_at else end
+            start = (
+                datetime.fromisoformat(self.created_at.replace("Z", "+00:00"))
+                if self.created_at
+                else end
+            )
 
         analytics_api_url = self._get_analytics_api_url()
         if analytics_api_url:
@@ -310,27 +331,39 @@ class Sandbox(SandboxDto):
                 to=end.isoformat(),
                 metric_names=",".join(SANDBOX_METRIC_NAMES),
             )
-            return pivot_sandbox_metrics((p.metric_name, p.timestamp, p.value) for p in points)
+            return pivot_sandbox_metrics(
+                (p.metric_name, p.timestamp, p.value) for p in points
+            )
 
         response = self._sandbox_api.get_sandbox_metrics(
             self.id, var_from=start, to=end, metric_names=SANDBOX_METRIC_NAMES
         )
         return pivot_sandbox_metrics(
-            (s.metric_name, dp.timestamp, dp.value) for s in response.series or [] for dp in s.data_points or []
+            (s.metric_name, dp.timestamp, dp.value)
+            for s in response.series or []
+            for dp in s.data_points or []
         )
 
     def _get_analytics_api_url(self) -> str | None:
         if self._analytics_api_url_provider is not None:
             return self._analytics_api_url_provider()
-        return ConfigApi(self._sandbox_api.api_client).config_controller_get_config().analytics_api_url
+        return (
+            ConfigApi(self._sandbox_api.api_client)
+            .config_controller_get_config()
+            .analytics_api_url
+        )
 
     def _build_analytics_telemetry_api(self, analytics_api_url: str) -> TelemetryApi:
         client = AnalyticsApiClient(AnalyticsConfiguration(host=analytics_api_url))
-        client.default_headers["Authorization"] = self._sandbox_api.api_client.default_headers["Authorization"]
+        client.default_headers[
+            "Authorization"
+        ] = self._sandbox_api.api_client.default_headers["Authorization"]
         return TelemetryApi(client)
 
     @with_instrumentation()
-    def create_lsp_server(self, language_id: LspLanguageId | LspLanguageIdLiteral, path_to_project: str) -> LspServer:
+    def create_lsp_server(
+        self, language_id: LspLanguageId | LspLanguageIdLiteral, path_to_project: str
+    ) -> LspServer:
         """Creates a new Language Server Protocol (LSP) server instance.
 
         The LSP server provides language-specific features like code completion,
@@ -357,7 +390,9 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set labels: ")
     @with_instrumentation()
-    def set_labels(self, labels: dict[str, str], request_timeout: float | None = None) -> dict[str, str]:
+    def set_labels(
+        self, labels: dict[str, str], request_timeout: float | None = None
+    ) -> dict[str, str]:
         """Sets labels for the Sandbox.
 
         Labels are key-value pairs that can be used to organize and identify Sandboxes.
@@ -384,7 +419,9 @@ class Sandbox(SandboxDto):
         """
         self.labels = (
             self._sandbox_api.replace_labels(
-                self.id, SandboxLabels(labels=labels), _request_timeout=http_timeout(request_timeout)
+                self.id,
+                SandboxLabels(labels=labels),
+                _request_timeout=http_timeout(request_timeout),
             )
         ).labels
         return self.labels
@@ -408,7 +445,9 @@ class Sandbox(SandboxDto):
             print("Sandbox started successfully")
             ```
         """
-        sandbox = self._sandbox_api.start_sandbox(self.id, _request_timeout=http_timeout(timeout))
+        sandbox = self._sandbox_api.start_sandbox(
+            self.id, _request_timeout=http_timeout(timeout)
+        )
         self.__process_sandbox_dto(sandbox)
         # This method already handles a timeout, so we don't need to pass one to internal methods
         self.wait_for_sandbox_start(timeout=0)
@@ -431,7 +470,9 @@ class Sandbox(SandboxDto):
             print("Sandbox recovered successfully")
             ```
         """
-        sandbox = self._sandbox_api.recover_sandbox(self.id, _request_timeout=http_timeout(timeout))
+        sandbox = self._sandbox_api.recover_sandbox(
+            self.id, _request_timeout=http_timeout(timeout)
+        )
         self.__process_sandbox_dto(sandbox)
         # This method already handles a timeout, so we don't need to pass one to internal methods
         self.wait_for_sandbox_start(timeout=0)
@@ -456,7 +497,9 @@ class Sandbox(SandboxDto):
             print("Sandbox stopped successfully")
             ```
         """
-        _ = self._sandbox_api.stop_sandbox(self.id, force=force, _request_timeout=http_timeout(timeout))
+        _ = self._sandbox_api.stop_sandbox(
+            self.id, force=force, _request_timeout=http_timeout(timeout)
+        )
         self.__refresh_data_safe()
         # This method already handles a timeout, so we don't need to pass one to internal methods
         self.wait_for_sandbox_stop(timeout=0)
@@ -471,7 +514,9 @@ class Sandbox(SandboxDto):
             timeout (float | None): Timeout (in seconds) for sandbox deletion. 0 means no timeout.
                 Default is 60 seconds.
         """
-        _ = self._sandbox_api.delete_sandbox(self.id, _request_timeout=http_timeout(timeout))
+        _ = self._sandbox_api.delete_sandbox(
+            self.id, _request_timeout=http_timeout(timeout)
+        )
         self.__refresh_data_safe()
 
     @intercept_errors(message_prefix="Failure during waiting for sandbox to start: ")
@@ -479,7 +524,8 @@ class Sandbox(SandboxDto):
     @with_instrumentation()
     def wait_for_sandbox_start(
         self,
-        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float
+        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox to reach the 'started' state. Polls the Sandbox status until it
         reaches the 'started' state, encounters an error or times out.
@@ -500,9 +546,7 @@ class Sandbox(SandboxDto):
                 return
 
             if self.state in ["error", "build_failed"]:
-                err_msg = (
-                    f"Sandbox {self.id} failed to start with state: {self.state}, error reason: {self.error_reason}"
-                )
+                err_msg = f"Sandbox {self.id} failed to start with state: {self.state}, error reason: {self.error_reason}"
                 raise DaytonaError(err_msg)
 
             time.sleep(check_interval)
@@ -514,7 +558,8 @@ class Sandbox(SandboxDto):
     @with_instrumentation()
     def wait_for_sandbox_stop(
         self,
-        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float
+        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox to reach the 'stopped' state. Polls the Sandbox status until it
         reaches the 'stopped' state, encounters an error or times out. It will wait up to 60 seconds
@@ -535,9 +580,7 @@ class Sandbox(SandboxDto):
                 self.__refresh_data_safe()
 
                 if self.state in ["error", "build_failed"]:
-                    err_msg = (
-                        f"Sandbox {self.id} failed to stop with status: {self.state}, error reason: {self.error_reason}"
-                    )
+                    err_msg = f"Sandbox {self.id} failed to stop with status: {self.state}, error reason: {self.error_reason}"
                     raise DaytonaError(err_msg)
             except Exception as e:
                 # If there's a validation error, continue waiting
@@ -550,7 +593,9 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set auto-stop interval: ")
     @with_instrumentation()
-    def set_autostop_interval(self, interval: int, request_timeout: float | None = None) -> None:
+    def set_autostop_interval(
+        self, interval: int, request_timeout: float | None = None
+    ) -> None:
         """Sets the auto-stop interval for the Sandbox.
 
         The Sandbox will automatically stop after being idle (no new events) for the specified interval.
@@ -577,9 +622,13 @@ class Sandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError("Auto-stop interval must be a non-negative integer")
+            raise DaytonaValidationError(
+                "Auto-stop interval must be a non-negative integer"
+            )
 
-        _ = self._sandbox_api.set_autostop_interval(self.id, interval, _request_timeout=http_timeout(request_timeout))
+        _ = self._sandbox_api.set_autostop_interval(
+            self.id, interval, _request_timeout=http_timeout(request_timeout)
+        )
         self.auto_stop_interval = interval
 
     @intercept_errors(message_prefix="Failed to set auto-pause interval: ")
@@ -606,14 +655,18 @@ class Sandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError("Auto-pause interval must be a non-negative integer")
+            raise DaytonaValidationError(
+                "Auto-pause interval must be a non-negative integer"
+            )
 
         _ = self._sandbox_api.set_auto_pause_interval(self.id, interval)
         self.auto_pause_interval = interval
 
     @intercept_errors(message_prefix="Failed to set auto-archive interval: ")
     @with_instrumentation()
-    def set_auto_archive_interval(self, interval: int, request_timeout: float | None = None) -> None:
+    def set_auto_archive_interval(
+        self, interval: int, request_timeout: float | None = None
+    ) -> None:
         """Sets the auto-archive interval for the Sandbox.
 
         The Sandbox will automatically archive after being continuously stopped for the specified interval.
@@ -638,7 +691,9 @@ class Sandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError("Auto-archive interval must be a non-negative integer")
+            raise DaytonaValidationError(
+                "Auto-archive interval must be a non-negative integer"
+            )
 
         _ = self._sandbox_api.set_auto_archive_interval(
             self.id, interval, _request_timeout=http_timeout(request_timeout)
@@ -647,7 +702,9 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set auto-delete interval: ")
     @with_instrumentation()
-    def set_auto_delete_interval(self, interval: int, request_timeout: float | None = None) -> None:
+    def set_auto_delete_interval(
+        self, interval: int, request_timeout: float | None = None
+    ) -> None:
         """Sets the auto-delete interval for the Sandbox.
 
         The Sandbox will automatically delete after being continuously stopped for the specified interval.
@@ -707,7 +764,11 @@ class Sandbox(SandboxDto):
             sandbox.update_network_settings(network_block_all=False)
             ```
         """
-        if network_block_all is None and network_allow_list is None and domain_allow_list is None:
+        if (
+            network_block_all is None
+            and network_allow_list is None
+            and domain_allow_list is None
+        ):
             raise DaytonaValidationError(
                 "At least one of network_block_all, network_allow_list or domain_allow_list must be set"
             )
@@ -743,13 +804,17 @@ class Sandbox(SandboxDto):
             sandbox.update_secrets({})  # detach all
             ```
         """
-        body = UpdateSandboxSecrets(secrets=[{env_var: secret_name} for env_var, secret_name in secrets.items()])
+        body = UpdateSandboxSecrets(
+            secrets=[{env_var: secret_name} for env_var, secret_name in secrets.items()]
+        )
         updated = self._sandbox_api.update_sandbox_secrets(self.id, body)
         self.__process_sandbox_dto(updated)
 
     @intercept_errors(message_prefix="Failed to update environment: ")
     @with_instrumentation()
-    def update_env(self, env: dict[str, str], *, unset: list[str] | None = None) -> None:
+    def update_env(
+        self, env: dict[str, str], *, unset: list[str] | None = None
+    ) -> None:
         """Updates the Sandbox daemon's process environment.
 
         Newly spawned processes, sessions and PTYs inherit the change; already-running processes
@@ -769,7 +834,9 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to get preview link: ")
     @with_instrumentation()
-    def get_preview_link(self, port: int, request_timeout: float | None = None) -> PortPreviewUrl:
+    def get_preview_link(
+        self, port: int, request_timeout: float | None = None
+    ) -> PortPreviewUrl:
         """Retrieves the preview link for the sandbox at the specified port. If the port is closed,
         it will be opened automatically. For private sandboxes, a token is included to grant access
         to the URL.
@@ -792,11 +859,16 @@ class Sandbox(SandboxDto):
             print(f"Token: {preview_link.token}")
             ```
         """
-        return self._sandbox_api.get_port_preview_url(self.id, port, _request_timeout=http_timeout(request_timeout))
+        return self._sandbox_api.get_port_preview_url(
+            self.id, port, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to create signed preview url: ")
     def create_signed_preview_url(
-        self, port: int, expires_in_seconds: int | None = None, request_timeout: float | None = None
+        self,
+        port: int,
+        expires_in_seconds: int | None = None,
+        request_timeout: float | None = None,
     ) -> SignedPortPreviewUrl:
         """Creates a signed preview URL for the sandbox at the specified port.
 
@@ -813,11 +885,16 @@ class Sandbox(SandboxDto):
             SignedPortPreviewUrl: The response object for the signed preview url.
         """
         return self._sandbox_api.get_signed_port_preview_url(
-            self.id, port, expires_in_seconds=expires_in_seconds, _request_timeout=http_timeout(request_timeout)
+            self.id,
+            port,
+            expires_in_seconds=expires_in_seconds,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to expire signed preview url: ")
-    def expire_signed_preview_url(self, port: int, token: str, request_timeout: float | None = None) -> None:
+    def expire_signed_preview_url(
+        self, port: int, token: str, request_timeout: float | None = None
+    ) -> None:
         """Expires a signed preview URL for the sandbox at the specified port.
 
         Args:
@@ -847,7 +924,9 @@ class Sandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = self._sandbox_api.archive_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
+        _ = self._sandbox_api.archive_sandbox(
+            self.id, _request_timeout=http_timeout(request_timeout)
+        )
         self.refresh_data(request_timeout=request_timeout)
 
     @intercept_errors(message_prefix="Failed to resize sandbox: ")
@@ -888,7 +967,9 @@ class Sandbox(SandboxDto):
             memory=resources.memory,
             disk=resources.disk,
         )
-        sandbox = self._sandbox_api.resize_sandbox(self.id, resize_request, _request_timeout=timeout or None)
+        sandbox = self._sandbox_api.resize_sandbox(
+            self.id, resize_request, _request_timeout=timeout or None
+        )
         self.__process_sandbox_dto(sandbox)
         self.wait_for_resize_complete(timeout=0)
 
@@ -897,7 +978,8 @@ class Sandbox(SandboxDto):
     @with_instrumentation()
     def wait_for_resize_complete(
         self,
-        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float
+        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox resize operation to complete. Polls the Sandbox status until
         the state is no longer 'resizing'.
@@ -928,7 +1010,9 @@ class Sandbox(SandboxDto):
     @intercept_errors(message_prefix="Failed to create SSH access: ")
     @with_instrumentation()
     def create_ssh_access(
-        self, expires_in_minutes: int | None = None, request_timeout: float | None = None
+        self,
+        expires_in_minutes: int | None = None,
+        request_timeout: float | None = None,
     ) -> SshAccessDto:
         """Creates an SSH access token for the sandbox.
 
@@ -940,12 +1024,16 @@ class Sandbox(SandboxDto):
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
         return self._sandbox_api.create_ssh_access(
-            self.id, expires_in_minutes=expires_in_minutes, _request_timeout=http_timeout(request_timeout)
+            self.id,
+            expires_in_minutes=expires_in_minutes,
+            _request_timeout=http_timeout(request_timeout),
         )
 
     @intercept_errors(message_prefix="Failed to revoke SSH access: ")
     @with_instrumentation()
-    def revoke_ssh_access(self, token: str, request_timeout: float | None = None) -> None:
+    def revoke_ssh_access(
+        self, token: str, request_timeout: float | None = None
+    ) -> None:
         """Revokes an SSH access token for the sandbox.
 
         Args:
@@ -955,11 +1043,15 @@ class Sandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = self._sandbox_api.revoke_ssh_access(self.id, token, _request_timeout=http_timeout(request_timeout))
+        _ = self._sandbox_api.revoke_ssh_access(
+            self.id, token, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to validate SSH access: ")
     @with_instrumentation()
-    def validate_ssh_access(self, token: str, request_timeout: float | None = None) -> SshAccessValidationDto:
+    def validate_ssh_access(
+        self, token: str, request_timeout: float | None = None
+    ) -> SshAccessValidationDto:
         """Validates an SSH access token for the sandbox.
 
         Args:
@@ -969,7 +1061,9 @@ class Sandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        return self._sandbox_api.validate_ssh_access(token, _request_timeout=http_timeout(request_timeout))
+        return self._sandbox_api.validate_ssh_access(
+            token, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to refresh sandbox activity: ")
     def refresh_activity(self, request_timeout: float | None = None) -> None:
@@ -989,12 +1083,16 @@ class Sandbox(SandboxDto):
             sandbox.refresh_activity()
             ```
         """
-        self._sandbox_api.update_last_activity(self.id, _request_timeout=http_timeout(request_timeout))
+        self._sandbox_api.update_last_activity(
+            self.id, _request_timeout=http_timeout(request_timeout)
+        )
 
     @intercept_errors(message_prefix="Failed to fork sandbox: ")
     @with_timeout()
     @with_instrumentation()
-    def _experimental_fork(self, name: str | None = None, timeout: float | None = 60) -> "Sandbox":
+    def _experimental_fork(
+        self, name: str | None = None, timeout: float | None = 60
+    ) -> "Sandbox":
         """Forks the Sandbox, creating a new Sandbox with an identical filesystem.
 
         The forked Sandbox is a copy-on-write clone of the original. It starts
@@ -1036,7 +1134,9 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to create snapshot: ")
     @with_instrumentation()
-    def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
+    def _experimental_create_snapshot(
+        self, name: str, timeout: float | None = 60
+    ) -> None:
         """Creates a snapshot from the current state of the Sandbox.
 
         This captures the Sandbox's filesystem into a reusable snapshot that can be
@@ -1059,11 +1159,15 @@ class Sandbox(SandboxDto):
         """
         start_time = time.monotonic()
         accepted = self._sandbox_api.create_sandbox_snapshot(
-            self.id, CreateSandboxSnapshot(name=name), _request_timeout=http_timeout(timeout)
+            self.id,
+            CreateSandboxSnapshot(name=name),
+            _request_timeout=http_timeout(timeout),
         )
         snapshot_id = accepted.id if accepted else None
         if not snapshot_id:
-            raise DaytonaError("Failed to create snapshot. Didn't receive a snapshot ID from the server API.")
+            raise DaytonaError(
+                "Failed to create snapshot. Didn't receive a snapshot ID from the server API."
+            )
 
         deadline = None if timeout in (None, 0) else start_time + timeout
         self.__wait_for_snapshot_complete(snapshot_id, deadline)
@@ -1088,7 +1192,9 @@ class Sandbox(SandboxDto):
             raise DaytonaError("Timeout must be a non-negative number")
 
         start_time = time.time()
-        _ = self._sandbox_api.pause_sandbox(self.id, _request_timeout=timeout if timeout > 0 else None)
+        _ = self._sandbox_api.pause_sandbox(
+            self.id, _request_timeout=timeout if timeout > 0 else None
+        )
         self.refresh_data()
 
         elapsed = time.time() - start_time
@@ -1103,11 +1209,15 @@ class Sandbox(SandboxDto):
                     f"Sandbox {self.id} pause failed with state: {self.state}, error reason: {self.error_reason}"
                 )
             if 0 < remaining <= time.time() - wait_start:
-                raise DaytonaError(f"Sandbox {self.id} failed to pause within {timeout} seconds")
+                raise DaytonaError(
+                    f"Sandbox {self.id} failed to pause within {timeout} seconds"
+                )
             time.sleep(check_interval)
             check_interval = min(check_interval * 1.5, 1.0)
 
-    def __wait_for_snapshot_complete(self, snapshot_id: str, deadline: float | None) -> None:
+    def __wait_for_snapshot_complete(
+        self, snapshot_id: str, deadline: float | None
+    ) -> None:
         check_interval = 0.1
         start_time = time.monotonic()
 
@@ -1119,16 +1229,24 @@ class Sandbox(SandboxDto):
 
             snapshot = self._snapshots_api.get_snapshot(snapshot_id)
             if not snapshot or snapshot.id != snapshot_id:
-                raise DaytonaError(f"Snapshot lookup for {snapshot_id} returned an invalid response")
+                raise DaytonaError(
+                    f"Snapshot lookup for {snapshot_id} returned an invalid response"
+                )
 
             if snapshot.state == SnapshotState.ACTIVE:
                 try:
                     self.refresh_data()
-                except Exception:  # Best-effort local cleanup after definitive server success.
+                except (
+                    Exception
+                ):  # Best-effort local cleanup after definitive server success.
                     pass
                 return
             if snapshot.state in (SnapshotState.ERROR, SnapshotState.BUILD_FAILED):
-                state = snapshot.state.value if isinstance(snapshot.state, SnapshotState) else snapshot.state
+                state = (
+                    snapshot.state.value
+                    if isinstance(snapshot.state, SnapshotState)
+                    else snapshot.state
+                )
                 raise DaytonaError(
                     f"Snapshot {snapshot.id} failed with state: {state}, error reason: {snapshot.error_reason}"
                 )
@@ -1156,7 +1274,9 @@ class Sandbox(SandboxDto):
         self.backup_state: str | None = sandbox_dto.backup_state
         self.auto_stop_interval: float | int | None = sandbox_dto.auto_stop_interval
         self.auto_pause_interval: float | int | None = sandbox_dto.auto_pause_interval
-        self.auto_archive_interval: float | int | None = sandbox_dto.auto_archive_interval
+        self.auto_archive_interval: float | int | None = (
+            sandbox_dto.auto_archive_interval
+        )
         self.auto_delete_interval: float | int | None = sandbox_dto.auto_delete_interval
         self.created_at: str | None = sandbox_dto.created_at
         self.updated_at: str | None = sandbox_dto.updated_at
@@ -1165,7 +1285,11 @@ class Sandbox(SandboxDto):
 
         # Fields only present in the full SandboxDto (not returned by list results
         if isinstance(sandbox_dto, SandboxDto):
-            self.env: dict[str, str] | None = sandbox_dto.env  # pyright: ignore[reportIncompatibleVariableOverride]
+            self.env: dict[
+                str, str
+            ] | None = (
+                sandbox_dto.env
+            )  # pyright: ignore[reportIncompatibleVariableOverride]
             self.network_block_all: bool | None = (  # pyright: ignore[reportIncompatibleVariableOverride]
                 sandbox_dto.network_block_all
             )

--- a/sdk-python/src/daytona/_sync/sandbox.py
+++ b/sdk-python/src/daytona/_sync/sandbox.py
@@ -14,14 +14,7 @@ from pydantic import ConfigDict, PrivateAttr
 from daytona_analytics_api_client import ApiClient as AnalyticsApiClient
 from daytona_analytics_api_client import Configuration as AnalyticsConfiguration
 from daytona_analytics_api_client import TelemetryApi
-from daytona_api_client import (
-    BuildInfo,
-    ConfigApi,
-    CreateSandboxSnapshot,
-    ForkSandbox,
-    PortPreviewUrl,
-    ResizeSandbox,
-)
+from daytona_api_client import BuildInfo, ConfigApi, CreateSandboxSnapshot, ForkSandbox, PortPreviewUrl, ResizeSandbox
 from daytona_api_client import Sandbox as SandboxDto
 from daytona_api_client import (
     SandboxApi,
@@ -55,12 +48,7 @@ from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from .._utils.timeout import http_timeout, with_timeout
 from ..common.daytona import CODE_TOOLBOX_LANGUAGE_LABEL
-from ..common.errors import (
-    DaytonaError,
-    DaytonaNotFoundError,
-    DaytonaTimeoutError,
-    DaytonaValidationError,
-)
+from ..common.errors import DaytonaError, DaytonaNotFoundError, DaytonaTimeoutError, DaytonaValidationError
 from ..common.lsp_server import LspLanguageId, LspLanguageIdLiteral
 from ..common.sandbox import (
     SANDBOX_METRIC_NAMES,
@@ -163,9 +151,7 @@ class Sandbox(SandboxDto):
         self.__process_sandbox_dto(sandbox_dto)
         self._sandbox_api: SandboxApi = sandbox_api
         self._snapshots_api: SnapshotsApi = SnapshotsApi(self._sandbox_api.api_client)
-        self._analytics_api_url_provider: Callable[
-            [], str | None
-        ] | None = analytics_api_url_provider
+        self._analytics_api_url_provider: Callable[[], str | None] | None = analytics_api_url_provider
         self._http_client: httpx.Client = http_client
         # Wrap the toolbox API client to inject the sandbox ID into the resource path
         self._toolbox_api: ToolboxApiClientProxy[ApiClient] = ToolboxApiClientProxy(
@@ -179,9 +165,7 @@ class Sandbox(SandboxDto):
             ProcessApi(self._toolbox_api),
             http_client=http_client,
         )
-        self._computer_use = ComputerUse(
-            ComputerUseApi(self._toolbox_api), http_client=http_client
-        )
+        self._computer_use = ComputerUse(ComputerUseApi(self._toolbox_api), http_client=http_client)
         self._code_interpreter = CodeInterpreter(
             InterpreterApi(self._toolbox_api),
             http_client=http_client,
@@ -229,9 +213,7 @@ class Sandbox(SandboxDto):
             print(f"Resources: {sandbox.cpu} CPU, {sandbox.memory} GiB RAM")
             ```
         """
-        instance = self._sandbox_api.get_sandbox(
-            self.id, _request_timeout=http_timeout(request_timeout)
-        )
+        instance = self._sandbox_api.get_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
         self.__process_sandbox_dto(instance)
 
     @intercept_errors(message_prefix="Failed to get user home directory: ")
@@ -289,15 +271,11 @@ class Sandbox(SandboxDto):
         Returns:
             SandboxMetrics: The current CPU, memory, and disk usage sample for the Sandbox.
         """
-        return sandbox_metrics_from_system_metrics(
-            self._system_api.get_system_metrics()
-        )
+        return sandbox_metrics_from_system_metrics(self._system_api.get_system_metrics())
 
     @intercept_errors(message_prefix="Failed to get sandbox metrics: ")
     @with_instrumentation()
-    def get_metrics(
-        self, start: datetime | None = None, end: datetime | None = None
-    ) -> list[SandboxMetrics]:
+    def get_metrics(self, start: datetime | None = None, end: datetime | None = None) -> list[SandboxMetrics]:
         """Gets historical time-series resource usage metrics for the Sandbox.
 
         When the deployment runs a dedicated Analytics API, metrics are fetched from it
@@ -314,11 +292,7 @@ class Sandbox(SandboxDto):
         if end is None:
             end = datetime.now(timezone.utc)
         if start is None:
-            start = (
-                datetime.fromisoformat(self.created_at.replace("Z", "+00:00"))
-                if self.created_at
-                else end
-            )
+            start = datetime.fromisoformat(self.created_at.replace("Z", "+00:00")) if self.created_at else end
 
         analytics_api_url = self._get_analytics_api_url()
         if analytics_api_url:
@@ -331,39 +305,27 @@ class Sandbox(SandboxDto):
                 to=end.isoformat(),
                 metric_names=",".join(SANDBOX_METRIC_NAMES),
             )
-            return pivot_sandbox_metrics(
-                (p.metric_name, p.timestamp, p.value) for p in points
-            )
+            return pivot_sandbox_metrics((p.metric_name, p.timestamp, p.value) for p in points)
 
         response = self._sandbox_api.get_sandbox_metrics(
             self.id, var_from=start, to=end, metric_names=SANDBOX_METRIC_NAMES
         )
         return pivot_sandbox_metrics(
-            (s.metric_name, dp.timestamp, dp.value)
-            for s in response.series or []
-            for dp in s.data_points or []
+            (s.metric_name, dp.timestamp, dp.value) for s in response.series or [] for dp in s.data_points or []
         )
 
     def _get_analytics_api_url(self) -> str | None:
         if self._analytics_api_url_provider is not None:
             return self._analytics_api_url_provider()
-        return (
-            ConfigApi(self._sandbox_api.api_client)
-            .config_controller_get_config()
-            .analytics_api_url
-        )
+        return ConfigApi(self._sandbox_api.api_client).config_controller_get_config().analytics_api_url
 
     def _build_analytics_telemetry_api(self, analytics_api_url: str) -> TelemetryApi:
         client = AnalyticsApiClient(AnalyticsConfiguration(host=analytics_api_url))
-        client.default_headers[
-            "Authorization"
-        ] = self._sandbox_api.api_client.default_headers["Authorization"]
+        client.default_headers["Authorization"] = self._sandbox_api.api_client.default_headers["Authorization"]
         return TelemetryApi(client)
 
     @with_instrumentation()
-    def create_lsp_server(
-        self, language_id: LspLanguageId | LspLanguageIdLiteral, path_to_project: str
-    ) -> LspServer:
+    def create_lsp_server(self, language_id: LspLanguageId | LspLanguageIdLiteral, path_to_project: str) -> LspServer:
         """Creates a new Language Server Protocol (LSP) server instance.
 
         The LSP server provides language-specific features like code completion,
@@ -390,9 +352,7 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set labels: ")
     @with_instrumentation()
-    def set_labels(
-        self, labels: dict[str, str], request_timeout: float | None = None
-    ) -> dict[str, str]:
+    def set_labels(self, labels: dict[str, str], request_timeout: float | None = None) -> dict[str, str]:
         """Sets labels for the Sandbox.
 
         Labels are key-value pairs that can be used to organize and identify Sandboxes.
@@ -445,9 +405,7 @@ class Sandbox(SandboxDto):
             print("Sandbox started successfully")
             ```
         """
-        sandbox = self._sandbox_api.start_sandbox(
-            self.id, _request_timeout=http_timeout(timeout)
-        )
+        sandbox = self._sandbox_api.start_sandbox(self.id, _request_timeout=http_timeout(timeout))
         self.__process_sandbox_dto(sandbox)
         # This method already handles a timeout, so we don't need to pass one to internal methods
         self.wait_for_sandbox_start(timeout=0)
@@ -470,9 +428,7 @@ class Sandbox(SandboxDto):
             print("Sandbox recovered successfully")
             ```
         """
-        sandbox = self._sandbox_api.recover_sandbox(
-            self.id, _request_timeout=http_timeout(timeout)
-        )
+        sandbox = self._sandbox_api.recover_sandbox(self.id, _request_timeout=http_timeout(timeout))
         self.__process_sandbox_dto(sandbox)
         # This method already handles a timeout, so we don't need to pass one to internal methods
         self.wait_for_sandbox_start(timeout=0)
@@ -497,9 +453,7 @@ class Sandbox(SandboxDto):
             print("Sandbox stopped successfully")
             ```
         """
-        _ = self._sandbox_api.stop_sandbox(
-            self.id, force=force, _request_timeout=http_timeout(timeout)
-        )
+        _ = self._sandbox_api.stop_sandbox(self.id, force=force, _request_timeout=http_timeout(timeout))
         self.__refresh_data_safe()
         # This method already handles a timeout, so we don't need to pass one to internal methods
         self.wait_for_sandbox_stop(timeout=0)
@@ -514,9 +468,7 @@ class Sandbox(SandboxDto):
             timeout (float | None): Timeout (in seconds) for sandbox deletion. 0 means no timeout.
                 Default is 60 seconds.
         """
-        _ = self._sandbox_api.delete_sandbox(
-            self.id, _request_timeout=http_timeout(timeout)
-        )
+        _ = self._sandbox_api.delete_sandbox(self.id, _request_timeout=http_timeout(timeout))
         self.__refresh_data_safe()
 
     @intercept_errors(message_prefix="Failure during waiting for sandbox to start: ")
@@ -524,8 +476,7 @@ class Sandbox(SandboxDto):
     @with_instrumentation()
     def wait_for_sandbox_start(
         self,
-        timeout: float
-        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox to reach the 'started' state. Polls the Sandbox status until it
         reaches the 'started' state, encounters an error or times out.
@@ -546,7 +497,9 @@ class Sandbox(SandboxDto):
                 return
 
             if self.state in ["error", "build_failed"]:
-                err_msg = f"Sandbox {self.id} failed to start with state: {self.state}, error reason: {self.error_reason}"
+                err_msg = (
+                    f"Sandbox {self.id} failed to start with state: {self.state}, error reason: {self.error_reason}"
+                )
                 raise DaytonaError(err_msg)
 
             time.sleep(check_interval)
@@ -558,8 +511,7 @@ class Sandbox(SandboxDto):
     @with_instrumentation()
     def wait_for_sandbox_stop(
         self,
-        timeout: float
-        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox to reach the 'stopped' state. Polls the Sandbox status until it
         reaches the 'stopped' state, encounters an error or times out. It will wait up to 60 seconds
@@ -580,7 +532,9 @@ class Sandbox(SandboxDto):
                 self.__refresh_data_safe()
 
                 if self.state in ["error", "build_failed"]:
-                    err_msg = f"Sandbox {self.id} failed to stop with status: {self.state}, error reason: {self.error_reason}"
+                    err_msg = (
+                        f"Sandbox {self.id} failed to stop with status: {self.state}, error reason: {self.error_reason}"
+                    )
                     raise DaytonaError(err_msg)
             except Exception as e:
                 # If there's a validation error, continue waiting
@@ -593,9 +547,7 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set auto-stop interval: ")
     @with_instrumentation()
-    def set_autostop_interval(
-        self, interval: int, request_timeout: float | None = None
-    ) -> None:
+    def set_autostop_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-stop interval for the Sandbox.
 
         The Sandbox will automatically stop after being idle (no new events) for the specified interval.
@@ -622,13 +574,9 @@ class Sandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError(
-                "Auto-stop interval must be a non-negative integer"
-            )
+            raise DaytonaValidationError("Auto-stop interval must be a non-negative integer")
 
-        _ = self._sandbox_api.set_autostop_interval(
-            self.id, interval, _request_timeout=http_timeout(request_timeout)
-        )
+        _ = self._sandbox_api.set_autostop_interval(self.id, interval, _request_timeout=http_timeout(request_timeout))
         self.auto_stop_interval = interval
 
     @intercept_errors(message_prefix="Failed to set auto-pause interval: ")
@@ -655,18 +603,14 @@ class Sandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError(
-                "Auto-pause interval must be a non-negative integer"
-            )
+            raise DaytonaValidationError("Auto-pause interval must be a non-negative integer")
 
         _ = self._sandbox_api.set_auto_pause_interval(self.id, interval)
         self.auto_pause_interval = interval
 
     @intercept_errors(message_prefix="Failed to set auto-archive interval: ")
     @with_instrumentation()
-    def set_auto_archive_interval(
-        self, interval: int, request_timeout: float | None = None
-    ) -> None:
+    def set_auto_archive_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-archive interval for the Sandbox.
 
         The Sandbox will automatically archive after being continuously stopped for the specified interval.
@@ -691,9 +635,7 @@ class Sandbox(SandboxDto):
             ```
         """
         if interval < 0:
-            raise DaytonaValidationError(
-                "Auto-archive interval must be a non-negative integer"
-            )
+            raise DaytonaValidationError("Auto-archive interval must be a non-negative integer")
 
         _ = self._sandbox_api.set_auto_archive_interval(
             self.id, interval, _request_timeout=http_timeout(request_timeout)
@@ -702,9 +644,7 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to set auto-delete interval: ")
     @with_instrumentation()
-    def set_auto_delete_interval(
-        self, interval: int, request_timeout: float | None = None
-    ) -> None:
+    def set_auto_delete_interval(self, interval: int, request_timeout: float | None = None) -> None:
         """Sets the auto-delete interval for the Sandbox.
 
         The Sandbox will automatically delete after being continuously stopped for the specified interval.
@@ -764,11 +704,7 @@ class Sandbox(SandboxDto):
             sandbox.update_network_settings(network_block_all=False)
             ```
         """
-        if (
-            network_block_all is None
-            and network_allow_list is None
-            and domain_allow_list is None
-        ):
+        if network_block_all is None and network_allow_list is None and domain_allow_list is None:
             raise DaytonaValidationError(
                 "At least one of network_block_all, network_allow_list or domain_allow_list must be set"
             )
@@ -804,17 +740,13 @@ class Sandbox(SandboxDto):
             sandbox.update_secrets({})  # detach all
             ```
         """
-        body = UpdateSandboxSecrets(
-            secrets=[{env_var: secret_name} for env_var, secret_name in secrets.items()]
-        )
+        body = UpdateSandboxSecrets(secrets=[{env_var: secret_name} for env_var, secret_name in secrets.items()])
         updated = self._sandbox_api.update_sandbox_secrets(self.id, body)
         self.__process_sandbox_dto(updated)
 
     @intercept_errors(message_prefix="Failed to update environment: ")
     @with_instrumentation()
-    def update_env(
-        self, env: dict[str, str], *, unset: list[str] | None = None
-    ) -> None:
+    def update_env(self, env: dict[str, str], *, unset: list[str] | None = None) -> None:
         """Updates the Sandbox daemon's process environment.
 
         Newly spawned processes, sessions and PTYs inherit the change; already-running processes
@@ -834,9 +766,7 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to get preview link: ")
     @with_instrumentation()
-    def get_preview_link(
-        self, port: int, request_timeout: float | None = None
-    ) -> PortPreviewUrl:
+    def get_preview_link(self, port: int, request_timeout: float | None = None) -> PortPreviewUrl:
         """Retrieves the preview link for the sandbox at the specified port. If the port is closed,
         it will be opened automatically. For private sandboxes, a token is included to grant access
         to the URL.
@@ -859,9 +789,7 @@ class Sandbox(SandboxDto):
             print(f"Token: {preview_link.token}")
             ```
         """
-        return self._sandbox_api.get_port_preview_url(
-            self.id, port, _request_timeout=http_timeout(request_timeout)
-        )
+        return self._sandbox_api.get_port_preview_url(self.id, port, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to create signed preview url: ")
     def create_signed_preview_url(
@@ -892,9 +820,7 @@ class Sandbox(SandboxDto):
         )
 
     @intercept_errors(message_prefix="Failed to expire signed preview url: ")
-    def expire_signed_preview_url(
-        self, port: int, token: str, request_timeout: float | None = None
-    ) -> None:
+    def expire_signed_preview_url(self, port: int, token: str, request_timeout: float | None = None) -> None:
         """Expires a signed preview URL for the sandbox at the specified port.
 
         Args:
@@ -924,9 +850,7 @@ class Sandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = self._sandbox_api.archive_sandbox(
-            self.id, _request_timeout=http_timeout(request_timeout)
-        )
+        _ = self._sandbox_api.archive_sandbox(self.id, _request_timeout=http_timeout(request_timeout))
         self.refresh_data(request_timeout=request_timeout)
 
     @intercept_errors(message_prefix="Failed to resize sandbox: ")
@@ -967,9 +891,7 @@ class Sandbox(SandboxDto):
             memory=resources.memory,
             disk=resources.disk,
         )
-        sandbox = self._sandbox_api.resize_sandbox(
-            self.id, resize_request, _request_timeout=timeout or None
-        )
+        sandbox = self._sandbox_api.resize_sandbox(self.id, resize_request, _request_timeout=timeout or None)
         self.__process_sandbox_dto(sandbox)
         self.wait_for_resize_complete(timeout=0)
 
@@ -978,8 +900,7 @@ class Sandbox(SandboxDto):
     @with_instrumentation()
     def wait_for_resize_complete(
         self,
-        timeout: float
-        | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
+        timeout: float | None = 60,  # pylint: disable=unused-argument # pyright: ignore[reportUnusedParameter]
     ) -> None:
         """Waits for the Sandbox resize operation to complete. Polls the Sandbox status until
         the state is no longer 'resizing'.
@@ -1031,9 +952,7 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to revoke SSH access: ")
     @with_instrumentation()
-    def revoke_ssh_access(
-        self, token: str, request_timeout: float | None = None
-    ) -> None:
+    def revoke_ssh_access(self, token: str, request_timeout: float | None = None) -> None:
         """Revokes an SSH access token for the sandbox.
 
         Args:
@@ -1043,15 +962,11 @@ class Sandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        _ = self._sandbox_api.revoke_ssh_access(
-            self.id, token, _request_timeout=http_timeout(request_timeout)
-        )
+        _ = self._sandbox_api.revoke_ssh_access(self.id, token, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to validate SSH access: ")
     @with_instrumentation()
-    def validate_ssh_access(
-        self, token: str, request_timeout: float | None = None
-    ) -> SshAccessValidationDto:
+    def validate_ssh_access(self, token: str, request_timeout: float | None = None) -> SshAccessValidationDto:
         """Validates an SSH access token for the sandbox.
 
         Args:
@@ -1061,9 +976,7 @@ class Sandbox(SandboxDto):
                 the operation on the server. Positive values under 1 second are rounded up to 1
                 second; 0 disables the client-side timeout and negative values are rejected.
         """
-        return self._sandbox_api.validate_ssh_access(
-            token, _request_timeout=http_timeout(request_timeout)
-        )
+        return self._sandbox_api.validate_ssh_access(token, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to refresh sandbox activity: ")
     def refresh_activity(self, request_timeout: float | None = None) -> None:
@@ -1083,16 +996,12 @@ class Sandbox(SandboxDto):
             sandbox.refresh_activity()
             ```
         """
-        self._sandbox_api.update_last_activity(
-            self.id, _request_timeout=http_timeout(request_timeout)
-        )
+        self._sandbox_api.update_last_activity(self.id, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to fork sandbox: ")
     @with_timeout()
     @with_instrumentation()
-    def _experimental_fork(
-        self, name: str | None = None, timeout: float | None = 60
-    ) -> "Sandbox":
+    def _experimental_fork(self, name: str | None = None, timeout: float | None = 60) -> "Sandbox":
         """Forks the Sandbox, creating a new Sandbox with an identical filesystem.
 
         The forked Sandbox is a copy-on-write clone of the original. It starts
@@ -1134,9 +1043,7 @@ class Sandbox(SandboxDto):
 
     @intercept_errors(message_prefix="Failed to create snapshot: ")
     @with_instrumentation()
-    def _experimental_create_snapshot(
-        self, name: str, timeout: float | None = 60
-    ) -> None:
+    def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
         """Creates a snapshot from the current state of the Sandbox.
 
         This captures the Sandbox's filesystem into a reusable snapshot that can be
@@ -1165,9 +1072,7 @@ class Sandbox(SandboxDto):
         )
         snapshot_id = accepted.id if accepted else None
         if not snapshot_id:
-            raise DaytonaError(
-                "Failed to create snapshot. Didn't receive a snapshot ID from the server API."
-            )
+            raise DaytonaError("Failed to create snapshot. Didn't receive a snapshot ID from the server API.")
 
         deadline = None if timeout in (None, 0) else start_time + timeout
         self.__wait_for_snapshot_complete(snapshot_id, deadline)
@@ -1192,9 +1097,7 @@ class Sandbox(SandboxDto):
             raise DaytonaError("Timeout must be a non-negative number")
 
         start_time = time.time()
-        _ = self._sandbox_api.pause_sandbox(
-            self.id, _request_timeout=timeout if timeout > 0 else None
-        )
+        _ = self._sandbox_api.pause_sandbox(self.id, _request_timeout=timeout if timeout > 0 else None)
         self.refresh_data()
 
         elapsed = time.time() - start_time
@@ -1209,15 +1112,11 @@ class Sandbox(SandboxDto):
                     f"Sandbox {self.id} pause failed with state: {self.state}, error reason: {self.error_reason}"
                 )
             if 0 < remaining <= time.time() - wait_start:
-                raise DaytonaError(
-                    f"Sandbox {self.id} failed to pause within {timeout} seconds"
-                )
+                raise DaytonaError(f"Sandbox {self.id} failed to pause within {timeout} seconds")
             time.sleep(check_interval)
             check_interval = min(check_interval * 1.5, 1.0)
 
-    def __wait_for_snapshot_complete(
-        self, snapshot_id: str, deadline: float | None
-    ) -> None:
+    def __wait_for_snapshot_complete(self, snapshot_id: str, deadline: float | None) -> None:
         check_interval = 0.1
         start_time = time.monotonic()
 
@@ -1229,24 +1128,16 @@ class Sandbox(SandboxDto):
 
             snapshot = self._snapshots_api.get_snapshot(snapshot_id)
             if not snapshot or snapshot.id != snapshot_id:
-                raise DaytonaError(
-                    f"Snapshot lookup for {snapshot_id} returned an invalid response"
-                )
+                raise DaytonaError(f"Snapshot lookup for {snapshot_id} returned an invalid response")
 
             if snapshot.state == SnapshotState.ACTIVE:
                 try:
                     self.refresh_data()
-                except (
-                    Exception
-                ):  # Best-effort local cleanup after definitive server success.
+                except Exception:  # Best-effort local cleanup after definitive server success.
                     pass
                 return
             if snapshot.state in (SnapshotState.ERROR, SnapshotState.BUILD_FAILED):
-                state = (
-                    snapshot.state.value
-                    if isinstance(snapshot.state, SnapshotState)
-                    else snapshot.state
-                )
+                state = snapshot.state.value
                 raise DaytonaError(
                     f"Snapshot {snapshot.id} failed with state: {state}, error reason: {snapshot.error_reason}"
                 )
@@ -1274,9 +1165,7 @@ class Sandbox(SandboxDto):
         self.backup_state: str | None = sandbox_dto.backup_state
         self.auto_stop_interval: float | int | None = sandbox_dto.auto_stop_interval
         self.auto_pause_interval: float | int | None = sandbox_dto.auto_pause_interval
-        self.auto_archive_interval: float | int | None = (
-            sandbox_dto.auto_archive_interval
-        )
+        self.auto_archive_interval: float | int | None = sandbox_dto.auto_archive_interval
         self.auto_delete_interval: float | int | None = sandbox_dto.auto_delete_interval
         self.created_at: str | None = sandbox_dto.created_at
         self.updated_at: str | None = sandbox_dto.updated_at
@@ -1285,11 +1174,7 @@ class Sandbox(SandboxDto):
 
         # Fields only present in the full SandboxDto (not returned by list results
         if isinstance(sandbox_dto, SandboxDto):
-            self.env: dict[
-                str, str
-            ] | None = (
-                sandbox_dto.env
-            )  # pyright: ignore[reportIncompatibleVariableOverride]
+            self.env: dict[str, str] | None = sandbox_dto.env  # pyright: ignore[reportIncompatibleVariableOverride]
             self.network_block_all: bool | None = (  # pyright: ignore[reportIncompatibleVariableOverride]
                 sandbox_dto.network_block_all
             )

--- a/sdk-python/tests/test_async_sandbox.py
+++ b/sdk-python/tests/test_async_sandbox.py
@@ -16,22 +16,34 @@ from daytona_api_client_async import SnapshotState, UpdateSandboxSecrets
 from .conftest import make_sandbox_dto
 
 
-def make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+def make_async_sandbox(
+    sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+):
     from daytona._async.sandbox import AsyncSandbox
 
-    return AsyncSandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api, "python")
+    return AsyncSandbox(
+        sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api, "python"
+    )
 
 
 class TestAsyncSandboxInit:
-    def test_sandbox_properties(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+    def test_sandbox_properties(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
         assert sandbox.id == "test-sandbox-id"
         assert sandbox.name == "test-sandbox"
         assert sandbox.state == SandboxState.STARTED
         assert sandbox.cpu == 4
 
-    def test_sandbox_has_subsystems(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+    def test_sandbox_has_subsystems(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
         assert sandbox.fs is not None
         assert sandbox.git is not None
         assert sandbox.process is not None
@@ -44,13 +56,21 @@ class TestAsyncSandboxLifecycleSettings:
     async def test_negative_autostop_interval_raises(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
-        with pytest.raises(DaytonaValidationError, match="Auto-stop interval must be a non-negative"):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
+        with pytest.raises(
+            DaytonaValidationError, match="Auto-stop interval must be a non-negative"
+        ):
             await sandbox.set_autostop_interval(-1)
 
     @pytest.mark.asyncio
-    async def test_valid_autostop_interval(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+    async def test_valid_autostop_interval(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
         mock_async_sandbox_api.set_autostop_interval = AsyncMock(return_value=None)
         await sandbox.set_autostop_interval(30)
         assert sandbox.auto_stop_interval == 30
@@ -59,13 +79,21 @@ class TestAsyncSandboxLifecycleSettings:
     async def test_negative_autopause_interval_raises(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
-        with pytest.raises(DaytonaValidationError, match="Auto-pause interval must be a non-negative"):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
+        with pytest.raises(
+            DaytonaValidationError, match="Auto-pause interval must be a non-negative"
+        ):
             await sandbox.set_auto_pause_interval(-1)
 
     @pytest.mark.asyncio
-    async def test_valid_autopause_interval(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+    async def test_valid_autopause_interval(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
         mock_async_sandbox_api.set_auto_pause_interval = AsyncMock(return_value=None)
         await sandbox.set_auto_pause_interval(30)
         assert sandbox.auto_pause_interval == 30
@@ -74,22 +102,32 @@ class TestAsyncSandboxLifecycleSettings:
     async def test_negative_auto_archive_interval_raises(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
-        with pytest.raises(DaytonaValidationError, match="Auto-archive interval must be a non-negative"):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
+        with pytest.raises(
+            DaytonaValidationError, match="Auto-archive interval must be a non-negative"
+        ):
             await sandbox.set_auto_archive_interval(-1)
 
     @pytest.mark.asyncio
     async def test_valid_auto_archive_interval(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
         mock_async_sandbox_api.set_auto_archive_interval = AsyncMock(return_value=None)
         await sandbox.set_auto_archive_interval(60)
         assert sandbox.auto_archive_interval == 60
 
     @pytest.mark.asyncio
-    async def test_auto_delete_interval(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+    async def test_auto_delete_interval(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
         mock_async_sandbox_api.set_auto_delete_interval = AsyncMock(return_value=None)
         await sandbox.set_auto_delete_interval(120)
         assert sandbox.auto_delete_interval == 120
@@ -97,46 +135,78 @@ class TestAsyncSandboxLifecycleSettings:
 
 class TestAsyncSandboxOperations:
     @pytest.mark.asyncio
-    async def test_set_labels(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+    async def test_set_labels(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
         new_labels = {"project": "test", "env": "dev"}
-        mock_async_sandbox_api.replace_labels = AsyncMock(return_value=MagicMock(labels=new_labels))
+        mock_async_sandbox_api.replace_labels = AsyncMock(
+            return_value=MagicMock(labels=new_labels)
+        )
         result = await sandbox.set_labels(new_labels)
         assert result == new_labels
 
-    def test_create_lsp_server(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+    def test_create_lsp_server(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
         from daytona._async.lsp_server import AsyncLspServer
 
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
         lsp = sandbox.create_lsp_server("python", "/workspace/project")
         assert isinstance(lsp, AsyncLspServer)
 
     @pytest.mark.asyncio
-    async def test_refresh_data(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
-        mock_async_sandbox_api.get_sandbox = AsyncMock(return_value=make_sandbox_dto(state=SandboxState.STOPPED, cpu=8))
+    async def test_refresh_data(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
+        mock_async_sandbox_api.get_sandbox = AsyncMock(
+            return_value=make_sandbox_dto(state=SandboxState.STOPPED, cpu=8)
+        )
         await sandbox.refresh_data()
         assert sandbox.state == SandboxState.STOPPED
         assert sandbox.cpu == 8
 
     @pytest.mark.asyncio
-    async def test_get_user_home_dir(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
-        sandbox._info_api = AsyncMock(get_user_home_dir=AsyncMock(return_value=MagicMock(dir="/home/daytona")))
+    async def test_get_user_home_dir(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
+        sandbox._info_api = AsyncMock(
+            get_user_home_dir=AsyncMock(return_value=MagicMock(dir="/home/daytona"))
+        )
         assert await sandbox.get_user_home_dir() == "/home/daytona"
 
     @pytest.mark.asyncio
-    async def test_get_work_dir(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
-        sandbox._info_api = AsyncMock(get_work_dir=AsyncMock(return_value=MagicMock(dir="/workspace")))
+    async def test_get_work_dir(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
+        sandbox._info_api = AsyncMock(
+            get_work_dir=AsyncMock(return_value=MagicMock(dir="/workspace"))
+        )
         assert await sandbox.get_work_dir() == "/workspace"
 
     @pytest.mark.asyncio
     async def test_get_user_root_dir_delegates_to_home_dir(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
-        sandbox._info_api = AsyncMock(get_user_home_dir=AsyncMock(return_value=MagicMock(dir="/home/daytona")))
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
+        sandbox._info_api = AsyncMock(
+            get_user_home_dir=AsyncMock(return_value=MagicMock(dir="/home/daytona"))
+        )
 
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
@@ -146,10 +216,18 @@ class TestAsyncSandboxOperations:
     async def test_preview_and_ssh_operations_delegate(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
-        mock_async_sandbox_api.get_port_preview_url = AsyncMock(return_value=MagicMock(url="https://preview"))
-        mock_async_sandbox_api.create_ssh_access = AsyncMock(return_value=MagicMock(token="ssh-token"))
-        mock_async_sandbox_api.validate_ssh_access = AsyncMock(return_value=MagicMock(valid=True))
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
+        mock_async_sandbox_api.get_port_preview_url = AsyncMock(
+            return_value=MagicMock(url="https://preview")
+        )
+        mock_async_sandbox_api.create_ssh_access = AsyncMock(
+            return_value=MagicMock(token="ssh-token")
+        )
+        mock_async_sandbox_api.validate_ssh_access = AsyncMock(
+            return_value=MagicMock(valid=True)
+        )
         mock_async_sandbox_api.revoke_ssh_access = AsyncMock()
         mock_async_sandbox_api.update_last_activity = AsyncMock()
 
@@ -159,15 +237,29 @@ class TestAsyncSandboxOperations:
         await sandbox.revoke_ssh_access("token")
         await sandbox.refresh_activity()
 
-        mock_async_sandbox_api.get_port_preview_url.assert_awaited_once_with(sandbox.id, 3000, _request_timeout=None)
-        mock_async_sandbox_api.revoke_ssh_access.assert_awaited_once_with(sandbox.id, "token", _request_timeout=None)
-        mock_async_sandbox_api.update_last_activity.assert_awaited_once_with(sandbox.id, _request_timeout=None)
+        mock_async_sandbox_api.get_port_preview_url.assert_awaited_once_with(
+            sandbox.id, 3000, _request_timeout=None
+        )
+        mock_async_sandbox_api.revoke_ssh_access.assert_awaited_once_with(
+            sandbox.id, "token", _request_timeout=None
+        )
+        mock_async_sandbox_api.update_last_activity.assert_awaited_once_with(
+            sandbox.id, _request_timeout=None
+        )
 
     @pytest.mark.asyncio
-    async def test_update_secrets(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
-        updated_dto = AsyncSandboxDto(**make_sandbox_dto(env={"FOO": "placeholder"}).model_dump())
-        mock_async_sandbox_api.update_sandbox_secrets = AsyncMock(return_value=updated_dto)
+    async def test_update_secrets(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
+        updated_dto = AsyncSandboxDto(
+            **make_sandbox_dto(env={"FOO": "placeholder"}).model_dump()
+        )
+        mock_async_sandbox_api.update_sandbox_secrets = AsyncMock(
+            return_value=updated_dto
+        )
 
         await sandbox.update_secrets({"FOO": "foo-secret", "BAR": "bar"})
 
@@ -182,9 +274,13 @@ class TestAsyncSandboxOperations:
     async def test_update_secrets_empty_dict_detaches_all(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
         updated_dto = AsyncSandboxDto(**make_sandbox_dto(env={}).model_dump())
-        mock_async_sandbox_api.update_sandbox_secrets = AsyncMock(return_value=updated_dto)
+        mock_async_sandbox_api.update_sandbox_secrets = AsyncMock(
+            return_value=updated_dto
+        )
 
         await sandbox.update_secrets({})
 
@@ -193,11 +289,17 @@ class TestAsyncSandboxOperations:
         assert body.secrets == []
 
     @pytest.mark.asyncio
-    async def test_update_env(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+    async def test_update_env(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
         # The daemon responds with a status message, which update_env discards.
         sandbox._server_api = AsyncMock(
-            update_env=AsyncMock(return_value={"message": "Environment updated successfully"})
+            update_env=AsyncMock(
+                return_value={"message": "Environment updated successfully"}
+            )
         )
 
         result = await sandbox.update_env({"A": "1"}, unset=["B"])
@@ -215,14 +317,22 @@ class TestAsyncSandboxSnapshotCapture:
     async def test_polls_accepted_snapshot_id_until_active(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
-        mock_async_sandbox_api.create_sandbox_snapshot = AsyncMock(return_value=MagicMock(id="snapshot-id"))
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
+        mock_async_sandbox_api.create_sandbox_snapshot = AsyncMock(
+            return_value=MagicMock(id="snapshot-id")
+        )
         sandbox._snapshots_api = MagicMock(
             get_snapshot=AsyncMock(
-                return_value=MagicMock(id="snapshot-id", state=SnapshotState.ACTIVE, error_reason=None)
+                return_value=MagicMock(
+                    id="snapshot-id", state=SnapshotState.ACTIVE, error_reason=None
+                )
             )
         )
-        mock_async_sandbox_api.get_sandbox = AsyncMock(side_effect=DaytonaError("best-effort refresh failed"))
+        mock_async_sandbox_api.get_sandbox = AsyncMock(
+            side_effect=DaytonaError("best-effort refresh failed")
+        )
 
         await sandbox._experimental_create_snapshot("snap-1", timeout=1)
 
@@ -232,8 +342,12 @@ class TestAsyncSandboxSnapshotCapture:
     async def test_reports_snapshot_terminal_failure(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
-        mock_async_sandbox_api.create_sandbox_snapshot = AsyncMock(return_value=MagicMock(id="snapshot-id"))
+        sandbox = make_async_sandbox(
+            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
+        mock_async_sandbox_api.create_sandbox_snapshot = AsyncMock(
+            return_value=MagicMock(id="snapshot-id")
+        )
         sandbox._snapshots_api = MagicMock(
             get_snapshot=AsyncMock(
                 return_value=MagicMock(
@@ -253,9 +367,15 @@ class TestAsyncSandboxSnapshotCapture:
 
 class TestAsyncSandboxWaitForStart:
     @pytest.mark.asyncio
-    async def test_error_state_raises(self, mock_async_toolbox_api_client, mock_async_sandbox_api):
-        error_dto = make_sandbox_dto(state=SandboxState.ERROR, error_reason="build failed")
-        sandbox = make_async_sandbox(error_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+    async def test_error_state_raises(
+        self, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        error_dto = make_sandbox_dto(
+            state=SandboxState.ERROR, error_reason="build failed"
+        )
+        sandbox = make_async_sandbox(
+            error_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+        )
         mock_async_sandbox_api.get_sandbox = AsyncMock(return_value=error_dto)
         with pytest.raises(DaytonaError, match="failed to start"):
             await sandbox.wait_for_sandbox_start(timeout=0)

--- a/sdk-python/tests/test_async_sandbox.py
+++ b/sdk-python/tests/test_async_sandbox.py
@@ -11,7 +11,7 @@ import pytest
 from daytona.common.errors import DaytonaError, DaytonaValidationError
 from daytona_api_client import SandboxState
 from daytona_api_client_async import Sandbox as AsyncSandboxDto
-from daytona_api_client_async import UpdateSandboxSecrets
+from daytona_api_client_async import SnapshotState, UpdateSandboxSecrets
 
 from .conftest import make_sandbox_dto
 
@@ -208,6 +208,47 @@ class TestAsyncSandboxOperations:
         assert request.set == {"A": "1"}
         assert request.unset == ["B"]
         assert request.unset_value_prefix is None
+
+
+class TestAsyncSandboxSnapshotCapture:
+    @pytest.mark.asyncio
+    async def test_polls_accepted_snapshot_id_until_active(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        mock_async_sandbox_api.create_sandbox_snapshot = AsyncMock(return_value=MagicMock(id="snapshot-id"))
+        sandbox._snapshots_api = MagicMock(
+            get_snapshot=AsyncMock(
+                return_value=MagicMock(id="snapshot-id", state=SnapshotState.ACTIVE, error_reason=None)
+            )
+        )
+        mock_async_sandbox_api.get_sandbox = AsyncMock(side_effect=DaytonaError("best-effort refresh failed"))
+
+        await sandbox._experimental_create_snapshot("snap-1", timeout=1)
+
+        sandbox._snapshots_api.get_snapshot.assert_awaited_once_with("snapshot-id")
+
+    @pytest.mark.asyncio
+    async def test_reports_snapshot_terminal_failure(
+        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        mock_async_sandbox_api.create_sandbox_snapshot = AsyncMock(return_value=MagicMock(id="snapshot-id"))
+        sandbox._snapshots_api = MagicMock(
+            get_snapshot=AsyncMock(
+                return_value=MagicMock(
+                    id="snapshot-id",
+                    state=SnapshotState.ERROR,
+                    error_reason="capture failed",
+                )
+            )
+        )
+
+        with pytest.raises(
+            DaytonaError,
+            match="Snapshot snapshot-id failed with state: error, error reason: capture failed",
+        ):
+            await sandbox._experimental_create_snapshot("snap-1", timeout=1)
 
 
 class TestAsyncSandboxWaitForStart:

--- a/sdk-python/tests/test_async_sandbox.py
+++ b/sdk-python/tests/test_async_sandbox.py
@@ -16,34 +16,22 @@ from daytona_api_client_async import SnapshotState, UpdateSandboxSecrets
 from .conftest import make_sandbox_dto
 
 
-def make_async_sandbox(
-    sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-):
+def make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
     from daytona._async.sandbox import AsyncSandbox
 
-    return AsyncSandbox(
-        sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api, "python"
-    )
+    return AsyncSandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api, "python")
 
 
 class TestAsyncSandboxInit:
-    def test_sandbox_properties(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
+    def test_sandbox_properties(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
         assert sandbox.id == "test-sandbox-id"
         assert sandbox.name == "test-sandbox"
         assert sandbox.state == SandboxState.STARTED
         assert sandbox.cpu == 4
 
-    def test_sandbox_has_subsystems(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
+    def test_sandbox_has_subsystems(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
         assert sandbox.fs is not None
         assert sandbox.git is not None
         assert sandbox.process is not None
@@ -56,21 +44,13 @@ class TestAsyncSandboxLifecycleSettings:
     async def test_negative_autostop_interval_raises(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
-        with pytest.raises(
-            DaytonaValidationError, match="Auto-stop interval must be a non-negative"
-        ):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        with pytest.raises(DaytonaValidationError, match="Auto-stop interval must be a non-negative"):
             await sandbox.set_autostop_interval(-1)
 
     @pytest.mark.asyncio
-    async def test_valid_autostop_interval(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
+    async def test_valid_autostop_interval(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
         mock_async_sandbox_api.set_autostop_interval = AsyncMock(return_value=None)
         await sandbox.set_autostop_interval(30)
         assert sandbox.auto_stop_interval == 30
@@ -79,21 +59,13 @@ class TestAsyncSandboxLifecycleSettings:
     async def test_negative_autopause_interval_raises(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
-        with pytest.raises(
-            DaytonaValidationError, match="Auto-pause interval must be a non-negative"
-        ):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        with pytest.raises(DaytonaValidationError, match="Auto-pause interval must be a non-negative"):
             await sandbox.set_auto_pause_interval(-1)
 
     @pytest.mark.asyncio
-    async def test_valid_autopause_interval(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
+    async def test_valid_autopause_interval(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
         mock_async_sandbox_api.set_auto_pause_interval = AsyncMock(return_value=None)
         await sandbox.set_auto_pause_interval(30)
         assert sandbox.auto_pause_interval == 30
@@ -102,32 +74,22 @@ class TestAsyncSandboxLifecycleSettings:
     async def test_negative_auto_archive_interval_raises(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
-        with pytest.raises(
-            DaytonaValidationError, match="Auto-archive interval must be a non-negative"
-        ):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        with pytest.raises(DaytonaValidationError, match="Auto-archive interval must be a non-negative"):
             await sandbox.set_auto_archive_interval(-1)
 
     @pytest.mark.asyncio
     async def test_valid_auto_archive_interval(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
         mock_async_sandbox_api.set_auto_archive_interval = AsyncMock(return_value=None)
         await sandbox.set_auto_archive_interval(60)
         assert sandbox.auto_archive_interval == 60
 
     @pytest.mark.asyncio
-    async def test_auto_delete_interval(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
+    async def test_auto_delete_interval(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
         mock_async_sandbox_api.set_auto_delete_interval = AsyncMock(return_value=None)
         await sandbox.set_auto_delete_interval(120)
         assert sandbox.auto_delete_interval == 120
@@ -135,78 +97,46 @@ class TestAsyncSandboxLifecycleSettings:
 
 class TestAsyncSandboxOperations:
     @pytest.mark.asyncio
-    async def test_set_labels(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
+    async def test_set_labels(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
         new_labels = {"project": "test", "env": "dev"}
-        mock_async_sandbox_api.replace_labels = AsyncMock(
-            return_value=MagicMock(labels=new_labels)
-        )
+        mock_async_sandbox_api.replace_labels = AsyncMock(return_value=MagicMock(labels=new_labels))
         result = await sandbox.set_labels(new_labels)
         assert result == new_labels
 
-    def test_create_lsp_server(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
+    def test_create_lsp_server(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
         from daytona._async.lsp_server import AsyncLspServer
 
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
         lsp = sandbox.create_lsp_server("python", "/workspace/project")
         assert isinstance(lsp, AsyncLspServer)
 
     @pytest.mark.asyncio
-    async def test_refresh_data(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
-        mock_async_sandbox_api.get_sandbox = AsyncMock(
-            return_value=make_sandbox_dto(state=SandboxState.STOPPED, cpu=8)
-        )
+    async def test_refresh_data(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        mock_async_sandbox_api.get_sandbox = AsyncMock(return_value=make_sandbox_dto(state=SandboxState.STOPPED, cpu=8))
         await sandbox.refresh_data()
         assert sandbox.state == SandboxState.STOPPED
         assert sandbox.cpu == 8
 
     @pytest.mark.asyncio
-    async def test_get_user_home_dir(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
-        sandbox._info_api = AsyncMock(
-            get_user_home_dir=AsyncMock(return_value=MagicMock(dir="/home/daytona"))
-        )
+    async def test_get_user_home_dir(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        sandbox._info_api = AsyncMock(get_user_home_dir=AsyncMock(return_value=MagicMock(dir="/home/daytona")))
         assert await sandbox.get_user_home_dir() == "/home/daytona"
 
     @pytest.mark.asyncio
-    async def test_get_work_dir(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
-        sandbox._info_api = AsyncMock(
-            get_work_dir=AsyncMock(return_value=MagicMock(dir="/workspace"))
-        )
+    async def test_get_work_dir(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        sandbox._info_api = AsyncMock(get_work_dir=AsyncMock(return_value=MagicMock(dir="/workspace")))
         assert await sandbox.get_work_dir() == "/workspace"
 
     @pytest.mark.asyncio
     async def test_get_user_root_dir_delegates_to_home_dir(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
-        sandbox._info_api = AsyncMock(
-            get_user_home_dir=AsyncMock(return_value=MagicMock(dir="/home/daytona"))
-        )
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        sandbox._info_api = AsyncMock(get_user_home_dir=AsyncMock(return_value=MagicMock(dir="/home/daytona")))
 
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
@@ -216,18 +146,10 @@ class TestAsyncSandboxOperations:
     async def test_preview_and_ssh_operations_delegate(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
-        mock_async_sandbox_api.get_port_preview_url = AsyncMock(
-            return_value=MagicMock(url="https://preview")
-        )
-        mock_async_sandbox_api.create_ssh_access = AsyncMock(
-            return_value=MagicMock(token="ssh-token")
-        )
-        mock_async_sandbox_api.validate_ssh_access = AsyncMock(
-            return_value=MagicMock(valid=True)
-        )
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        mock_async_sandbox_api.get_port_preview_url = AsyncMock(return_value=MagicMock(url="https://preview"))
+        mock_async_sandbox_api.create_ssh_access = AsyncMock(return_value=MagicMock(token="ssh-token"))
+        mock_async_sandbox_api.validate_ssh_access = AsyncMock(return_value=MagicMock(valid=True))
         mock_async_sandbox_api.revoke_ssh_access = AsyncMock()
         mock_async_sandbox_api.update_last_activity = AsyncMock()
 
@@ -237,29 +159,15 @@ class TestAsyncSandboxOperations:
         await sandbox.revoke_ssh_access("token")
         await sandbox.refresh_activity()
 
-        mock_async_sandbox_api.get_port_preview_url.assert_awaited_once_with(
-            sandbox.id, 3000, _request_timeout=None
-        )
-        mock_async_sandbox_api.revoke_ssh_access.assert_awaited_once_with(
-            sandbox.id, "token", _request_timeout=None
-        )
-        mock_async_sandbox_api.update_last_activity.assert_awaited_once_with(
-            sandbox.id, _request_timeout=None
-        )
+        mock_async_sandbox_api.get_port_preview_url.assert_awaited_once_with(sandbox.id, 3000, _request_timeout=None)
+        mock_async_sandbox_api.revoke_ssh_access.assert_awaited_once_with(sandbox.id, "token", _request_timeout=None)
+        mock_async_sandbox_api.update_last_activity.assert_awaited_once_with(sandbox.id, _request_timeout=None)
 
     @pytest.mark.asyncio
-    async def test_update_secrets(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
-        updated_dto = AsyncSandboxDto(
-            **make_sandbox_dto(env={"FOO": "placeholder"}).model_dump()
-        )
-        mock_async_sandbox_api.update_sandbox_secrets = AsyncMock(
-            return_value=updated_dto
-        )
+    async def test_update_secrets(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        updated_dto = AsyncSandboxDto(**make_sandbox_dto(env={"FOO": "placeholder"}).model_dump())
+        mock_async_sandbox_api.update_sandbox_secrets = AsyncMock(return_value=updated_dto)
 
         await sandbox.update_secrets({"FOO": "foo-secret", "BAR": "bar"})
 
@@ -274,13 +182,9 @@ class TestAsyncSandboxOperations:
     async def test_update_secrets_empty_dict_detaches_all(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
         updated_dto = AsyncSandboxDto(**make_sandbox_dto(env={}).model_dump())
-        mock_async_sandbox_api.update_sandbox_secrets = AsyncMock(
-            return_value=updated_dto
-        )
+        mock_async_sandbox_api.update_sandbox_secrets = AsyncMock(return_value=updated_dto)
 
         await sandbox.update_secrets({})
 
@@ -289,17 +193,11 @@ class TestAsyncSandboxOperations:
         assert body.secrets == []
 
     @pytest.mark.asyncio
-    async def test_update_env(
-        self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
+    async def test_update_env(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
         # The daemon responds with a status message, which update_env discards.
         sandbox._server_api = AsyncMock(
-            update_env=AsyncMock(
-                return_value={"message": "Environment updated successfully"}
-            )
+            update_env=AsyncMock(return_value={"message": "Environment updated successfully"})
         )
 
         result = await sandbox.update_env({"A": "1"}, unset=["B"])
@@ -317,22 +215,14 @@ class TestAsyncSandboxSnapshotCapture:
     async def test_polls_accepted_snapshot_id_until_active(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
-        mock_async_sandbox_api.create_sandbox_snapshot = AsyncMock(
-            return_value=MagicMock(id="snapshot-id")
-        )
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        mock_async_sandbox_api.create_sandbox_snapshot = AsyncMock(return_value=MagicMock(id="snapshot-id"))
         sandbox._snapshots_api = MagicMock(
             get_snapshot=AsyncMock(
-                return_value=MagicMock(
-                    id="snapshot-id", state=SnapshotState.ACTIVE, error_reason=None
-                )
+                return_value=MagicMock(id="snapshot-id", state=SnapshotState.ACTIVE, error_reason=None)
             )
         )
-        mock_async_sandbox_api.get_sandbox = AsyncMock(
-            side_effect=DaytonaError("best-effort refresh failed")
-        )
+        mock_async_sandbox_api.get_sandbox = AsyncMock(side_effect=DaytonaError("best-effort refresh failed"))
 
         await sandbox._experimental_create_snapshot("snap-1", timeout=1)
 
@@ -342,12 +232,8 @@ class TestAsyncSandboxSnapshotCapture:
     async def test_reports_snapshot_terminal_failure(
         self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
     ):
-        sandbox = make_async_sandbox(
-            sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
-        mock_async_sandbox_api.create_sandbox_snapshot = AsyncMock(
-            return_value=MagicMock(id="snapshot-id")
-        )
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        mock_async_sandbox_api.create_sandbox_snapshot = AsyncMock(return_value=MagicMock(id="snapshot-id"))
         sandbox._snapshots_api = MagicMock(
             get_snapshot=AsyncMock(
                 return_value=MagicMock(
@@ -367,15 +253,9 @@ class TestAsyncSandboxSnapshotCapture:
 
 class TestAsyncSandboxWaitForStart:
     @pytest.mark.asyncio
-    async def test_error_state_raises(
-        self, mock_async_toolbox_api_client, mock_async_sandbox_api
-    ):
-        error_dto = make_sandbox_dto(
-            state=SandboxState.ERROR, error_reason="build failed"
-        )
-        sandbox = make_async_sandbox(
-            error_dto, mock_async_toolbox_api_client, mock_async_sandbox_api
-        )
+    async def test_error_state_raises(self, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        error_dto = make_sandbox_dto(state=SandboxState.ERROR, error_reason="build failed")
+        sandbox = make_async_sandbox(error_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
         mock_async_sandbox_api.get_sandbox = AsyncMock(return_value=error_dto)
         with pytest.raises(DaytonaError, match="failed to start"):
             await sandbox.wait_for_sandbox_start(timeout=0)

--- a/sdk-python/tests/test_sandbox.py
+++ b/sdk-python/tests/test_sandbox.py
@@ -27,9 +27,7 @@ def make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
 
 
 class TestSandboxInit:
-    def test_sandbox_properties(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_sandbox_properties(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         assert sandbox.id == "test-sandbox-id"
         assert sandbox.name == "test-sandbox"
@@ -40,9 +38,7 @@ class TestSandboxInit:
         assert sandbox.user == "daytona"
         assert sandbox.public is False
 
-    def test_sandbox_has_subsystems(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_sandbox_has_subsystems(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         assert sandbox.fs is not None
         assert sandbox.git is not None
@@ -52,61 +48,39 @@ class TestSandboxInit:
 
 
 class TestSandboxLifecycleSettings:
-    def test_negative_autostop_interval_raises(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_negative_autostop_interval_raises(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        with pytest.raises(
-            DaytonaValidationError, match="Auto-stop interval must be a non-negative"
-        ):
+        with pytest.raises(DaytonaValidationError, match="Auto-stop interval must be a non-negative"):
             sandbox.set_autostop_interval(-1)
 
-    def test_valid_autostop_interval(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_valid_autostop_interval(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         sandbox.set_autostop_interval(30)
         assert sandbox.auto_stop_interval == 30
-        mock_sandbox_api.set_autostop_interval.assert_called_once_with(
-            sandbox.id, 30, _request_timeout=None
-        )
+        mock_sandbox_api.set_autostop_interval.assert_called_once_with(sandbox.id, 30, _request_timeout=None)
 
-    def test_negative_autopause_interval_raises(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_negative_autopause_interval_raises(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        with pytest.raises(
-            DaytonaValidationError, match="Auto-pause interval must be a non-negative"
-        ):
+        with pytest.raises(DaytonaValidationError, match="Auto-pause interval must be a non-negative"):
             sandbox.set_auto_pause_interval(-1)
 
-    def test_valid_autopause_interval(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_valid_autopause_interval(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         sandbox.set_auto_pause_interval(30)
         assert sandbox.auto_pause_interval == 30
         mock_sandbox_api.set_auto_pause_interval.assert_called_once_with(sandbox.id, 30)
 
-    def test_negative_auto_archive_interval_raises(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_negative_auto_archive_interval_raises(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        with pytest.raises(
-            DaytonaValidationError, match="Auto-archive interval must be a non-negative"
-        ):
+        with pytest.raises(DaytonaValidationError, match="Auto-archive interval must be a non-negative"):
             sandbox.set_auto_archive_interval(-1)
 
-    def test_valid_auto_archive_interval(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_valid_auto_archive_interval(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         sandbox.set_auto_archive_interval(60)
         assert sandbox.auto_archive_interval == 60
 
-    def test_auto_delete_interval(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_auto_delete_interval(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         sandbox.set_auto_delete_interval(120)
         assert sandbox.auto_delete_interval == 120
@@ -124,9 +98,7 @@ class TestSandboxOperations:
         assert result == new_labels
         assert sandbox.labels == new_labels
 
-    def test_create_lsp_server(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_create_lsp_server(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         from daytona._sync.lsp_server import LspServer
 
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
@@ -135,48 +107,32 @@ class TestSandboxOperations:
 
     def test_refresh_data(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        mock_sandbox_api.get_sandbox.return_value = make_sandbox_dto(
-            state=SandboxState.STOPPED, cpu=8
-        )
+        mock_sandbox_api.get_sandbox.return_value = make_sandbox_dto(state=SandboxState.STOPPED, cpu=8)
         sandbox.refresh_data()
         assert sandbox.state == SandboxState.STOPPED
         assert sandbox.cpu == 8
 
-    def test_get_user_home_dir(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_get_user_home_dir(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        sandbox._info_api = MagicMock(
-            get_user_home_dir=MagicMock(return_value=MagicMock(dir="/home/daytona"))
-        )
+        sandbox._info_api = MagicMock(get_user_home_dir=MagicMock(return_value=MagicMock(dir="/home/daytona")))
         assert sandbox.get_user_home_dir() == "/home/daytona"
 
     def test_get_work_dir(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        sandbox._info_api = MagicMock(
-            get_work_dir=MagicMock(return_value=MagicMock(dir="/workspace"))
-        )
+        sandbox._info_api = MagicMock(get_work_dir=MagicMock(return_value=MagicMock(dir="/workspace")))
         assert sandbox.get_work_dir() == "/workspace"
 
-    def test_get_user_root_dir_delegates_to_home_dir(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_get_user_root_dir_delegates_to_home_dir(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        sandbox._info_api = MagicMock(
-            get_user_home_dir=MagicMock(return_value=MagicMock(dir="/home/daytona"))
-        )
+        sandbox._info_api = MagicMock(get_user_home_dir=MagicMock(return_value=MagicMock(dir="/home/daytona")))
 
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             assert sandbox.get_user_root_dir() == "/home/daytona"
 
-    def test_preview_and_ssh_operations_delegate(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_preview_and_ssh_operations_delegate(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        mock_sandbox_api.get_port_preview_url.return_value = MagicMock(
-            url="https://preview"
-        )
+        mock_sandbox_api.get_port_preview_url.return_value = MagicMock(url="https://preview")
         mock_sandbox_api.create_ssh_access.return_value = MagicMock(token="ssh-token")
         mock_sandbox_api.validate_ssh_access.return_value = MagicMock(valid=True)
 
@@ -186,23 +142,13 @@ class TestSandboxOperations:
         sandbox.revoke_ssh_access("token")
         sandbox.refresh_activity()
 
-        mock_sandbox_api.get_port_preview_url.assert_called_once_with(
-            sandbox.id, 3000, _request_timeout=None
-        )
-        mock_sandbox_api.revoke_ssh_access.assert_called_once_with(
-            sandbox.id, "token", _request_timeout=None
-        )
-        mock_sandbox_api.update_last_activity.assert_called_once_with(
-            sandbox.id, _request_timeout=None
-        )
+        mock_sandbox_api.get_port_preview_url.assert_called_once_with(sandbox.id, 3000, _request_timeout=None)
+        mock_sandbox_api.revoke_ssh_access.assert_called_once_with(sandbox.id, "token", _request_timeout=None)
+        mock_sandbox_api.update_last_activity.assert_called_once_with(sandbox.id, _request_timeout=None)
 
-    def test_update_secrets(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_update_secrets(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        mock_sandbox_api.update_sandbox_secrets.return_value = make_sandbox_dto(
-            env={"FOO": "placeholder"}
-        )
+        mock_sandbox_api.update_sandbox_secrets.return_value = make_sandbox_dto(env={"FOO": "placeholder"})
 
         sandbox.update_secrets({"FOO": "foo-secret", "BAR": "bar"})
 
@@ -213,9 +159,7 @@ class TestSandboxOperations:
         assert body.secrets == [{"FOO": "foo-secret"}, {"BAR": "bar"}]
         assert sandbox.env == {"FOO": "placeholder"}
 
-    def test_update_secrets_empty_dict_detaches_all(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_update_secrets_empty_dict_detaches_all(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         mock_sandbox_api.update_sandbox_secrets.return_value = make_sandbox_dto(env={})
 
@@ -229,9 +173,7 @@ class TestSandboxOperations:
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         # The daemon responds with a status message, which update_env discards.
         sandbox._server_api = MagicMock(
-            update_env=MagicMock(
-                return_value={"message": "Environment updated successfully"}
-            )
+            update_env=MagicMock(return_value={"message": "Environment updated successfully"})
         )
 
         result = sandbox.update_env({"A": "1"}, unset=["B"])
@@ -245,35 +187,23 @@ class TestSandboxOperations:
 
 
 class TestSandboxSnapshotCapture:
-    def test_polls_accepted_snapshot_id_until_active(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_polls_accepted_snapshot_id_until_active(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        mock_sandbox_api.create_sandbox_snapshot.return_value = MagicMock(
-            id="snapshot-id"
-        )
+        mock_sandbox_api.create_sandbox_snapshot.return_value = MagicMock(id="snapshot-id")
         sandbox._snapshots_api = MagicMock(
             get_snapshot=MagicMock(
-                return_value=MagicMock(
-                    id="snapshot-id", state=SnapshotState.ACTIVE, error_reason=None
-                )
+                return_value=MagicMock(id="snapshot-id", state=SnapshotState.ACTIVE, error_reason=None)
             )
         )
-        mock_sandbox_api.get_sandbox.side_effect = DaytonaError(
-            "best-effort refresh failed"
-        )
+        mock_sandbox_api.get_sandbox.side_effect = DaytonaError("best-effort refresh failed")
 
         sandbox._experimental_create_snapshot("snap-1", timeout=1)
 
         sandbox._snapshots_api.get_snapshot.assert_called_once_with("snapshot-id")
 
-    def test_reports_snapshot_terminal_failure(
-        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
-    ):
+    def test_reports_snapshot_terminal_failure(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        mock_sandbox_api.create_sandbox_snapshot.return_value = MagicMock(
-            id="snapshot-id"
-        )
+        mock_sandbox_api.create_sandbox_snapshot.return_value = MagicMock(id="snapshot-id")
         sandbox._snapshots_api = MagicMock(
             get_snapshot=MagicMock(
                 return_value=MagicMock(
@@ -293,9 +223,7 @@ class TestSandboxSnapshotCapture:
 
 class TestSandboxWaitForStart:
     def test_error_state_raises(self, mock_toolbox_api_client, mock_sandbox_api):
-        error_dto = make_sandbox_dto(
-            state=SandboxState.ERROR, error_reason="build failed"
-        )
+        error_dto = make_sandbox_dto(state=SandboxState.ERROR, error_reason="build failed")
         sandbox = make_sandbox(error_dto, mock_toolbox_api_client, mock_sandbox_api)
         mock_sandbox_api.get_sandbox.return_value = error_dto
         with pytest.raises(DaytonaError, match="failed to start"):

--- a/sdk-python/tests/test_sandbox.py
+++ b/sdk-python/tests/test_sandbox.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from daytona.common.errors import DaytonaError, DaytonaValidationError
-from daytona_api_client import SandboxState, UpdateSandboxSecrets
+from daytona_api_client import SandboxState, SnapshotState, UpdateSandboxSecrets
 
 from .conftest import make_sandbox_dto
 
@@ -178,6 +178,43 @@ class TestSandboxOperations:
         assert request.set == {"A": "1"}
         assert request.unset == ["B"]
         assert request.unset_value_prefix is None
+
+
+class TestSandboxSnapshotCapture:
+    def test_polls_accepted_snapshot_id_until_active(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
+        sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
+        mock_sandbox_api.create_sandbox_snapshot.return_value = MagicMock(id="snapshot-id")
+        sandbox._snapshots_api = MagicMock(
+            get_snapshot=MagicMock(
+                return_value=MagicMock(id="snapshot-id", state=SnapshotState.ACTIVE, error_reason=None)
+            )
+        )
+        mock_sandbox_api.get_sandbox.side_effect = DaytonaError("best-effort refresh failed")
+
+        sandbox._experimental_create_snapshot("snap-1", timeout=1)
+
+        sandbox._snapshots_api.get_snapshot.assert_called_once_with("snapshot-id")
+
+    def test_reports_snapshot_terminal_failure(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+        sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
+        mock_sandbox_api.create_sandbox_snapshot.return_value = MagicMock(id="snapshot-id")
+        sandbox._snapshots_api = MagicMock(
+            get_snapshot=MagicMock(
+                return_value=MagicMock(
+                    id="snapshot-id",
+                    state=SnapshotState.ERROR,
+                    error_reason="capture failed",
+                )
+            )
+        )
+
+        with pytest.raises(
+            DaytonaError,
+            match="Snapshot snapshot-id failed with state: error, error reason: capture failed",
+        ):
+            sandbox._experimental_create_snapshot("snap-1", timeout=1)
 
 
 class TestSandboxWaitForStart:

--- a/sdk-python/tests/test_sandbox.py
+++ b/sdk-python/tests/test_sandbox.py
@@ -17,11 +17,19 @@ from .conftest import make_sandbox_dto
 def make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
     from daytona._sync.sandbox import Sandbox
 
-    return Sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api, "python", http_client=MagicMock())
+    return Sandbox(
+        sandbox_dto,
+        mock_toolbox_api_client,
+        mock_sandbox_api,
+        "python",
+        http_client=MagicMock(),
+    )
 
 
 class TestSandboxInit:
-    def test_sandbox_properties(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_sandbox_properties(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         assert sandbox.id == "test-sandbox-id"
         assert sandbox.name == "test-sandbox"
@@ -32,7 +40,9 @@ class TestSandboxInit:
         assert sandbox.user == "daytona"
         assert sandbox.public is False
 
-    def test_sandbox_has_subsystems(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_sandbox_has_subsystems(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         assert sandbox.fs is not None
         assert sandbox.git is not None
@@ -42,39 +52,61 @@ class TestSandboxInit:
 
 
 class TestSandboxLifecycleSettings:
-    def test_negative_autostop_interval_raises(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_negative_autostop_interval_raises(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        with pytest.raises(DaytonaValidationError, match="Auto-stop interval must be a non-negative"):
+        with pytest.raises(
+            DaytonaValidationError, match="Auto-stop interval must be a non-negative"
+        ):
             sandbox.set_autostop_interval(-1)
 
-    def test_valid_autostop_interval(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_valid_autostop_interval(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         sandbox.set_autostop_interval(30)
         assert sandbox.auto_stop_interval == 30
-        mock_sandbox_api.set_autostop_interval.assert_called_once_with(sandbox.id, 30, _request_timeout=None)
+        mock_sandbox_api.set_autostop_interval.assert_called_once_with(
+            sandbox.id, 30, _request_timeout=None
+        )
 
-    def test_negative_autopause_interval_raises(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_negative_autopause_interval_raises(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        with pytest.raises(DaytonaValidationError, match="Auto-pause interval must be a non-negative"):
+        with pytest.raises(
+            DaytonaValidationError, match="Auto-pause interval must be a non-negative"
+        ):
             sandbox.set_auto_pause_interval(-1)
 
-    def test_valid_autopause_interval(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_valid_autopause_interval(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         sandbox.set_auto_pause_interval(30)
         assert sandbox.auto_pause_interval == 30
         mock_sandbox_api.set_auto_pause_interval.assert_called_once_with(sandbox.id, 30)
 
-    def test_negative_auto_archive_interval_raises(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_negative_auto_archive_interval_raises(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        with pytest.raises(DaytonaValidationError, match="Auto-archive interval must be a non-negative"):
+        with pytest.raises(
+            DaytonaValidationError, match="Auto-archive interval must be a non-negative"
+        ):
             sandbox.set_auto_archive_interval(-1)
 
-    def test_valid_auto_archive_interval(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_valid_auto_archive_interval(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         sandbox.set_auto_archive_interval(60)
         assert sandbox.auto_archive_interval == 60
 
-    def test_auto_delete_interval(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_auto_delete_interval(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         sandbox.set_auto_delete_interval(120)
         assert sandbox.auto_delete_interval == 120
@@ -92,7 +124,9 @@ class TestSandboxOperations:
         assert result == new_labels
         assert sandbox.labels == new_labels
 
-    def test_create_lsp_server(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_create_lsp_server(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         from daytona._sync.lsp_server import LspServer
 
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
@@ -101,32 +135,48 @@ class TestSandboxOperations:
 
     def test_refresh_data(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        mock_sandbox_api.get_sandbox.return_value = make_sandbox_dto(state=SandboxState.STOPPED, cpu=8)
+        mock_sandbox_api.get_sandbox.return_value = make_sandbox_dto(
+            state=SandboxState.STOPPED, cpu=8
+        )
         sandbox.refresh_data()
         assert sandbox.state == SandboxState.STOPPED
         assert sandbox.cpu == 8
 
-    def test_get_user_home_dir(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_get_user_home_dir(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        sandbox._info_api = MagicMock(get_user_home_dir=MagicMock(return_value=MagicMock(dir="/home/daytona")))
+        sandbox._info_api = MagicMock(
+            get_user_home_dir=MagicMock(return_value=MagicMock(dir="/home/daytona"))
+        )
         assert sandbox.get_user_home_dir() == "/home/daytona"
 
     def test_get_work_dir(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        sandbox._info_api = MagicMock(get_work_dir=MagicMock(return_value=MagicMock(dir="/workspace")))
+        sandbox._info_api = MagicMock(
+            get_work_dir=MagicMock(return_value=MagicMock(dir="/workspace"))
+        )
         assert sandbox.get_work_dir() == "/workspace"
 
-    def test_get_user_root_dir_delegates_to_home_dir(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_get_user_root_dir_delegates_to_home_dir(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        sandbox._info_api = MagicMock(get_user_home_dir=MagicMock(return_value=MagicMock(dir="/home/daytona")))
+        sandbox._info_api = MagicMock(
+            get_user_home_dir=MagicMock(return_value=MagicMock(dir="/home/daytona"))
+        )
 
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             assert sandbox.get_user_root_dir() == "/home/daytona"
 
-    def test_preview_and_ssh_operations_delegate(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_preview_and_ssh_operations_delegate(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        mock_sandbox_api.get_port_preview_url.return_value = MagicMock(url="https://preview")
+        mock_sandbox_api.get_port_preview_url.return_value = MagicMock(
+            url="https://preview"
+        )
         mock_sandbox_api.create_ssh_access.return_value = MagicMock(token="ssh-token")
         mock_sandbox_api.validate_ssh_access.return_value = MagicMock(valid=True)
 
@@ -136,13 +186,23 @@ class TestSandboxOperations:
         sandbox.revoke_ssh_access("token")
         sandbox.refresh_activity()
 
-        mock_sandbox_api.get_port_preview_url.assert_called_once_with(sandbox.id, 3000, _request_timeout=None)
-        mock_sandbox_api.revoke_ssh_access.assert_called_once_with(sandbox.id, "token", _request_timeout=None)
-        mock_sandbox_api.update_last_activity.assert_called_once_with(sandbox.id, _request_timeout=None)
+        mock_sandbox_api.get_port_preview_url.assert_called_once_with(
+            sandbox.id, 3000, _request_timeout=None
+        )
+        mock_sandbox_api.revoke_ssh_access.assert_called_once_with(
+            sandbox.id, "token", _request_timeout=None
+        )
+        mock_sandbox_api.update_last_activity.assert_called_once_with(
+            sandbox.id, _request_timeout=None
+        )
 
-    def test_update_secrets(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_update_secrets(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        mock_sandbox_api.update_sandbox_secrets.return_value = make_sandbox_dto(env={"FOO": "placeholder"})
+        mock_sandbox_api.update_sandbox_secrets.return_value = make_sandbox_dto(
+            env={"FOO": "placeholder"}
+        )
 
         sandbox.update_secrets({"FOO": "foo-secret", "BAR": "bar"})
 
@@ -153,7 +213,9 @@ class TestSandboxOperations:
         assert body.secrets == [{"FOO": "foo-secret"}, {"BAR": "bar"}]
         assert sandbox.env == {"FOO": "placeholder"}
 
-    def test_update_secrets_empty_dict_detaches_all(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_update_secrets_empty_dict_detaches_all(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         mock_sandbox_api.update_sandbox_secrets.return_value = make_sandbox_dto(env={})
 
@@ -167,7 +229,9 @@ class TestSandboxOperations:
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
         # The daemon responds with a status message, which update_env discards.
         sandbox._server_api = MagicMock(
-            update_env=MagicMock(return_value={"message": "Environment updated successfully"})
+            update_env=MagicMock(
+                return_value={"message": "Environment updated successfully"}
+            )
         )
 
         result = sandbox.update_env({"A": "1"}, unset=["B"])
@@ -185,21 +249,31 @@ class TestSandboxSnapshotCapture:
         self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
     ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        mock_sandbox_api.create_sandbox_snapshot.return_value = MagicMock(id="snapshot-id")
+        mock_sandbox_api.create_sandbox_snapshot.return_value = MagicMock(
+            id="snapshot-id"
+        )
         sandbox._snapshots_api = MagicMock(
             get_snapshot=MagicMock(
-                return_value=MagicMock(id="snapshot-id", state=SnapshotState.ACTIVE, error_reason=None)
+                return_value=MagicMock(
+                    id="snapshot-id", state=SnapshotState.ACTIVE, error_reason=None
+                )
             )
         )
-        mock_sandbox_api.get_sandbox.side_effect = DaytonaError("best-effort refresh failed")
+        mock_sandbox_api.get_sandbox.side_effect = DaytonaError(
+            "best-effort refresh failed"
+        )
 
         sandbox._experimental_create_snapshot("snap-1", timeout=1)
 
         sandbox._snapshots_api.get_snapshot.assert_called_once_with("snapshot-id")
 
-    def test_reports_snapshot_terminal_failure(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+    def test_reports_snapshot_terminal_failure(
+        self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api
+    ):
         sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
-        mock_sandbox_api.create_sandbox_snapshot.return_value = MagicMock(id="snapshot-id")
+        mock_sandbox_api.create_sandbox_snapshot.return_value = MagicMock(
+            id="snapshot-id"
+        )
         sandbox._snapshots_api = MagicMock(
             get_snapshot=MagicMock(
                 return_value=MagicMock(
@@ -219,7 +293,9 @@ class TestSandboxSnapshotCapture:
 
 class TestSandboxWaitForStart:
     def test_error_state_raises(self, mock_toolbox_api_client, mock_sandbox_api):
-        error_dto = make_sandbox_dto(state=SandboxState.ERROR, error_reason="build failed")
+        error_dto = make_sandbox_dto(
+            state=SandboxState.ERROR, error_reason="build failed"
+        )
         sandbox = make_sandbox(error_dto, mock_toolbox_api_client, mock_sandbox_api)
         mock_sandbox_api.get_sandbox.return_value = error_dto
         with pytest.raises(DaytonaError, match="failed to start"):

--- a/sdk-ruby/lib/daytona/sandbox.rb
+++ b/sdk-ruby/lib/daytona/sandbox.rb
@@ -665,7 +665,10 @@ module Daytona
       started_at = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
       accepted = sandbox_api.create_sandbox_snapshot(id, DaytonaApiClient::CreateSandboxSnapshot.new(name:))
       snapshot_id = accepted&.id
-      raise Sdk::Error, "Failed to create snapshot. Didn't receive a snapshot ID from the server API." unless snapshot_id
+      unless snapshot_id
+        raise Sdk::Error,
+              "Failed to create snapshot. Didn't receive a snapshot ID from the server API."
+      end
 
       deadline = timeout == NO_TIMEOUT ? nil : started_at + timeout
       wait_for_snapshot_complete(snapshot_id, deadline)

--- a/sdk-ruby/lib/daytona/sandbox.rb
+++ b/sdk-ruby/lib/daytona/sandbox.rb
@@ -158,6 +158,7 @@ module Daytona
       process_response(sandbox_dto)
       @config = config
       @sandbox_api = sandbox_api
+      @snapshots_api = DaytonaApiClient::SnapshotsApi.new(sandbox_api.api_client)
       @otel_state = otel_state
       @analytics_api_url_provider = analytics_api_url_provider
 
@@ -654,20 +655,20 @@ module Daytona
     end
 
     # Creates a snapshot from the current state of the Sandbox.
-    # The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
     #
     # @param name [String] Name for the new snapshot
-    # @param timeout [Numeric] Maximum wait time in seconds (defaults to 60 s)
+    # @param timeout [Numeric] Maximum wait time in seconds (defaults to 60 s; 0 disables the timeout)
     # @return [void]
     def experimental_create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
-      with_timeout(
-        timeout:,
-        message: "Sandbox #{id} snapshot failed within the #{timeout} seconds timeout period",
-        setup: proc {
-          sandbox_api.create_sandbox_snapshot(id, DaytonaApiClient::CreateSandboxSnapshot.new(name:))
-          refresh
-        }
-      ) { wait_for_snapshot_complete }
+      raise Sdk::Error, 'Timeout must be a non-negative number' if timeout.negative?
+
+      started_at = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      accepted = sandbox_api.create_sandbox_snapshot(id, DaytonaApiClient::CreateSandboxSnapshot.new(name:))
+      snapshot_id = accepted&.id
+      raise Sdk::Error, "Failed to create snapshot. Didn't receive a snapshot ID from the server API." unless snapshot_id
+
+      deadline = timeout == NO_TIMEOUT ? nil : started_at + timeout
+      wait_for_snapshot_complete(snapshot_id, deadline)
     end
 
     # Pauses the Sandbox, freezing all running processes.
@@ -903,18 +904,32 @@ module Daytona
     OPERATION_RESIZE = :resize
     private_constant :OPERATION_RESIZE
 
-    def wait_for_snapshot_complete
+    def wait_for_snapshot_complete(snapshot_id, deadline)
       interval = INITIAL_POLL_INTERVAL
       start_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-      while state == DaytonaApiClient::SandboxState::SNAPSHOTTING
-        refresh
 
-        if [DaytonaApiClient::SandboxState::ERROR, DaytonaApiClient::SandboxState::BUILD_FAILED].include?(state)
-          raise Sdk::Error,
-                "Sandbox #{id} snapshot failed with state: #{state}, error reason: #{error_reason}"
+      loop do
+        if deadline && ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) >= deadline
+          raise Sdk::Error, "Timed out waiting for snapshot #{snapshot_id}; capture continues on the server"
         end
 
-        break if state != DaytonaApiClient::SandboxState::SNAPSHOTTING
+        snapshot = @snapshots_api.get_snapshot(snapshot_id)
+        unless snapshot && snapshot.id == snapshot_id
+          raise Sdk::Error, "Snapshot lookup for #{snapshot_id} returned an invalid response"
+        end
+
+        case snapshot.state
+        when DaytonaApiClient::SnapshotState::ACTIVE
+          begin
+            refresh
+          rescue StandardError
+            nil
+          end
+          return
+        when DaytonaApiClient::SnapshotState::ERROR, DaytonaApiClient::SnapshotState::BUILD_FAILED
+          raise Sdk::Error,
+                "Snapshot #{snapshot.id} failed with state: #{snapshot.state}, error reason: #{snapshot.error_reason}"
+        end
 
         sleep(interval)
         if ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - start_time > 5

--- a/sdk-ruby/spec/daytona/sandbox_spec.rb
+++ b/sdk-ruby/spec/daytona/sandbox_spec.rb
@@ -6,6 +6,7 @@
 RSpec.describe Daytona::Sandbox do
   let(:config) { build_config }
   let(:sandbox_api) { instance_double(DaytonaApiClient::SandboxApi) }
+  let(:snapshots_api) { instance_double(DaytonaApiClient::SnapshotsApi) }
   let(:sandbox_dto) { build_sandbox_dto }
   let(:toolbox_client) do
     double('ToolboxApiClient', default_headers: {}).tap do |client|
@@ -22,6 +23,8 @@ RSpec.describe Daytona::Sandbox do
   let(:server_api) { instance_double(DaytonaToolboxApiClient::ServerApi) }
 
   before do
+    allow(sandbox_api).to receive(:api_client).and_return(double('ApiClient'))
+    allow(DaytonaApiClient::SnapshotsApi).to receive(:new).and_return(snapshots_api)
     allow(DaytonaToolboxApiClient::ApiClient).to receive(:new).and_return(toolbox_client)
     allow(DaytonaToolboxApiClient::ProcessApi).to receive(:new).and_return(process_api)
     allow(DaytonaToolboxApiClient::FileSystemApi).to receive(:new).and_return(fs_api)
@@ -464,15 +467,34 @@ RSpec.describe Daytona::Sandbox do
   end
 
   describe '#experimental_create_snapshot' do
-    it 'creates a snapshot and waits for completion' do
-      allow(sandbox_api).to receive(:create_sandbox_snapshot).with('sandbox-123', anything)
-      allow(sandbox_api).to receive(:get_sandbox).with('sandbox-123').and_return(build_sandbox_dto(state: DaytonaApiClient::SandboxState::STARTED))
+    it 'polls the accepted snapshot ID until active' do
+      accepted = build_snapshot_dto(id: 'snapshot-id', state: DaytonaApiClient::SnapshotState::CAPTURING)
+      active = build_snapshot_dto(id: 'snapshot-id', state: DaytonaApiClient::SnapshotState::ACTIVE)
+      allow(sandbox_api).to receive(:create_sandbox_snapshot).with('sandbox-123', anything).and_return(accepted)
+      allow(snapshots_api).to receive(:get_snapshot).with('snapshot-id').and_return(active)
+      allow(sandbox_api).to receive(:get_sandbox).with('sandbox-123').and_raise(Daytona::Sdk::Error, 'refresh failed')
 
-      sandbox.experimental_create_snapshot(name: 'snap-1', timeout: 5)
+      expect { sandbox.experimental_create_snapshot(name: 'snap-1', timeout: 5) }.not_to raise_error
 
-      expect(sandbox_api).to have_received(:create_sandbox_snapshot) do |_id, request|
-        expect(request.name).to eq('snap-1')
-      end
+      expect(snapshots_api).to have_received(:get_snapshot).with('snapshot-id')
+    end
+
+    it 'reports the accepted snapshot terminal failure' do
+      accepted = build_snapshot_dto(id: 'snapshot-id', state: DaytonaApiClient::SnapshotState::CAPTURING)
+      failed = build_snapshot_dto(
+        id: 'snapshot-id',
+        state: DaytonaApiClient::SnapshotState::ERROR,
+        error_reason: 'capture failed'
+      )
+      allow(sandbox_api).to receive(:create_sandbox_snapshot).and_return(accepted)
+      allow(snapshots_api).to receive(:get_snapshot).with('snapshot-id').and_return(failed)
+
+      expect do
+        sandbox.experimental_create_snapshot(name: 'snap-1', timeout: 5)
+      end.to raise_error(
+        Daytona::Sdk::Error,
+        /Snapshot snapshot-id failed with state: error, error reason: capture failed/
+      )
     end
   end
 end

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -237,6 +237,7 @@ export type CreateSandboxFromSnapshotParams = CreateSandboxBaseParams & {
 export class Daytona implements AsyncDisposable {
   private readonly clientConfig: Configuration
   private readonly sandboxApi: SandboxApi
+  private readonly snapshotsApi: SnapshotsApi
   private readonly objectStorageApi: ObjectStorageApi
   private readonly configApi: ConfigApi
   private analyticsApiUrlPromise?: Promise<string | undefined>
@@ -352,14 +353,10 @@ export class Daytona implements AsyncDisposable {
     this.sandboxApi = new SandboxApi(configuration, '', axiosInstance)
     this.objectStorageApi = new ObjectStorageApi(configuration, '', axiosInstance)
     this.configApi = new ConfigApi(configuration, '', axiosInstance)
+    this.snapshotsApi = new SnapshotsApi(configuration, '', axiosInstance)
     this.volume = new VolumeService(new VolumesApi(configuration, '', axiosInstance))
     this.secret = new SecretService(new SecretApi(configuration, '', axiosInstance))
-    this.snapshot = new SnapshotService(
-      configuration,
-      new SnapshotsApi(configuration, '', axiosInstance),
-      this.objectStorageApi,
-      this.target,
-    )
+    this.snapshot = new SnapshotService(configuration, this.snapshotsApi, this.objectStorageApi, this.target)
     this.clientConfig = configuration
 
     const env = envReader()
@@ -670,6 +667,7 @@ export class Daytona implements AsyncDisposable {
         new Configuration(structuredClone(this.clientConfig)),
         Daytona.createAxiosInstance(),
         this.sandboxApi,
+        this.snapshotsApi,
         this.getAnalyticsApiUrl,
       )
 
@@ -711,6 +709,7 @@ export class Daytona implements AsyncDisposable {
       structuredClone(this.clientConfig),
       Daytona.createAxiosInstance(),
       this.sandboxApi,
+      this.snapshotsApi,
       this.getAnalyticsApiUrl,
     )
   }
@@ -727,7 +726,7 @@ export class Daytona implements AsyncDisposable {
    * }
    */
   public list(query?: ListSandboxesQuery): AsyncIterableIterator<Sandbox> {
-    const { sandboxApi, clientConfig } = this
+    const { sandboxApi, snapshotsApi, clientConfig } = this
     const getAnalyticsApiUrl = this.getAnalyticsApiUrl
     const tracer = trace.getTracer('')
 
@@ -804,6 +803,7 @@ export class Daytona implements AsyncDisposable {
             structuredClone(clientConfig),
             Daytona.createAxiosInstance(),
             sandboxApi,
+            snapshotsApi,
             getAnalyticsApiUrl,
           )
         }

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SandboxState, SandboxApi, SandboxBackupStateEnum, Configuration } from '@daytona/api-client'
+import {
+  SandboxState,
+  SnapshotState,
+  SandboxApi,
+  SnapshotsApi,
+  SandboxBackupStateEnum,
+  Configuration,
+} from '@daytona/api-client'
 import {
   TelemetryApi as AnalyticsTelemetryApi,
   Configuration as AnalyticsConfiguration,
@@ -143,6 +150,7 @@ export class Sandbox {
   private infoApi: InfoApi
   private serverApi: ServerApi
   private systemApi: SystemApi
+  private snapshotsApi: SnapshotsApi
 
   /**
    * Creates a new Sandbox instance
@@ -157,6 +165,7 @@ export class Sandbox {
     private readonly getAnalyticsApiUrl: () => Promise<string | undefined>,
   ) {
     this.processSandboxDto(sandboxDto)
+    this.snapshotsApi = new SnapshotsApi(this.clientConfig, '', this.axiosInstance)
 
     // Set the toolbox base URL
     let baseUrl = this.toolboxProxyUrl
@@ -463,8 +472,8 @@ export class Sandbox {
    * Creates a snapshot from the current state of the Sandbox.
    *
    * This captures the Sandbox's filesystem into a reusable snapshot that can be
-   * used to create new Sandboxes. The Sandbox will temporarily enter a
-   * 'snapshotting' state and return to its previous state when complete.
+   * used to create new Sandboxes. The method waits for the accepted snapshot
+   * to become active.
    *
    * @param {string} name - Name for the new snapshot
    * @param {number} [timeout] - Maximum time to wait in seconds. 0 means no timeout.
@@ -486,40 +495,50 @@ export class Sandbox {
 
     const startTime = Date.now()
     const req: CreateSandboxSnapshot = { name }
-    await this.sandboxApi.createSandboxSnapshot(this.id, req, undefined, {
-      timeout: timeout * 1000,
-    })
+    const accepted = (
+      await this.sandboxApi.createSandboxSnapshot(this.id, req, undefined, {
+        timeout: timeout * 1000,
+      })
+    ).data
+    const snapshotId = accepted?.id
+    if (!snapshotId) {
+      throw new DaytonaError("Failed to create snapshot. Didn't receive a snapshot ID from the server API.")
+    }
 
-    await this.refreshData()
-
-    const timeElapsed = Date.now() - startTime
-    const remainingTimeout = timeout ? Math.max(0.001, timeout - timeElapsed / 1000) : timeout
-    await this.waitForSnapshotComplete(remainingTimeout)
+    const deadline = timeout === 0 ? undefined : startTime + timeout * 1000
+    await this.waitForSnapshotComplete(snapshotId, deadline)
   }
 
-  private async waitForSnapshotComplete(timeout: number) {
+  private async waitForSnapshotComplete(snapshotId: string, deadline?: number): Promise<void> {
     let checkInterval = 100
     const startTime = Date.now()
 
-    while (this.state === SandboxState.SNAPSHOTTING) {
-      await this.refreshData()
-
-      // @ts-expect-error this.refreshData() can modify this.state so this check is fine
-      if (this.state === SandboxState.ERROR || this.state === SandboxState.BUILD_FAILED) {
-        throw new DaytonaError(
-          `Sandbox ${this.id} snapshot failed with state: ${this.state}, error reason: ${this.errorReason}`,
+    for (;;) {
+      if (deadline !== undefined && Date.now() >= deadline) {
+        throw new DaytonaTimeoutError(
+          `Timed out waiting for snapshot ${snapshotId}; capture continues on the server`,
         )
       }
 
-      if (this.state !== SandboxState.SNAPSHOTTING) {
-        return
+      const snapshot = (await this.snapshotsApi.getSnapshot(snapshotId)).data
+      if (!snapshot || snapshot.id !== snapshotId) {
+        throw new DaytonaError(`Snapshot lookup for ${snapshotId} returned an invalid response`)
       }
 
-      if (timeout !== 0 && Date.now() - startTime > timeout * 1000) {
-        throw new DaytonaTimeoutError('Sandbox snapshot did not complete within the timeout period')
+      switch (snapshot.state) {
+        case SnapshotState.ACTIVE:
+          await this.refreshData().catch(() => undefined)
+          return
+        case SnapshotState.ERROR:
+        case SnapshotState.BUILD_FAILED:
+          throw new DaytonaError(
+            `Snapshot ${snapshot.id} failed with state: ${snapshot.state}, error reason: ${snapshot.errorReason}`,
+          )
       }
 
-      await new Promise((resolve) => setTimeout(resolve, checkInterval))
+      const { promise, resolve } = Promise.withResolvers<void>()
+      setTimeout(resolve, checkInterval)
+      await promise
       if (Date.now() - startTime > 5000) {
         checkInterval = Math.min(checkInterval * 1.1, 1000)
       }

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -150,7 +150,6 @@ export class Sandbox {
   private infoApi: InfoApi
   private serverApi: ServerApi
   private systemApi: SystemApi
-  private snapshotsApi: SnapshotsApi
 
   /**
    * Creates a new Sandbox instance
@@ -162,10 +161,10 @@ export class Sandbox {
     private readonly clientConfig: Configuration,
     private readonly axiosInstance: AxiosInstance,
     private readonly sandboxApi: SandboxApi,
+    private readonly snapshotsApi: SnapshotsApi,
     private readonly getAnalyticsApiUrl: () => Promise<string | undefined>,
   ) {
     this.processSandboxDto(sandboxDto)
-    this.snapshotsApi = new SnapshotsApi(this.clientConfig, '', this.axiosInstance)
 
     // Set the toolbox base URL
     let baseUrl = this.toolboxProxyUrl
@@ -459,6 +458,7 @@ export class Sandbox {
       structuredClone(this.clientConfig),
       Daytona.createAxiosInstance(),
       this.sandboxApi,
+      this.snapshotsApi,
       this.getAnalyticsApiUrl,
     )
 

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -515,9 +515,7 @@ export class Sandbox {
 
     for (;;) {
       if (deadline !== undefined && Date.now() >= deadline) {
-        throw new DaytonaTimeoutError(
-          `Timed out waiting for snapshot ${snapshotId}; capture continues on the server`,
-        )
+        throw new DaytonaTimeoutError(`Timed out waiting for snapshot ${snapshotId}; capture continues on the server`)
       }
 
       const snapshot = (await this.snapshotsApi.getSnapshot(snapshotId)).data

--- a/sdk-typescript/src/__tests__/Sandbox.snapshot-base-url.test.ts
+++ b/sdk-typescript/src/__tests__/Sandbox.snapshot-base-url.test.ts
@@ -1,0 +1,104 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import axios from 'axios'
+import { createServer, type Server } from 'node:http'
+import {
+  Configuration,
+  SandboxApi,
+  SnapshotsApi,
+  SandboxState,
+  SnapshotState,
+  type Sandbox as SandboxDto,
+} from '@daytona/api-client'
+import { Sandbox } from '../Sandbox'
+
+const sandboxDto = (toolboxProxyUrl: string): SandboxDto => ({
+  id: 'sb-1',
+  name: 'sandbox-one',
+  organizationId: 'org-1',
+  user: 'daytona',
+  env: {},
+  labels: {},
+  public: false,
+  target: 'eu',
+  cpu: 2,
+  gpu: 0,
+  memory: 4,
+  disk: 10,
+  state: SandboxState.STOPPED,
+  networkBlockAll: false,
+  toolboxProxyUrl,
+})
+
+describe('Sandbox snapshot polling base URL', () => {
+  let server: Server
+  let origin: string
+  let requests: string[]
+
+  beforeEach(async () => {
+    requests = []
+    server = createServer((request, response) => {
+      const path = request.url ?? ''
+      requests.push(`${request.method} ${path}`)
+      response.setHeader('content-type', 'application/json')
+
+      if (request.method === 'POST' && path === '/api/sandbox/sb-1/snapshot') {
+        response.statusCode = 202
+        response.end(JSON.stringify({ id: 'snapshot-id', name: 'snap-1', state: SnapshotState.CAPTURING }))
+        return
+      }
+
+      if (request.method === 'GET' && path === '/api/snapshots/snapshot-id') {
+        response.end(JSON.stringify({ id: 'snapshot-id', name: 'snap-1', state: SnapshotState.ACTIVE }))
+        return
+      }
+
+      if (request.method === 'GET' && path === '/api/sandbox/sb-1') {
+        response.end(JSON.stringify(sandboxDto(`${origin}/toolbox`)))
+        return
+      }
+
+      response.statusCode = 404
+      response.end(JSON.stringify({ message: 'page not found' }))
+    })
+
+    const { promise, resolve, reject } = Promise.withResolvers<void>()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+    await promise
+
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Mock server did not bind to a TCP port')
+    }
+    origin = `http://127.0.0.1:${address.port}`
+  })
+
+  afterEach(async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<void>()
+    server.close((error) => (error ? reject(error) : resolve()))
+    await promise
+  })
+
+  it('keeps snapshot polling on the main API after toolbox initialization', async () => {
+    const mainConfiguration = new Configuration({ basePath: `${origin}/api` })
+    const sandboxApi = new SandboxApi(mainConfiguration, '', axios.create())
+    const snapshotsApi = new SnapshotsApi(mainConfiguration, '', axios.create())
+    const sandboxConfiguration = new Configuration(structuredClone(mainConfiguration))
+    const sandbox = new Sandbox(
+      sandboxDto(`${origin}/toolbox`),
+      sandboxConfiguration,
+      axios.create(),
+      sandboxApi,
+      snapshotsApi,
+      async () => undefined,
+    )
+
+    await sandbox._experimental_createSnapshot('snap-1', 1)
+
+    expect(requests).toContain('POST /api/sandbox/sb-1/snapshot')
+    expect(requests).toContain('GET /api/snapshots/snapshot-id')
+    expect(requests).not.toContain('GET /toolbox/sb-1/snapshots/snapshot-id')
+  })
+})

--- a/sdk-typescript/src/__tests__/Sandbox.test.ts
+++ b/sdk-typescript/src/__tests__/Sandbox.test.ts
@@ -110,6 +110,7 @@ const makeSandbox = (
     cfg,
     axiosInstance as unknown as never,
     sandboxApi as unknown as never,
+    mockSnapshotsApi as unknown as never,
     getAnalyticsApiUrl as unknown as never,
   )
 

--- a/sdk-typescript/src/__tests__/Sandbox.test.ts
+++ b/sdk-typescript/src/__tests__/Sandbox.test.ts
@@ -4,6 +4,15 @@
 import type { Configuration, Sandbox as SandboxDto } from '@daytona/api-client'
 import { createApiResponse } from './helpers'
 import { DaytonaNotFoundError } from '../errors/DaytonaError'
+import { Sandbox } from '../Sandbox'
+
+const mockSnapshotsApi = {
+  getSnapshot: jest.fn(),
+}
+
+const mockServerApi = {
+  updateEnv: jest.fn(),
+}
 
 jest.mock(
   '@daytona/api-client',
@@ -14,6 +23,12 @@ jest.mock(
       BUILD_FAILED: 'build_failed',
       DESTROYED: 'destroyed',
     },
+    SnapshotState: {
+      ACTIVE: 'active',
+      ERROR: 'error',
+      BUILD_FAILED: 'build_failed',
+    },
+    SnapshotsApi: jest.fn(() => mockSnapshotsApi),
   }),
   { virtual: true },
 )
@@ -26,7 +41,7 @@ jest.mock(
     ProcessApi: jest.fn(() => ({})),
     LspApi: jest.fn(() => ({})),
     InfoApi: jest.fn(() => ({ getUserHomeDir: jest.fn(), getWorkDir: jest.fn() })),
-    ServerApi: jest.fn(() => ({ updateEnv: jest.fn() })),
+    ServerApi: jest.fn(() => mockServerApi),
     SystemApi: jest.fn(() => ({ getSystemMetrics: jest.fn() })),
     ComputerUseApi: jest.fn(() => ({})),
     InterpreterApi: jest.fn(() => ({})),
@@ -54,8 +69,7 @@ const baseDto: SandboxDto = {
 
 const makeSandbox = (
   overrides: Partial<SandboxDto> = {},
-): { sandbox: import('../Sandbox').Sandbox; sandboxApi: Record<string, jest.Mock> } => {
-  const { Sandbox } = require('../Sandbox') as typeof import('../Sandbox')
+): { sandbox: Sandbox; sandboxApi: Record<string, jest.Mock> } => {
   const sandboxApi = {
     startSandbox: jest.fn(),
     recoverSandbox: jest.fn(),
@@ -103,6 +117,10 @@ const makeSandbox = (
 }
 
 describe('Sandbox', () => {
+  beforeEach(() => {
+    mockSnapshotsApi.getSnapshot.mockReset()
+    mockServerApi.updateEnv.mockReset()
+  })
   it('maps dto fields in constructor', () => {
     const { sandbox } = makeSandbox({ labels: { team: 'sdk' }, autoStopInterval: 10 })
     expect(sandbox.id).toBe('sb-1')
@@ -265,25 +283,53 @@ describe('Sandbox', () => {
 
   it('updates the daemon environment', async () => {
     const { sandbox } = makeSandbox()
-    const serverApi = (sandbox as unknown as { serverApi: { updateEnv: jest.Mock } }).serverApi
-    // The daemon responds with a status message, not the resulting environment.
-    serverApi.updateEnv.mockResolvedValue(createApiResponse({ message: 'Environment updated successfully' }))
+    mockServerApi.updateEnv.mockResolvedValue(createApiResponse({ message: 'Environment updated successfully' }))
 
     await expect(sandbox.updateEnv({ NODE_ENV: 'production' }, { unset: ['DEBUG'] })).resolves.toBeUndefined()
 
-    expect(serverApi.updateEnv).toHaveBeenCalledWith({ set: { NODE_ENV: 'production' }, unset: ['DEBUG'] })
+    expect(mockServerApi.updateEnv).toHaveBeenCalledWith({ set: { NODE_ENV: 'production' }, unset: ['DEBUG'] })
   })
 
-  it('creates sandbox snapshots and waits for completion', async () => {
-    const { sandbox, sandboxApi } = makeSandbox({ state: 'snapshotting' })
-    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+  it('polls the accepted snapshot ID until that snapshot is active', async () => {
+    const { sandbox, sandboxApi } = makeSandbox()
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(
+      createApiResponse({ id: 'snapshot-id', name: 'snap-1', state: 'capturing' }),
+    )
     sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
+    mockSnapshotsApi.getSnapshot.mockResolvedValue(
+      createApiResponse({ id: 'snapshot-id', name: 'snap-1', state: 'active' }),
+    )
 
     await sandbox._experimental_createSnapshot('snap-1', 1)
 
     expect(sandboxApi.createSandboxSnapshot).toHaveBeenCalledWith('sb-1', { name: 'snap-1' }, undefined, {
       timeout: 1000,
     })
+    expect(mockSnapshotsApi.getSnapshot).toHaveBeenCalledWith('snapshot-id')
+  })
+
+  it('reports the accepted snapshot terminal failure', async () => {
+    const { sandbox, sandboxApi } = makeSandbox()
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(
+      createApiResponse({ id: 'snapshot-id', name: 'snap-1', state: 'capturing' }),
+    )
+    mockSnapshotsApi.getSnapshot.mockResolvedValue(
+      createApiResponse({ id: 'snapshot-id', name: 'snap-1', state: 'error', errorReason: 'capture failed' }),
+    )
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).rejects.toThrow(
+      'Snapshot snapshot-id failed with state: error, error reason: capture failed',
+    )
+  })
+
+  it('rejects a missing accepted snapshot response', async () => {
+    const { sandbox, sandboxApi } = makeSandbox()
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).rejects.toThrow(
+      "Didn't receive a snapshot ID",
+    )
+    expect(mockSnapshotsApi.getSnapshot).not.toHaveBeenCalled()
   })
 
   it('waitUntilStarted throws when sandbox enters an error state', async () => {

--- a/sdk-typescript/src/__tests__/Sandbox.test.ts
+++ b/sdk-typescript/src/__tests__/Sandbox.test.ts
@@ -326,9 +326,7 @@ describe('Sandbox', () => {
     const { sandbox, sandboxApi } = makeSandbox()
     sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
 
-    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).rejects.toThrow(
-      "Didn't receive a snapshot ID",
-    )
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).rejects.toThrow("Didn't receive a snapshot ID")
     expect(mockSnapshotsApi.getSnapshot).not.toHaveBeenCalled()
   })
 

--- a/sdk-typescript/tsconfig.json
+++ b/sdk-typescript/tsconfig.json
@@ -5,6 +5,7 @@
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
   "compilerOptions": {
     "esModuleInterop": true,
+    "lib": ["es2024", "dom"],
     "types": ["node"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
This updates snapshot-from-sandbox clients to track the Snapshot accepted by the API instead of inferring completion from Sandbox state.

- Decode the `202` response as `SnapshotDto`, add `CAPTURING`, and regenerate all six API clients.
- Update TypeScript, Python sync/async, Ruby, Go, and Java SDKs to poll the returned Snapshot ID until `ACTIVE`.
- Surface Snapshot ID, terminal state, and `errorReason` for `ERROR` and `BUILD_FAILED`.
- Stop waiting on local timeout or cancellation without cancelling the server-side capture.
- Keep TypeScript polling on the main API client rather than the Sandbox toolbox proxy.
- Add per-language regression coverage and refresh generated SDK documentation.

Verification:
- TypeScript focused tests: 58 passed.
- Python sync/async tests: 44 passed.
- Ruby specs: 46 passed.
- Focused Go and Java tests passed.
- All six generated API clients built successfully.
- Full client build passed across 24 projects.
- SDK documentation generated successfully for all five languages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Snapshot-from-sandbox now returns a `SnapshotDto`, and all SDKs poll that snapshot by ID until it becomes ACTIVE. Added a "capturing" state, clearer failure/timeout messages, and kept TypeScript polling on the main API.

- **New Features**
  - API returns 202 with `SnapshotDto` for POST `/sandbox/{id}/snapshot`; 409 on name conflicts.
  - Added `SnapshotState` "capturing"; SDKs poll the accepted snapshot ID and surface terminal state and `errorReason`.
  - TypeScript keeps polling via the main API client (not the toolbox).

- **Migration**
  - Handle 202 responses and decode `SnapshotDto` instead of assuming 200/`Sandbox`.
  - Track Snapshot state (including "capturing") rather than Sandbox "snapshotting".
  - Handle 409 when a snapshot name already exists.
  - Treat timeout=0 as no timeout; negative timeouts are invalid in SDKs.
  - TypeScript: if constructing `Sandbox` manually, pass a `SnapshotsApi` instance alongside `SandboxApi`.

<sup>Written for commit 6d4928cc739bdc2c6285794d663ba2e0a07e282a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

