### PR TITLE
feat(sdk,cli): sandbox TTL support

### DIFF
--- a/api-client-go/api/openapi.yaml
+++ b/api-client-go/api/openapi.yaml
@@ -8656,11 +8656,11 @@ components:
         cpu: 2
         gpu: 0
         daemonVersion: 1.0.0
-        expiresAt: 2026-07-15T12:00:00.000Z
         target: local
         labels:
           daytona.io/public: "true"
         disk: 10
+        autoDestroyAt: 2026-07-15T12:00:00.000Z
         name: MySandbox
         backupState: None
         user: daytona
@@ -8777,8 +8777,8 @@ components:
             \ 0 means delete immediately upon stopping)"
           example: 30
           type: number
-        expiresAt:
-          description: "When the sandbox will expire and be destroyed, regardless\
+        autoDestroyAt:
+          description: "When the sandbox will be automatically destroyed, regardless\
             \ of its state (only set when a TTL is configured)"
           example: 2026-07-15T12:00:00.000Z
           type: string
@@ -8841,11 +8841,11 @@ components:
           cpu: 2
           gpu: 0
           daemonVersion: 1.0.0
-          expiresAt: 2026-07-15T12:00:00.000Z
           target: local
           labels:
             daytona.io/public: "true"
           disk: 10
+          autoDestroyAt: 2026-07-15T12:00:00.000Z
           name: MySandbox
           backupState: None
           user: daytona
@@ -8872,11 +8872,11 @@ components:
           cpu: 2
           gpu: 0
           daemonVersion: 1.0.0
-          expiresAt: 2026-07-15T12:00:00.000Z
           target: local
           labels:
             daytona.io/public: "true"
           disk: 10
+          autoDestroyAt: 2026-07-15T12:00:00.000Z
           name: MySandbox
           backupState: None
           user: daytona
@@ -8995,11 +8995,11 @@ components:
         gpu: 0
         daemonVersion: 1.0.0
         backupCreatedAt: 2024-10-01T12:00:00Z
-        expiresAt: 2026-07-15T12:00:00.000Z
         labels:
           daytona.io/public: "true"
         target: local
         disk: 10
+        autoDestroyAt: 2026-07-15T12:00:00.000Z
         name: MySandbox
         backupState: None
         user: daytona
@@ -9131,8 +9131,8 @@ components:
             \ 0 means delete immediately upon stopping)"
           example: 30
           type: number
-        expiresAt:
-          description: "When the sandbox will expire and be destroyed, regardless\
+        autoDestroyAt:
+          description: "When the sandbox will be automatically destroyed, regardless\
             \ of its state (only set when a TTL is configured)"
           example: 2026-07-15T12:00:00.000Z
           type: string
@@ -9246,11 +9246,11 @@ components:
           gpu: 0
           daemonVersion: 1.0.0
           backupCreatedAt: 2024-10-01T12:00:00Z
-          expiresAt: 2026-07-15T12:00:00.000Z
           labels:
             daytona.io/public: "true"
           target: local
           disk: 10
+          autoDestroyAt: 2026-07-15T12:00:00.000Z
           name: MySandbox
           backupState: None
           user: daytona
@@ -9292,11 +9292,11 @@ components:
           gpu: 0
           daemonVersion: 1.0.0
           backupCreatedAt: 2024-10-01T12:00:00Z
-          expiresAt: 2026-07-15T12:00:00.000Z
           labels:
             daytona.io/public: "true"
           target: local
           disk: 10
+          autoDestroyAt: 2026-07-15T12:00:00.000Z
           name: MySandbox
           backupState: None
           user: daytona

--- a/api-client-go/api/openapi.yaml
+++ b/api-client-go/api/openapi.yaml
@@ -2969,6 +2969,52 @@ paths:
       summary: Set sandbox auto-pause interval
       tags:
       - sandbox
+  /sandbox/{sandboxIdOrName}/ttl/{ttlMinutes}:
+    post:
+      operationId: setTtl
+      parameters:
+      - description: Use with JWT to specify the organization ID
+        explode: false
+        in: header
+        name: X-Daytona-Organization-ID
+        required: false
+        schema:
+          type: string
+        style: simple
+      - description: ID or name of the sandbox
+        explode: false
+        in: path
+        name: sandboxIdOrName
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: "Maximum time to live in minutes, re-anchored from the current\
+          \ time (0 to disable). When it elapses the sandbox is destroyed, even if\
+          \ it is stopped, paused, or archived"
+        explode: false
+        in: path
+        name: ttlMinutes
+        required: true
+        schema:
+          type: number
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Sandbox"
+          description: TTL has been set
+      security:
+      - bearer: []
+      - oauth2:
+        - openid
+        - profile
+        - email
+      summary: Set sandbox TTL
+      tags:
+      - sandbox
   /sandbox/{sandboxIdOrName}/autoarchive/{interval}:
     post:
       operationId: setAutoArchiveInterval
@@ -8610,6 +8656,7 @@ components:
         cpu: 2
         gpu: 0
         daemonVersion: 1.0.0
+        expiresAt: 2026-07-15T12:00:00.000Z
         target: local
         labels:
           daytona.io/public: "true"
@@ -8730,6 +8777,11 @@ components:
             \ 0 means delete immediately upon stopping)"
           example: 30
           type: number
+        expiresAt:
+          description: "When the sandbox will expire and be destroyed, regardless\
+            \ of its state (only set when a TTL is configured)"
+          example: 2026-07-15T12:00:00.000Z
+          type: string
         createdAt:
           description: The creation timestamp of the sandbox
           example: 2024-10-01T12:00:00Z
@@ -8789,6 +8841,7 @@ components:
           cpu: 2
           gpu: 0
           daemonVersion: 1.0.0
+          expiresAt: 2026-07-15T12:00:00.000Z
           target: local
           labels:
             daytona.io/public: "true"
@@ -8819,6 +8872,7 @@ components:
           cpu: 2
           gpu: 0
           daemonVersion: 1.0.0
+          expiresAt: 2026-07-15T12:00:00.000Z
           target: local
           labels:
             daytona.io/public: "true"
@@ -8941,6 +8995,7 @@ components:
         gpu: 0
         daemonVersion: 1.0.0
         backupCreatedAt: 2024-10-01T12:00:00Z
+        expiresAt: 2026-07-15T12:00:00.000Z
         labels:
           daytona.io/public: "true"
         target: local
@@ -9076,6 +9131,11 @@ components:
             \ 0 means delete immediately upon stopping)"
           example: 30
           type: number
+        expiresAt:
+          description: "When the sandbox will expire and be destroyed, regardless\
+            \ of its state (only set when a TTL is configured)"
+          example: 2026-07-15T12:00:00.000Z
+          type: string
         volumes:
           description: Array of volumes attached to the sandbox
           items:
@@ -9186,6 +9246,7 @@ components:
           gpu: 0
           daemonVersion: 1.0.0
           backupCreatedAt: 2024-10-01T12:00:00Z
+          expiresAt: 2026-07-15T12:00:00.000Z
           labels:
             daytona.io/public: "true"
           target: local
@@ -9231,6 +9292,7 @@ components:
           gpu: 0
           daemonVersion: 1.0.0
           backupCreatedAt: 2024-10-01T12:00:00Z
+          expiresAt: 2026-07-15T12:00:00.000Z
           labels:
             daytona.io/public: "true"
           target: local
@@ -9292,6 +9354,7 @@ components:
           volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
           subpath: users/alice
         cpu: 2
+        ttlMinutes: 1440
         env:
           NODE_ENV: production
         gpu: 1
@@ -9411,6 +9474,13 @@ components:
           description: "Auto-delete interval in minutes (negative value means disabled,\
             \ 0 means delete immediately upon stopping)"
           example: 30
+          type: integer
+        ttlMinutes:
+          description: "Maximum time to live in minutes, counted as wall-clock time\
+            \ since creation regardless of sandbox state (0 means disabled). When\
+            \ it elapses the sandbox is destroyed, even if it is stopped, paused,\
+            \ or archived."
+          example: 1440
           type: integer
         volumes:
           description: Array of volumes to attach to the sandbox

--- a/api-client-go/api_sandbox.go
+++ b/api-client-go/api_sandbox.go
@@ -515,6 +515,20 @@ type SandboxAPI interface {
 	SetAutostopIntervalExecute(r SandboxAPISetAutostopIntervalRequest) (*Sandbox, *http.Response, error)
 
 	/*
+	SetTtl Set sandbox TTL
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param sandboxIdOrName ID or name of the sandbox
+	@param ttlMinutes Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived
+	@return SandboxAPISetTtlRequest
+	*/
+	SetTtl(ctx context.Context, sandboxIdOrName string, ttlMinutes float32) SandboxAPISetTtlRequest
+
+	// SetTtlExecute executes the request
+	//  @return Sandbox
+	SetTtlExecute(r SandboxAPISetTtlRequest) (*Sandbox, *http.Response, error)
+
+	/*
 	StartSandbox Start or resume sandbox
 
 	Starts a stopped or archived sandbox, or resumes a paused sandbox. The transition taken depends on the current sandbox state.
@@ -5402,6 +5416,121 @@ func (a *SandboxAPIService) SetAutostopIntervalExecute(r SandboxAPISetAutostopIn
 	localVarPath := localBasePath + "/sandbox/{sandboxIdOrName}/autostop/{interval}"
 	localVarPath = strings.Replace(localVarPath, "{"+"sandboxIdOrName"+"}", url.PathEscape(parameterValueToString(r.sandboxIdOrName, "sandboxIdOrName")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"interval"+"}", url.PathEscape(parameterValueToString(r.interval, "interval")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.xDaytonaOrganizationID != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "X-Daytona-Organization-ID", r.xDaytonaOrganizationID, "simple", "")
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type SandboxAPISetTtlRequest struct {
+	ctx context.Context
+	ApiService SandboxAPI
+	sandboxIdOrName string
+	ttlMinutes float32
+	xDaytonaOrganizationID *string
+}
+
+// Use with JWT to specify the organization ID
+func (r SandboxAPISetTtlRequest) XDaytonaOrganizationID(xDaytonaOrganizationID string) SandboxAPISetTtlRequest {
+	r.xDaytonaOrganizationID = &xDaytonaOrganizationID
+	return r
+}
+
+func (r SandboxAPISetTtlRequest) Execute() (*Sandbox, *http.Response, error) {
+	return r.ApiService.SetTtlExecute(r)
+}
+
+/*
+SetTtl Set sandbox TTL
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param sandboxIdOrName ID or name of the sandbox
+ @param ttlMinutes Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived
+ @return SandboxAPISetTtlRequest
+*/
+func (a *SandboxAPIService) SetTtl(ctx context.Context, sandboxIdOrName string, ttlMinutes float32) SandboxAPISetTtlRequest {
+	return SandboxAPISetTtlRequest{
+		ApiService: a,
+		ctx: ctx,
+		sandboxIdOrName: sandboxIdOrName,
+		ttlMinutes: ttlMinutes,
+	}
+}
+
+// Execute executes the request
+//  @return Sandbox
+func (a *SandboxAPIService) SetTtlExecute(r SandboxAPISetTtlRequest) (*Sandbox, *http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodPost
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  *Sandbox
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SandboxAPIService.SetTtl")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/sandbox/{sandboxIdOrName}/ttl/{ttlMinutes}"
+	localVarPath = strings.Replace(localVarPath, "{"+"sandboxIdOrName"+"}", url.PathEscape(parameterValueToString(r.sandboxIdOrName, "sandboxIdOrName")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"ttlMinutes"+"}", url.PathEscape(parameterValueToString(r.ttlMinutes, "ttlMinutes")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/api-client-go/model_create_sandbox.go
+++ b/api-client-go/model_create_sandbox.go
@@ -58,6 +58,8 @@ type CreateSandbox struct {
 	AutoArchiveInterval *int32 `json:"autoArchiveInterval,omitempty"`
 	// Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
 	AutoDeleteInterval *int32 `json:"autoDeleteInterval,omitempty"`
+	// Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived.
+	TtlMinutes *int32 `json:"ttlMinutes,omitempty"`
 	// Array of volumes to attach to the sandbox
 	Volumes []SandboxVolume `json:"volumes,omitempty"`
 	// Build information for the sandbox
@@ -696,6 +698,38 @@ func (o *CreateSandbox) SetAutoDeleteInterval(v int32) {
 	o.AutoDeleteInterval = &v
 }
 
+// GetTtlMinutes returns the TtlMinutes field value if set, zero value otherwise.
+func (o *CreateSandbox) GetTtlMinutes() int32 {
+	if o == nil || IsNil(o.TtlMinutes) {
+		var ret int32
+		return ret
+	}
+	return *o.TtlMinutes
+}
+
+// GetTtlMinutesOk returns a tuple with the TtlMinutes field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CreateSandbox) GetTtlMinutesOk() (*int32, bool) {
+	if o == nil || IsNil(o.TtlMinutes) {
+		return nil, false
+	}
+	return o.TtlMinutes, true
+}
+
+// HasTtlMinutes returns a boolean if a field has been set.
+func (o *CreateSandbox) HasTtlMinutes() bool {
+	if o != nil && !IsNil(o.TtlMinutes) {
+		return true
+	}
+
+	return false
+}
+
+// SetTtlMinutes gets a reference to the given int32 and assigns it to the TtlMinutes field.
+func (o *CreateSandbox) SetTtlMinutes(v int32) {
+	o.TtlMinutes = &v
+}
+
 // GetVolumes returns the Volumes field value if set, zero value otherwise.
 func (o *CreateSandbox) GetVolumes() []SandboxVolume {
 	if o == nil || IsNil(o.Volumes) {
@@ -891,6 +925,9 @@ func (o CreateSandbox) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.AutoDeleteInterval) {
 		toSerialize["autoDeleteInterval"] = o.AutoDeleteInterval
 	}
+	if !IsNil(o.TtlMinutes) {
+		toSerialize["ttlMinutes"] = o.TtlMinutes
+	}
 	if !IsNil(o.Volumes) {
 		toSerialize["volumes"] = o.Volumes
 	}
@@ -944,6 +981,7 @@ func (o *CreateSandbox) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "autoPauseInterval")
 		delete(additionalProperties, "autoArchiveInterval")
 		delete(additionalProperties, "autoDeleteInterval")
+		delete(additionalProperties, "ttlMinutes")
 		delete(additionalProperties, "volumes")
 		delete(additionalProperties, "buildInfo")
 		delete(additionalProperties, "linkedSandbox")

--- a/api-client-go/model_sandbox.go
+++ b/api-client-go/model_sandbox.go
@@ -75,8 +75,8 @@ type Sandbox struct {
 	AutoArchiveInterval *float32 `json:"autoArchiveInterval,omitempty"`
 	// Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
 	AutoDeleteInterval *float32 `json:"autoDeleteInterval,omitempty"`
-	// When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
-	ExpiresAt *string `json:"expiresAt,omitempty"`
+	// When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)
+	AutoDestroyAt *string `json:"autoDestroyAt,omitempty"`
 	// Array of volumes attached to the sandbox
 	Volumes []SandboxVolume `json:"volumes,omitempty"`
 	// Build information for the sandbox
@@ -893,36 +893,36 @@ func (o *Sandbox) SetAutoDeleteInterval(v float32) {
 	o.AutoDeleteInterval = &v
 }
 
-// GetExpiresAt returns the ExpiresAt field value if set, zero value otherwise.
-func (o *Sandbox) GetExpiresAt() string {
-	if o == nil || IsNil(o.ExpiresAt) {
+// GetAutoDestroyAt returns the AutoDestroyAt field value if set, zero value otherwise.
+func (o *Sandbox) GetAutoDestroyAt() string {
+	if o == nil || IsNil(o.AutoDestroyAt) {
 		var ret string
 		return ret
 	}
-	return *o.ExpiresAt
+	return *o.AutoDestroyAt
 }
 
-// GetExpiresAtOk returns a tuple with the ExpiresAt field value if set, nil otherwise
+// GetAutoDestroyAtOk returns a tuple with the AutoDestroyAt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Sandbox) GetExpiresAtOk() (*string, bool) {
-	if o == nil || IsNil(o.ExpiresAt) {
+func (o *Sandbox) GetAutoDestroyAtOk() (*string, bool) {
+	if o == nil || IsNil(o.AutoDestroyAt) {
 		return nil, false
 	}
-	return o.ExpiresAt, true
+	return o.AutoDestroyAt, true
 }
 
-// HasExpiresAt returns a boolean if a field has been set.
-func (o *Sandbox) HasExpiresAt() bool {
-	if o != nil && !IsNil(o.ExpiresAt) {
+// HasAutoDestroyAt returns a boolean if a field has been set.
+func (o *Sandbox) HasAutoDestroyAt() bool {
+	if o != nil && !IsNil(o.AutoDestroyAt) {
 		return true
 	}
 
 	return false
 }
 
-// SetExpiresAt gets a reference to the given string and assigns it to the ExpiresAt field.
-func (o *Sandbox) SetExpiresAt(v string) {
-	o.ExpiresAt = &v
+// SetAutoDestroyAt gets a reference to the given string and assigns it to the AutoDestroyAt field.
+func (o *Sandbox) SetAutoDestroyAt(v string) {
+	o.AutoDestroyAt = &v
 }
 
 // GetVolumes returns the Volumes field value if set, zero value otherwise.
@@ -1302,8 +1302,8 @@ func (o Sandbox) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.AutoDeleteInterval) {
 		toSerialize["autoDeleteInterval"] = o.AutoDeleteInterval
 	}
-	if !IsNil(o.ExpiresAt) {
-		toSerialize["expiresAt"] = o.ExpiresAt
+	if !IsNil(o.AutoDestroyAt) {
+		toSerialize["autoDestroyAt"] = o.AutoDestroyAt
 	}
 	if !IsNil(o.Volumes) {
 		toSerialize["volumes"] = o.Volumes
@@ -1416,7 +1416,7 @@ func (o *Sandbox) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "autoPauseInterval")
 		delete(additionalProperties, "autoArchiveInterval")
 		delete(additionalProperties, "autoDeleteInterval")
-		delete(additionalProperties, "expiresAt")
+		delete(additionalProperties, "autoDestroyAt")
 		delete(additionalProperties, "volumes")
 		delete(additionalProperties, "buildInfo")
 		delete(additionalProperties, "createdAt")

--- a/api-client-go/model_sandbox.go
+++ b/api-client-go/model_sandbox.go
@@ -75,6 +75,8 @@ type Sandbox struct {
 	AutoArchiveInterval *float32 `json:"autoArchiveInterval,omitempty"`
 	// Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
 	AutoDeleteInterval *float32 `json:"autoDeleteInterval,omitempty"`
+	// When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
+	ExpiresAt *string `json:"expiresAt,omitempty"`
 	// Array of volumes attached to the sandbox
 	Volumes []SandboxVolume `json:"volumes,omitempty"`
 	// Build information for the sandbox
@@ -891,6 +893,38 @@ func (o *Sandbox) SetAutoDeleteInterval(v float32) {
 	o.AutoDeleteInterval = &v
 }
 
+// GetExpiresAt returns the ExpiresAt field value if set, zero value otherwise.
+func (o *Sandbox) GetExpiresAt() string {
+	if o == nil || IsNil(o.ExpiresAt) {
+		var ret string
+		return ret
+	}
+	return *o.ExpiresAt
+}
+
+// GetExpiresAtOk returns a tuple with the ExpiresAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Sandbox) GetExpiresAtOk() (*string, bool) {
+	if o == nil || IsNil(o.ExpiresAt) {
+		return nil, false
+	}
+	return o.ExpiresAt, true
+}
+
+// HasExpiresAt returns a boolean if a field has been set.
+func (o *Sandbox) HasExpiresAt() bool {
+	if o != nil && !IsNil(o.ExpiresAt) {
+		return true
+	}
+
+	return false
+}
+
+// SetExpiresAt gets a reference to the given string and assigns it to the ExpiresAt field.
+func (o *Sandbox) SetExpiresAt(v string) {
+	o.ExpiresAt = &v
+}
+
 // GetVolumes returns the Volumes field value if set, zero value otherwise.
 func (o *Sandbox) GetVolumes() []SandboxVolume {
 	if o == nil || IsNil(o.Volumes) {
@@ -1268,6 +1302,9 @@ func (o Sandbox) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.AutoDeleteInterval) {
 		toSerialize["autoDeleteInterval"] = o.AutoDeleteInterval
 	}
+	if !IsNil(o.ExpiresAt) {
+		toSerialize["expiresAt"] = o.ExpiresAt
+	}
 	if !IsNil(o.Volumes) {
 		toSerialize["volumes"] = o.Volumes
 	}
@@ -1379,6 +1416,7 @@ func (o *Sandbox) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "autoPauseInterval")
 		delete(additionalProperties, "autoArchiveInterval")
 		delete(additionalProperties, "autoDeleteInterval")
+		delete(additionalProperties, "expiresAt")
 		delete(additionalProperties, "volumes")
 		delete(additionalProperties, "buildInfo")
 		delete(additionalProperties, "createdAt")

--- a/api-client-go/model_sandbox_list_item.go
+++ b/api-client-go/model_sandbox_list_item.go
@@ -69,6 +69,8 @@ type SandboxListItem struct {
 	AutoArchiveInterval *float32 `json:"autoArchiveInterval,omitempty"`
 	// Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
 	AutoDeleteInterval *float32 `json:"autoDeleteInterval,omitempty"`
+	// When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
+	ExpiresAt *string `json:"expiresAt,omitempty"`
 	// The creation timestamp of the sandbox
 	CreatedAt *string `json:"createdAt,omitempty"`
 	// The last update timestamp of the sandbox
@@ -793,6 +795,38 @@ func (o *SandboxListItem) SetAutoDeleteInterval(v float32) {
 	o.AutoDeleteInterval = &v
 }
 
+// GetExpiresAt returns the ExpiresAt field value if set, zero value otherwise.
+func (o *SandboxListItem) GetExpiresAt() string {
+	if o == nil || IsNil(o.ExpiresAt) {
+		var ret string
+		return ret
+	}
+	return *o.ExpiresAt
+}
+
+// GetExpiresAtOk returns a tuple with the ExpiresAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SandboxListItem) GetExpiresAtOk() (*string, bool) {
+	if o == nil || IsNil(o.ExpiresAt) {
+		return nil, false
+	}
+	return o.ExpiresAt, true
+}
+
+// HasExpiresAt returns a boolean if a field has been set.
+func (o *SandboxListItem) HasExpiresAt() bool {
+	if o != nil && !IsNil(o.ExpiresAt) {
+		return true
+	}
+
+	return false
+}
+
+// SetExpiresAt gets a reference to the given string and assigns it to the ExpiresAt field.
+func (o *SandboxListItem) SetExpiresAt(v string) {
+	o.ExpiresAt = &v
+}
+
 // GetCreatedAt returns the CreatedAt field value if set, zero value otherwise.
 func (o *SandboxListItem) GetCreatedAt() string {
 	if o == nil || IsNil(o.CreatedAt) {
@@ -1005,6 +1039,9 @@ func (o SandboxListItem) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.AutoDeleteInterval) {
 		toSerialize["autoDeleteInterval"] = o.AutoDeleteInterval
 	}
+	if !IsNil(o.ExpiresAt) {
+		toSerialize["expiresAt"] = o.ExpiresAt
+	}
 	if !IsNil(o.CreatedAt) {
 		toSerialize["createdAt"] = o.CreatedAt
 	}
@@ -1096,6 +1133,7 @@ func (o *SandboxListItem) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "autoPauseInterval")
 		delete(additionalProperties, "autoArchiveInterval")
 		delete(additionalProperties, "autoDeleteInterval")
+		delete(additionalProperties, "expiresAt")
 		delete(additionalProperties, "createdAt")
 		delete(additionalProperties, "updatedAt")
 		delete(additionalProperties, "lastActivityAt")

--- a/api-client-go/model_sandbox_list_item.go
+++ b/api-client-go/model_sandbox_list_item.go
@@ -69,8 +69,8 @@ type SandboxListItem struct {
 	AutoArchiveInterval *float32 `json:"autoArchiveInterval,omitempty"`
 	// Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
 	AutoDeleteInterval *float32 `json:"autoDeleteInterval,omitempty"`
-	// When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
-	ExpiresAt *string `json:"expiresAt,omitempty"`
+	// When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)
+	AutoDestroyAt *string `json:"autoDestroyAt,omitempty"`
 	// The creation timestamp of the sandbox
 	CreatedAt *string `json:"createdAt,omitempty"`
 	// The last update timestamp of the sandbox
@@ -795,36 +795,36 @@ func (o *SandboxListItem) SetAutoDeleteInterval(v float32) {
 	o.AutoDeleteInterval = &v
 }
 
-// GetExpiresAt returns the ExpiresAt field value if set, zero value otherwise.
-func (o *SandboxListItem) GetExpiresAt() string {
-	if o == nil || IsNil(o.ExpiresAt) {
+// GetAutoDestroyAt returns the AutoDestroyAt field value if set, zero value otherwise.
+func (o *SandboxListItem) GetAutoDestroyAt() string {
+	if o == nil || IsNil(o.AutoDestroyAt) {
 		var ret string
 		return ret
 	}
-	return *o.ExpiresAt
+	return *o.AutoDestroyAt
 }
 
-// GetExpiresAtOk returns a tuple with the ExpiresAt field value if set, nil otherwise
+// GetAutoDestroyAtOk returns a tuple with the AutoDestroyAt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *SandboxListItem) GetExpiresAtOk() (*string, bool) {
-	if o == nil || IsNil(o.ExpiresAt) {
+func (o *SandboxListItem) GetAutoDestroyAtOk() (*string, bool) {
+	if o == nil || IsNil(o.AutoDestroyAt) {
 		return nil, false
 	}
-	return o.ExpiresAt, true
+	return o.AutoDestroyAt, true
 }
 
-// HasExpiresAt returns a boolean if a field has been set.
-func (o *SandboxListItem) HasExpiresAt() bool {
-	if o != nil && !IsNil(o.ExpiresAt) {
+// HasAutoDestroyAt returns a boolean if a field has been set.
+func (o *SandboxListItem) HasAutoDestroyAt() bool {
+	if o != nil && !IsNil(o.AutoDestroyAt) {
 		return true
 	}
 
 	return false
 }
 
-// SetExpiresAt gets a reference to the given string and assigns it to the ExpiresAt field.
-func (o *SandboxListItem) SetExpiresAt(v string) {
-	o.ExpiresAt = &v
+// SetAutoDestroyAt gets a reference to the given string and assigns it to the AutoDestroyAt field.
+func (o *SandboxListItem) SetAutoDestroyAt(v string) {
+	o.AutoDestroyAt = &v
 }
 
 // GetCreatedAt returns the CreatedAt field value if set, zero value otherwise.
@@ -1039,8 +1039,8 @@ func (o SandboxListItem) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.AutoDeleteInterval) {
 		toSerialize["autoDeleteInterval"] = o.AutoDeleteInterval
 	}
-	if !IsNil(o.ExpiresAt) {
-		toSerialize["expiresAt"] = o.ExpiresAt
+	if !IsNil(o.AutoDestroyAt) {
+		toSerialize["autoDestroyAt"] = o.AutoDestroyAt
 	}
 	if !IsNil(o.CreatedAt) {
 		toSerialize["createdAt"] = o.CreatedAt
@@ -1133,7 +1133,7 @@ func (o *SandboxListItem) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "autoPauseInterval")
 		delete(additionalProperties, "autoArchiveInterval")
 		delete(additionalProperties, "autoDeleteInterval")
-		delete(additionalProperties, "expiresAt")
+		delete(additionalProperties, "autoDestroyAt")
 		delete(additionalProperties, "createdAt")
 		delete(additionalProperties, "updatedAt")
 		delete(additionalProperties, "lastActivityAt")

--- a/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
@@ -5656,6 +5656,152 @@ public class SandboxApi {
         return localVarCall;
     }
     /**
+     * Build call for setTtl
+     * @param sandboxIdOrName ID or name of the sandbox (required)
+     * @param ttlMinutes Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived (required)
+     * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> TTL has been set </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call setTtlCall(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull BigDecimal ttlMinutes, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/sandbox/{sandboxIdOrName}/ttl/{ttlMinutes}"
+            .replace("{" + "sandboxIdOrName" + "}", localVarApiClient.escapeString(sandboxIdOrName.toString()))
+            .replace("{" + "ttlMinutes" + "}", localVarApiClient.escapeString(ttlMinutes.toString()));
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            "application/json"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        if (xDaytonaOrganizationID != null) {
+            localVarHeaderParams.put("X-Daytona-Organization-ID", localVarApiClient.parameterToString(xDaytonaOrganizationID));
+        }
+
+
+        String[] localVarAuthNames = new String[] { "bearer", "oauth2" };
+        return localVarApiClient.buildCall(basePath, localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call setTtlValidateBeforeCall(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull BigDecimal ttlMinutes, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
+        // verify the required parameter 'sandboxIdOrName' is set
+        if (sandboxIdOrName == null) {
+            throw new ApiException("Missing the required parameter 'sandboxIdOrName' when calling setTtl(Async)");
+        }
+
+        // verify the required parameter 'ttlMinutes' is set
+        if (ttlMinutes == null) {
+            throw new ApiException("Missing the required parameter 'ttlMinutes' when calling setTtl(Async)");
+        }
+
+        return setTtlCall(sandboxIdOrName, ttlMinutes, xDaytonaOrganizationID, _callback);
+
+    }
+
+    /**
+     * Set sandbox TTL
+     * 
+     * @param sandboxIdOrName ID or name of the sandbox (required)
+     * @param ttlMinutes Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived (required)
+     * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @return Sandbox
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> TTL has been set </td><td>  -  </td></tr>
+     </table>
+     */
+    public Sandbox setTtl(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull BigDecimal ttlMinutes, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
+        ApiResponse<Sandbox> localVarResp = setTtlWithHttpInfo(sandboxIdOrName, ttlMinutes, xDaytonaOrganizationID);
+        return localVarResp.getData();
+    }
+
+    /**
+     * Set sandbox TTL
+     * 
+     * @param sandboxIdOrName ID or name of the sandbox (required)
+     * @param ttlMinutes Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived (required)
+     * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @return ApiResponse&lt;Sandbox&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> TTL has been set </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<Sandbox> setTtlWithHttpInfo(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull BigDecimal ttlMinutes, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
+        okhttp3.Call localVarCall = setTtlValidateBeforeCall(sandboxIdOrName, ttlMinutes, xDaytonaOrganizationID, null);
+        Type localVarReturnType = new TypeToken<Sandbox>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    /**
+     * Set sandbox TTL (asynchronously)
+     * 
+     * @param sandboxIdOrName ID or name of the sandbox (required)
+     * @param ttlMinutes Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived (required)
+     * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> TTL has been set </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call setTtlAsync(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull BigDecimal ttlMinutes, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback<Sandbox> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = setTtlValidateBeforeCall(sandboxIdOrName, ttlMinutes, xDaytonaOrganizationID, _callback);
+        Type localVarReturnType = new TypeToken<Sandbox>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+    /**
      * Build call for startSandbox
      * @param sandboxIdOrName ID or name of the sandbox (required)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)

--- a/api-client-java/src/main/java/io/daytona/api/client/model/CreateSandbox.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/CreateSandbox.java
@@ -152,6 +152,11 @@ public class CreateSandbox {
   @javax.annotation.Nullable
   private Integer autoDeleteInterval;
 
+  public static final String SERIALIZED_NAME_TTL_MINUTES = "ttlMinutes";
+  @SerializedName(SERIALIZED_NAME_TTL_MINUTES)
+  @javax.annotation.Nullable
+  private Integer ttlMinutes;
+
   public static final String SERIALIZED_NAME_VOLUMES = "volumes";
   @SerializedName(SERIALIZED_NAME_VOLUMES)
   @javax.annotation.Nullable
@@ -560,6 +565,25 @@ public class CreateSandbox {
   }
 
 
+  public CreateSandbox ttlMinutes(@javax.annotation.Nullable Integer ttlMinutes) {
+    this.ttlMinutes = ttlMinutes;
+    return this;
+  }
+
+  /**
+   * Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived.
+   * @return ttlMinutes
+   */
+  @javax.annotation.Nullable
+  public Integer getTtlMinutes() {
+    return ttlMinutes;
+  }
+
+  public void setTtlMinutes(@javax.annotation.Nullable Integer ttlMinutes) {
+    this.ttlMinutes = ttlMinutes;
+  }
+
+
   public CreateSandbox volumes(@javax.annotation.Nullable List<SandboxVolume> volumes) {
     this.volumes = volumes;
     return this;
@@ -725,6 +749,7 @@ public class CreateSandbox {
         Objects.equals(this.autoPauseInterval, createSandbox.autoPauseInterval) &&
         Objects.equals(this.autoArchiveInterval, createSandbox.autoArchiveInterval) &&
         Objects.equals(this.autoDeleteInterval, createSandbox.autoDeleteInterval) &&
+        Objects.equals(this.ttlMinutes, createSandbox.ttlMinutes) &&
         Objects.equals(this.volumes, createSandbox.volumes) &&
         Objects.equals(this.buildInfo, createSandbox.buildInfo) &&
         Objects.equals(this.linkedSandbox, createSandbox.linkedSandbox) &&
@@ -734,7 +759,7 @@ public class CreateSandbox {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, target, cpu, gpu, gpuType, memory, disk, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, volumes, buildInfo, linkedSandbox, secrets, additionalProperties);
+    return Objects.hash(name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, target, cpu, gpu, gpuType, memory, disk, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, ttlMinutes, volumes, buildInfo, linkedSandbox, secrets, additionalProperties);
   }
 
   @Override
@@ -760,6 +785,7 @@ public class CreateSandbox {
     sb.append("    autoPauseInterval: ").append(toIndentedString(autoPauseInterval)).append("\n");
     sb.append("    autoArchiveInterval: ").append(toIndentedString(autoArchiveInterval)).append("\n");
     sb.append("    autoDeleteInterval: ").append(toIndentedString(autoDeleteInterval)).append("\n");
+    sb.append("    ttlMinutes: ").append(toIndentedString(ttlMinutes)).append("\n");
     sb.append("    volumes: ").append(toIndentedString(volumes)).append("\n");
     sb.append("    buildInfo: ").append(toIndentedString(buildInfo)).append("\n");
     sb.append("    linkedSandbox: ").append(toIndentedString(linkedSandbox)).append("\n");
@@ -783,7 +809,7 @@ public class CreateSandbox {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "linkedSandbox", "secrets"));
+    openapiFields = new HashSet<String>(Arrays.asList("name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(0);

--- a/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
@@ -255,10 +255,10 @@ public class Sandbox {
   @javax.annotation.Nullable
   private BigDecimal autoDeleteInterval;
 
-  public static final String SERIALIZED_NAME_EXPIRES_AT = "expiresAt";
-  @SerializedName(SERIALIZED_NAME_EXPIRES_AT)
+  public static final String SERIALIZED_NAME_AUTO_DESTROY_AT = "autoDestroyAt";
+  @SerializedName(SERIALIZED_NAME_AUTO_DESTROY_AT)
   @javax.annotation.Nullable
-  private String expiresAt;
+  private String autoDestroyAt;
 
   public static final String SERIALIZED_NAME_VOLUMES = "volumes";
   @SerializedName(SERIALIZED_NAME_VOLUMES)
@@ -900,22 +900,22 @@ public class Sandbox {
   }
 
 
-  public Sandbox expiresAt(@javax.annotation.Nullable String expiresAt) {
-    this.expiresAt = expiresAt;
+  public Sandbox autoDestroyAt(@javax.annotation.Nullable String autoDestroyAt) {
+    this.autoDestroyAt = autoDestroyAt;
     return this;
   }
 
   /**
-   * When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
-   * @return expiresAt
+   * When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)
+   * @return autoDestroyAt
    */
   @javax.annotation.Nullable
-  public String getExpiresAt() {
-    return expiresAt;
+  public String getAutoDestroyAt() {
+    return autoDestroyAt;
   }
 
-  public void setExpiresAt(@javax.annotation.Nullable String expiresAt) {
-    this.expiresAt = expiresAt;
+  public void setAutoDestroyAt(@javax.annotation.Nullable String autoDestroyAt) {
+    this.autoDestroyAt = autoDestroyAt;
   }
 
 
@@ -1198,7 +1198,7 @@ public class Sandbox {
         Objects.equals(this.autoPauseInterval, sandbox.autoPauseInterval) &&
         Objects.equals(this.autoArchiveInterval, sandbox.autoArchiveInterval) &&
         Objects.equals(this.autoDeleteInterval, sandbox.autoDeleteInterval) &&
-        Objects.equals(this.expiresAt, sandbox.expiresAt) &&
+        Objects.equals(this.autoDestroyAt, sandbox.autoDestroyAt) &&
         Objects.equals(this.volumes, sandbox.volumes) &&
         Objects.equals(this.buildInfo, sandbox.buildInfo) &&
         Objects.equals(this.createdAt, sandbox.createdAt) &&
@@ -1214,7 +1214,7 @@ public class Sandbox {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, target, cpu, gpu, gpuType, memory, disk, state, desiredState, errorReason, recoverable, backupState, backupCreatedAt, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, expiresAt, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, sandboxClass, daemonVersion, runnerId, linkedSandboxId, toolboxProxyUrl, additionalProperties);
+    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, target, cpu, gpu, gpuType, memory, disk, state, desiredState, errorReason, recoverable, backupState, backupCreatedAt, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, autoDestroyAt, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, sandboxClass, daemonVersion, runnerId, linkedSandboxId, toolboxProxyUrl, additionalProperties);
   }
 
   @Override
@@ -1248,7 +1248,7 @@ public class Sandbox {
     sb.append("    autoPauseInterval: ").append(toIndentedString(autoPauseInterval)).append("\n");
     sb.append("    autoArchiveInterval: ").append(toIndentedString(autoArchiveInterval)).append("\n");
     sb.append("    autoDeleteInterval: ").append(toIndentedString(autoDeleteInterval)).append("\n");
-    sb.append("    expiresAt: ").append(toIndentedString(expiresAt)).append("\n");
+    sb.append("    autoDestroyAt: ").append(toIndentedString(autoDestroyAt)).append("\n");
     sb.append("    volumes: ").append(toIndentedString(volumes)).append("\n");
     sb.append("    buildInfo: ").append(toIndentedString(buildInfo)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
@@ -1278,7 +1278,7 @@ public class Sandbox {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "user", "env", "labels", "public", "networkBlockAll", "target", "cpu", "gpu", "memory", "disk", "toolboxProxyUrl"));
@@ -1353,8 +1353,8 @@ public class Sandbox {
       if ((jsonObj.get("backupCreatedAt") != null && !jsonObj.get("backupCreatedAt").isJsonNull()) && !jsonObj.get("backupCreatedAt").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `backupCreatedAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("backupCreatedAt").toString()));
       }
-      if ((jsonObj.get("expiresAt") != null && !jsonObj.get("expiresAt").isJsonNull()) && !jsonObj.get("expiresAt").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `expiresAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("expiresAt").toString()));
+      if ((jsonObj.get("autoDestroyAt") != null && !jsonObj.get("autoDestroyAt").isJsonNull()) && !jsonObj.get("autoDestroyAt").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `autoDestroyAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("autoDestroyAt").toString()));
       }
       if (jsonObj.get("volumes") != null && !jsonObj.get("volumes").isJsonNull()) {
         JsonArray jsonArrayvolumes = jsonObj.getAsJsonArray("volumes");

--- a/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
@@ -255,6 +255,11 @@ public class Sandbox {
   @javax.annotation.Nullable
   private BigDecimal autoDeleteInterval;
 
+  public static final String SERIALIZED_NAME_EXPIRES_AT = "expiresAt";
+  @SerializedName(SERIALIZED_NAME_EXPIRES_AT)
+  @javax.annotation.Nullable
+  private String expiresAt;
+
   public static final String SERIALIZED_NAME_VOLUMES = "volumes";
   @SerializedName(SERIALIZED_NAME_VOLUMES)
   @javax.annotation.Nullable
@@ -895,6 +900,25 @@ public class Sandbox {
   }
 
 
+  public Sandbox expiresAt(@javax.annotation.Nullable String expiresAt) {
+    this.expiresAt = expiresAt;
+    return this;
+  }
+
+  /**
+   * When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
+   * @return expiresAt
+   */
+  @javax.annotation.Nullable
+  public String getExpiresAt() {
+    return expiresAt;
+  }
+
+  public void setExpiresAt(@javax.annotation.Nullable String expiresAt) {
+    this.expiresAt = expiresAt;
+  }
+
+
   public Sandbox volumes(@javax.annotation.Nullable List<SandboxVolume> volumes) {
     this.volumes = volumes;
     return this;
@@ -1174,6 +1198,7 @@ public class Sandbox {
         Objects.equals(this.autoPauseInterval, sandbox.autoPauseInterval) &&
         Objects.equals(this.autoArchiveInterval, sandbox.autoArchiveInterval) &&
         Objects.equals(this.autoDeleteInterval, sandbox.autoDeleteInterval) &&
+        Objects.equals(this.expiresAt, sandbox.expiresAt) &&
         Objects.equals(this.volumes, sandbox.volumes) &&
         Objects.equals(this.buildInfo, sandbox.buildInfo) &&
         Objects.equals(this.createdAt, sandbox.createdAt) &&
@@ -1189,7 +1214,7 @@ public class Sandbox {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, target, cpu, gpu, gpuType, memory, disk, state, desiredState, errorReason, recoverable, backupState, backupCreatedAt, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, sandboxClass, daemonVersion, runnerId, linkedSandboxId, toolboxProxyUrl, additionalProperties);
+    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, target, cpu, gpu, gpuType, memory, disk, state, desiredState, errorReason, recoverable, backupState, backupCreatedAt, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, expiresAt, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, sandboxClass, daemonVersion, runnerId, linkedSandboxId, toolboxProxyUrl, additionalProperties);
   }
 
   @Override
@@ -1223,6 +1248,7 @@ public class Sandbox {
     sb.append("    autoPauseInterval: ").append(toIndentedString(autoPauseInterval)).append("\n");
     sb.append("    autoArchiveInterval: ").append(toIndentedString(autoArchiveInterval)).append("\n");
     sb.append("    autoDeleteInterval: ").append(toIndentedString(autoDeleteInterval)).append("\n");
+    sb.append("    expiresAt: ").append(toIndentedString(expiresAt)).append("\n");
     sb.append("    volumes: ").append(toIndentedString(volumes)).append("\n");
     sb.append("    buildInfo: ").append(toIndentedString(buildInfo)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
@@ -1252,7 +1278,7 @@ public class Sandbox {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "user", "env", "labels", "public", "networkBlockAll", "target", "cpu", "gpu", "memory", "disk", "toolboxProxyUrl"));
@@ -1326,6 +1352,9 @@ public class Sandbox {
       }
       if ((jsonObj.get("backupCreatedAt") != null && !jsonObj.get("backupCreatedAt").isJsonNull()) && !jsonObj.get("backupCreatedAt").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `backupCreatedAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("backupCreatedAt").toString()));
+      }
+      if ((jsonObj.get("expiresAt") != null && !jsonObj.get("expiresAt").isJsonNull()) && !jsonObj.get("expiresAt").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `expiresAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("expiresAt").toString()));
       }
       if (jsonObj.get("volumes") != null && !jsonObj.get("volumes").isJsonNull()) {
         JsonArray jsonArrayvolumes = jsonObj.getAsJsonArray("volumes");

--- a/api-client-java/src/main/java/io/daytona/api/client/model/SandboxListItem.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/SandboxListItem.java
@@ -237,10 +237,10 @@ public class SandboxListItem {
   @javax.annotation.Nullable
   private BigDecimal autoDeleteInterval;
 
-  public static final String SERIALIZED_NAME_EXPIRES_AT = "expiresAt";
-  @SerializedName(SERIALIZED_NAME_EXPIRES_AT)
+  public static final String SERIALIZED_NAME_AUTO_DESTROY_AT = "autoDestroyAt";
+  @SerializedName(SERIALIZED_NAME_AUTO_DESTROY_AT)
   @javax.annotation.Nullable
-  private String expiresAt;
+  private String autoDestroyAt;
 
   public static final String SERIALIZED_NAME_CREATED_AT = "createdAt";
   @SerializedName(SERIALIZED_NAME_CREATED_AT)
@@ -734,22 +734,22 @@ public class SandboxListItem {
   }
 
 
-  public SandboxListItem expiresAt(@javax.annotation.Nullable String expiresAt) {
-    this.expiresAt = expiresAt;
+  public SandboxListItem autoDestroyAt(@javax.annotation.Nullable String autoDestroyAt) {
+    this.autoDestroyAt = autoDestroyAt;
     return this;
   }
 
   /**
-   * When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
-   * @return expiresAt
+   * When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)
+   * @return autoDestroyAt
    */
   @javax.annotation.Nullable
-  public String getExpiresAt() {
-    return expiresAt;
+  public String getAutoDestroyAt() {
+    return autoDestroyAt;
   }
 
-  public void setExpiresAt(@javax.annotation.Nullable String expiresAt) {
-    this.expiresAt = expiresAt;
+  public void setAutoDestroyAt(@javax.annotation.Nullable String autoDestroyAt) {
+    this.autoDestroyAt = autoDestroyAt;
   }
 
 
@@ -926,7 +926,7 @@ public class SandboxListItem {
         Objects.equals(this.autoPauseInterval, sandboxListItem.autoPauseInterval) &&
         Objects.equals(this.autoArchiveInterval, sandboxListItem.autoArchiveInterval) &&
         Objects.equals(this.autoDeleteInterval, sandboxListItem.autoDeleteInterval) &&
-        Objects.equals(this.expiresAt, sandboxListItem.expiresAt) &&
+        Objects.equals(this.autoDestroyAt, sandboxListItem.autoDestroyAt) &&
         Objects.equals(this.createdAt, sandboxListItem.createdAt) &&
         Objects.equals(this.updatedAt, sandboxListItem.updatedAt) &&
         Objects.equals(this.lastActivityAt, sandboxListItem.lastActivityAt) &&
@@ -937,7 +937,7 @@ public class SandboxListItem {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, organizationId, name, target, runnerId, sandboxClass, state, desiredState, snapshot, user, errorReason, recoverable, _public, cpu, gpu, gpuType, memory, disk, labels, backupState, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, expiresAt, createdAt, updatedAt, lastActivityAt, daemonVersion, toolboxProxyUrl, additionalProperties);
+    return Objects.hash(id, organizationId, name, target, runnerId, sandboxClass, state, desiredState, snapshot, user, errorReason, recoverable, _public, cpu, gpu, gpuType, memory, disk, labels, backupState, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, autoDestroyAt, createdAt, updatedAt, lastActivityAt, daemonVersion, toolboxProxyUrl, additionalProperties);
   }
 
   @Override
@@ -968,7 +968,7 @@ public class SandboxListItem {
     sb.append("    autoPauseInterval: ").append(toIndentedString(autoPauseInterval)).append("\n");
     sb.append("    autoArchiveInterval: ").append(toIndentedString(autoArchiveInterval)).append("\n");
     sb.append("    autoDeleteInterval: ").append(toIndentedString(autoDeleteInterval)).append("\n");
-    sb.append("    expiresAt: ").append(toIndentedString(expiresAt)).append("\n");
+    sb.append("    autoDestroyAt: ").append(toIndentedString(autoDestroyAt)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    lastActivityAt: ").append(toIndentedString(lastActivityAt)).append("\n");
@@ -993,7 +993,7 @@ public class SandboxListItem {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "target", "user", "public", "cpu", "gpu", "memory", "disk", "labels", "toolboxProxyUrl"));
@@ -1066,8 +1066,8 @@ public class SandboxListItem {
       if (jsonObj.get("backupState") != null && !jsonObj.get("backupState").isJsonNull()) {
         BackupStateEnum.validateJsonElement(jsonObj.get("backupState"));
       }
-      if ((jsonObj.get("expiresAt") != null && !jsonObj.get("expiresAt").isJsonNull()) && !jsonObj.get("expiresAt").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `expiresAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("expiresAt").toString()));
+      if ((jsonObj.get("autoDestroyAt") != null && !jsonObj.get("autoDestroyAt").isJsonNull()) && !jsonObj.get("autoDestroyAt").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `autoDestroyAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("autoDestroyAt").toString()));
       }
       if ((jsonObj.get("createdAt") != null && !jsonObj.get("createdAt").isJsonNull()) && !jsonObj.get("createdAt").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `createdAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("createdAt").toString()));

--- a/api-client-java/src/main/java/io/daytona/api/client/model/SandboxListItem.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/SandboxListItem.java
@@ -237,6 +237,11 @@ public class SandboxListItem {
   @javax.annotation.Nullable
   private BigDecimal autoDeleteInterval;
 
+  public static final String SERIALIZED_NAME_EXPIRES_AT = "expiresAt";
+  @SerializedName(SERIALIZED_NAME_EXPIRES_AT)
+  @javax.annotation.Nullable
+  private String expiresAt;
+
   public static final String SERIALIZED_NAME_CREATED_AT = "createdAt";
   @SerializedName(SERIALIZED_NAME_CREATED_AT)
   @javax.annotation.Nullable
@@ -729,6 +734,25 @@ public class SandboxListItem {
   }
 
 
+  public SandboxListItem expiresAt(@javax.annotation.Nullable String expiresAt) {
+    this.expiresAt = expiresAt;
+    return this;
+  }
+
+  /**
+   * When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
+   * @return expiresAt
+   */
+  @javax.annotation.Nullable
+  public String getExpiresAt() {
+    return expiresAt;
+  }
+
+  public void setExpiresAt(@javax.annotation.Nullable String expiresAt) {
+    this.expiresAt = expiresAt;
+  }
+
+
   public SandboxListItem createdAt(@javax.annotation.Nullable String createdAt) {
     this.createdAt = createdAt;
     return this;
@@ -902,6 +926,7 @@ public class SandboxListItem {
         Objects.equals(this.autoPauseInterval, sandboxListItem.autoPauseInterval) &&
         Objects.equals(this.autoArchiveInterval, sandboxListItem.autoArchiveInterval) &&
         Objects.equals(this.autoDeleteInterval, sandboxListItem.autoDeleteInterval) &&
+        Objects.equals(this.expiresAt, sandboxListItem.expiresAt) &&
         Objects.equals(this.createdAt, sandboxListItem.createdAt) &&
         Objects.equals(this.updatedAt, sandboxListItem.updatedAt) &&
         Objects.equals(this.lastActivityAt, sandboxListItem.lastActivityAt) &&
@@ -912,7 +937,7 @@ public class SandboxListItem {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, organizationId, name, target, runnerId, sandboxClass, state, desiredState, snapshot, user, errorReason, recoverable, _public, cpu, gpu, gpuType, memory, disk, labels, backupState, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, createdAt, updatedAt, lastActivityAt, daemonVersion, toolboxProxyUrl, additionalProperties);
+    return Objects.hash(id, organizationId, name, target, runnerId, sandboxClass, state, desiredState, snapshot, user, errorReason, recoverable, _public, cpu, gpu, gpuType, memory, disk, labels, backupState, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, expiresAt, createdAt, updatedAt, lastActivityAt, daemonVersion, toolboxProxyUrl, additionalProperties);
   }
 
   @Override
@@ -943,6 +968,7 @@ public class SandboxListItem {
     sb.append("    autoPauseInterval: ").append(toIndentedString(autoPauseInterval)).append("\n");
     sb.append("    autoArchiveInterval: ").append(toIndentedString(autoArchiveInterval)).append("\n");
     sb.append("    autoDeleteInterval: ").append(toIndentedString(autoDeleteInterval)).append("\n");
+    sb.append("    expiresAt: ").append(toIndentedString(expiresAt)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    lastActivityAt: ").append(toIndentedString(lastActivityAt)).append("\n");
@@ -967,7 +993,7 @@ public class SandboxListItem {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "target", "user", "public", "cpu", "gpu", "memory", "disk", "labels", "toolboxProxyUrl"));
@@ -1039,6 +1065,9 @@ public class SandboxListItem {
       // validate the optional field `backupState`
       if (jsonObj.get("backupState") != null && !jsonObj.get("backupState").isJsonNull()) {
         BackupStateEnum.validateJsonElement(jsonObj.get("backupState"));
+      }
+      if ((jsonObj.get("expiresAt") != null && !jsonObj.get("expiresAt").isJsonNull()) && !jsonObj.get("expiresAt").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `expiresAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("expiresAt").toString()));
       }
       if ((jsonObj.get("createdAt") != null && !jsonObj.get("createdAt").isJsonNull()) && !jsonObj.get("createdAt").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `createdAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("createdAt").toString()));

--- a/api-client-java/src/test/java/io/daytona/api/client/api/SandboxApiTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/api/SandboxApiTest.java
@@ -616,6 +616,20 @@ public class SandboxApiTest {
     }
 
     /**
+     * Set sandbox TTL
+     *
+     * @throws ApiException if the Api call fails
+     */
+    @Test
+    public void setTtlTest() throws ApiException {
+        String sandboxIdOrName = null;
+        BigDecimal ttlMinutes = null;
+        String xDaytonaOrganizationID = null;
+        Sandbox response = api.setTtl(sandboxIdOrName, ttlMinutes, xDaytonaOrganizationID);
+        // TODO: test validations
+    }
+
+    /**
      * Start or resume sandbox
      *
      * Starts a stopped or archived sandbox, or resumes a paused sandbox. The transition taken depends on the current sandbox state.

--- a/api-client-java/src/test/java/io/daytona/api/client/model/CreateSandboxTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/CreateSandboxTest.java
@@ -197,6 +197,14 @@ public class CreateSandboxTest {
     }
 
     /**
+     * Test the property 'ttlMinutes'
+     */
+    @Test
+    public void ttlMinutesTest() {
+        // TODO: test ttlMinutes
+    }
+
+    /**
      * Test the property 'volumes'
      */
     @Test

--- a/api-client-java/src/test/java/io/daytona/api/client/model/SandboxListItemTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/SandboxListItemTest.java
@@ -237,11 +237,11 @@ public class SandboxListItemTest {
     }
 
     /**
-     * Test the property 'expiresAt'
+     * Test the property 'autoDestroyAt'
      */
     @Test
-    public void expiresAtTest() {
-        // TODO: test expiresAt
+    public void autoDestroyAtTest() {
+        // TODO: test autoDestroyAt
     }
 
     /**

--- a/api-client-java/src/test/java/io/daytona/api/client/model/SandboxListItemTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/SandboxListItemTest.java
@@ -237,6 +237,14 @@ public class SandboxListItemTest {
     }
 
     /**
+     * Test the property 'expiresAt'
+     */
+    @Test
+    public void expiresAtTest() {
+        // TODO: test expiresAt
+    }
+
+    /**
      * Test the property 'createdAt'
      */
     @Test

--- a/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
@@ -264,6 +264,14 @@ public class SandboxTest {
     }
 
     /**
+     * Test the property 'expiresAt'
+     */
+    @Test
+    public void expiresAtTest() {
+        // TODO: test expiresAt
+    }
+
+    /**
      * Test the property 'volumes'
      */
     @Test

--- a/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
@@ -264,11 +264,11 @@ public class SandboxTest {
     }
 
     /**
-     * Test the property 'expiresAt'
+     * Test the property 'autoDestroyAt'
      */
     @Test
-    public void expiresAtTest() {
-        // TODO: test expiresAt
+    public void autoDestroyAtTest() {
+        // TODO: test autoDestroyAt
     }
 
     /**

--- a/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
+++ b/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
@@ -11379,6 +11379,295 @@ class SandboxApi:
 
 
     @validate_call
+    async def set_ttl(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        ttl_minutes: Annotated[Union[StrictFloat, StrictInt], Field(description="Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> Sandbox:
+        """Set sandbox TTL
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param ttl_minutes: Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived (required)
+        :type ttl_minutes: float
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._set_ttl_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            ttl_minutes=ttl_minutes,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Sandbox",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    async def set_ttl_with_http_info(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        ttl_minutes: Annotated[Union[StrictFloat, StrictInt], Field(description="Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[Sandbox]:
+        """Set sandbox TTL
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param ttl_minutes: Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived (required)
+        :type ttl_minutes: float
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._set_ttl_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            ttl_minutes=ttl_minutes,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Sandbox",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    async def set_ttl_without_preload_content(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        ttl_minutes: Annotated[Union[StrictFloat, StrictInt], Field(description="Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Set sandbox TTL
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param ttl_minutes: Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived (required)
+        :type ttl_minutes: float
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._set_ttl_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            ttl_minutes=ttl_minutes,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Sandbox",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _set_ttl_serialize(
+        self,
+        sandbox_id_or_name,
+        ttl_minutes,
+        x_daytona_organization_id,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if sandbox_id_or_name is not None:
+            _path_params['sandboxIdOrName'] = sandbox_id_or_name
+        if ttl_minutes is not None:
+            _path_params['ttlMinutes'] = ttl_minutes
+        # process the query parameters
+        # process the header parameters
+        if x_daytona_organization_id is not None:
+            _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'application/json'
+                ]
+            )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/sandbox/{sandboxIdOrName}/ttl/{ttlMinutes}',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     async def start_sandbox(
         self,
         sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],

--- a/api-client-python-async/daytona_api_client_async/models/create_sandbox.py
+++ b/api-client-python-async/daytona_api_client_async/models/create_sandbox.py
@@ -52,12 +52,13 @@ class CreateSandbox(BaseModel):
     auto_pause_interval: Optional[StrictInt] = Field(default=None, description="Auto-pause interval in minutes (0 means disabled). Only supported for sandbox classes that support pausing. Not allowed for ephemeral sandboxes. At most one of autoStopInterval and autoPauseInterval may be non-zero. For non-ephemeral sandbox classes that support pausing, defaults to 60 minutes (with auto-stop disabled) when neither interval is provided.", serialization_alias="autoPauseInterval")
     auto_archive_interval: Optional[StrictInt] = Field(default=None, description="Auto-archive interval in minutes (0 means the maximum interval will be used)", serialization_alias="autoArchiveInterval")
     auto_delete_interval: Optional[StrictInt] = Field(default=None, description="Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)", serialization_alias="autoDeleteInterval")
+    ttl_minutes: Optional[StrictInt] = Field(default=None, description="Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived.", serialization_alias="ttlMinutes")
     volumes: Optional[List[SandboxVolume]] = Field(default=None, description="Array of volumes to attach to the sandbox")
     build_info: Optional[CreateBuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     linked_sandbox: Optional[StrictStr] = Field(default=None, description="ID or name of an existing sandbox to link the new sandbox to. The new sandbox will be scheduled on the same runner as the linked sandbox so a local network can be established between them. Linked sandboxes must be ephemeral (autoDeleteInterval=0) and cannot themselves be linked to another sandbox.", serialization_alias="linkedSandbox")
     secrets: Optional[List[Dict[str, StrictStr]]] = Field(default=None, description="Secrets to mount in this sandbox. Each entry maps an env var name to a vault secret name.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "linkedSandbox", "secrets"]
+    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -145,6 +146,7 @@ class CreateSandbox(BaseModel):
             "auto_pause_interval": obj.get("autoPauseInterval"),
             "auto_archive_interval": obj.get("autoArchiveInterval"),
             "auto_delete_interval": obj.get("autoDeleteInterval"),
+            "ttl_minutes": obj.get("ttlMinutes"),
             "volumes": [SandboxVolume.from_dict(_item) for _item in obj["volumes"]] if obj.get("volumes") is not None else None,
             "build_info": CreateBuildInfo.from_dict(obj["buildInfo"]) if obj.get("buildInfo") is not None else None,
             "linked_sandbox": obj.get("linkedSandbox"),

--- a/api-client-python-async/daytona_api_client_async/models/sandbox.py
+++ b/api-client-python-async/daytona_api_client_async/models/sandbox.py
@@ -62,7 +62,7 @@ class Sandbox(BaseModel):
     auto_pause_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-pause interval in minutes (0 means disabled)", serialization_alias="autoPauseInterval")
     auto_archive_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-archive interval in minutes", serialization_alias="autoArchiveInterval")
     auto_delete_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)", serialization_alias="autoDeleteInterval")
-    expires_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="expiresAt")
+    auto_destroy_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="autoDestroyAt")
     volumes: Optional[List[SandboxVolume]] = Field(default=None, description="Array of volumes attached to the sandbox")
     build_info: Optional[BuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
@@ -74,7 +74,7 @@ class Sandbox(BaseModel):
     linked_sandbox_id: Optional[StrictStr] = Field(default=None, description="ID of the sandbox this sandbox is linked to. When set, the sandbox is co-located on the same runner as the linked sandbox.", serialization_alias="linkedSandboxId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -170,7 +170,7 @@ class Sandbox(BaseModel):
             "auto_pause_interval": obj.get("autoPauseInterval"),
             "auto_archive_interval": obj.get("autoArchiveInterval"),
             "auto_delete_interval": obj.get("autoDeleteInterval"),
-            "expires_at": obj.get("expiresAt"),
+            "auto_destroy_at": obj.get("autoDestroyAt"),
             "volumes": [SandboxVolume.from_dict(_item) for _item in obj["volumes"]] if obj.get("volumes") is not None else None,
             "build_info": BuildInfo.from_dict(obj["buildInfo"]) if obj.get("buildInfo") is not None else None,
             "created_at": obj.get("createdAt"),

--- a/api-client-python-async/daytona_api_client_async/models/sandbox.py
+++ b/api-client-python-async/daytona_api_client_async/models/sandbox.py
@@ -62,6 +62,7 @@ class Sandbox(BaseModel):
     auto_pause_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-pause interval in minutes (0 means disabled)", serialization_alias="autoPauseInterval")
     auto_archive_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-archive interval in minutes", serialization_alias="autoArchiveInterval")
     auto_delete_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)", serialization_alias="autoDeleteInterval")
+    expires_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="expiresAt")
     volumes: Optional[List[SandboxVolume]] = Field(default=None, description="Array of volumes attached to the sandbox")
     build_info: Optional[BuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
@@ -73,7 +74,7 @@ class Sandbox(BaseModel):
     linked_sandbox_id: Optional[StrictStr] = Field(default=None, description="ID of the sandbox this sandbox is linked to. When set, the sandbox is co-located on the same runner as the linked sandbox.", serialization_alias="linkedSandboxId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -169,6 +170,7 @@ class Sandbox(BaseModel):
             "auto_pause_interval": obj.get("autoPauseInterval"),
             "auto_archive_interval": obj.get("autoArchiveInterval"),
             "auto_delete_interval": obj.get("autoDeleteInterval"),
+            "expires_at": obj.get("expiresAt"),
             "volumes": [SandboxVolume.from_dict(_item) for _item in obj["volumes"]] if obj.get("volumes") is not None else None,
             "build_info": BuildInfo.from_dict(obj["buildInfo"]) if obj.get("buildInfo") is not None else None,
             "created_at": obj.get("createdAt"),

--- a/api-client-python-async/daytona_api_client_async/models/sandbox_list_item.py
+++ b/api-client-python-async/daytona_api_client_async/models/sandbox_list_item.py
@@ -58,14 +58,14 @@ class SandboxListItem(BaseModel):
     auto_pause_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-pause interval in minutes (0 means disabled)", serialization_alias="autoPauseInterval")
     auto_archive_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-archive interval in minutes", serialization_alias="autoArchiveInterval")
     auto_delete_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)", serialization_alias="autoDeleteInterval")
-    expires_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="expiresAt")
+    auto_destroy_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="autoDestroyAt")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
     updated_at: Optional[StrictStr] = Field(default=None, description="The last update timestamp of the sandbox", serialization_alias="updatedAt")
     last_activity_at: Optional[StrictStr] = Field(default=None, description="The last activity timestamp of the sandbox", serialization_alias="lastActivityAt")
     daemon_version: Optional[StrictStr] = Field(default=None, description="The version of the daemon running in the sandbox", serialization_alias="daemonVersion")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -148,7 +148,7 @@ class SandboxListItem(BaseModel):
             "auto_pause_interval": obj.get("autoPauseInterval"),
             "auto_archive_interval": obj.get("autoArchiveInterval"),
             "auto_delete_interval": obj.get("autoDeleteInterval"),
-            "expires_at": obj.get("expiresAt"),
+            "auto_destroy_at": obj.get("autoDestroyAt"),
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
             "last_activity_at": obj.get("lastActivityAt"),

--- a/api-client-python-async/daytona_api_client_async/models/sandbox_list_item.py
+++ b/api-client-python-async/daytona_api_client_async/models/sandbox_list_item.py
@@ -58,13 +58,14 @@ class SandboxListItem(BaseModel):
     auto_pause_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-pause interval in minutes (0 means disabled)", serialization_alias="autoPauseInterval")
     auto_archive_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-archive interval in minutes", serialization_alias="autoArchiveInterval")
     auto_delete_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)", serialization_alias="autoDeleteInterval")
+    expires_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="expiresAt")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
     updated_at: Optional[StrictStr] = Field(default=None, description="The last update timestamp of the sandbox", serialization_alias="updatedAt")
     last_activity_at: Optional[StrictStr] = Field(default=None, description="The last activity timestamp of the sandbox", serialization_alias="lastActivityAt")
     daemon_version: Optional[StrictStr] = Field(default=None, description="The version of the daemon running in the sandbox", serialization_alias="daemonVersion")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -147,6 +148,7 @@ class SandboxListItem(BaseModel):
             "auto_pause_interval": obj.get("autoPauseInterval"),
             "auto_archive_interval": obj.get("autoArchiveInterval"),
             "auto_delete_interval": obj.get("autoDeleteInterval"),
+            "expires_at": obj.get("expiresAt"),
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
             "last_activity_at": obj.get("lastActivityAt"),

--- a/api-client-python/daytona_api_client/api/sandbox_api.py
+++ b/api-client-python/daytona_api_client/api/sandbox_api.py
@@ -11379,6 +11379,295 @@ class SandboxApi:
 
 
     @validate_call
+    def set_ttl(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        ttl_minutes: Annotated[Union[StrictFloat, StrictInt], Field(description="Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> Sandbox:
+        """Set sandbox TTL
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param ttl_minutes: Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived (required)
+        :type ttl_minutes: float
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._set_ttl_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            ttl_minutes=ttl_minutes,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Sandbox",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def set_ttl_with_http_info(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        ttl_minutes: Annotated[Union[StrictFloat, StrictInt], Field(description="Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[Sandbox]:
+        """Set sandbox TTL
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param ttl_minutes: Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived (required)
+        :type ttl_minutes: float
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._set_ttl_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            ttl_minutes=ttl_minutes,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Sandbox",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def set_ttl_without_preload_content(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        ttl_minutes: Annotated[Union[StrictFloat, StrictInt], Field(description="Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Set sandbox TTL
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param ttl_minutes: Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived (required)
+        :type ttl_minutes: float
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._set_ttl_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            ttl_minutes=ttl_minutes,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Sandbox",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _set_ttl_serialize(
+        self,
+        sandbox_id_or_name,
+        ttl_minutes,
+        x_daytona_organization_id,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if sandbox_id_or_name is not None:
+            _path_params['sandboxIdOrName'] = sandbox_id_or_name
+        if ttl_minutes is not None:
+            _path_params['ttlMinutes'] = ttl_minutes
+        # process the query parameters
+        # process the header parameters
+        if x_daytona_organization_id is not None:
+            _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'application/json'
+                ]
+            )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/sandbox/{sandboxIdOrName}/ttl/{ttlMinutes}',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     def start_sandbox(
         self,
         sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],

--- a/api-client-python/daytona_api_client/models/create_sandbox.py
+++ b/api-client-python/daytona_api_client/models/create_sandbox.py
@@ -52,12 +52,13 @@ class CreateSandbox(BaseModel):
     auto_pause_interval: Optional[StrictInt] = Field(default=None, description="Auto-pause interval in minutes (0 means disabled). Only supported for sandbox classes that support pausing. Not allowed for ephemeral sandboxes. At most one of autoStopInterval and autoPauseInterval may be non-zero. For non-ephemeral sandbox classes that support pausing, defaults to 60 minutes (with auto-stop disabled) when neither interval is provided.", serialization_alias="autoPauseInterval")
     auto_archive_interval: Optional[StrictInt] = Field(default=None, description="Auto-archive interval in minutes (0 means the maximum interval will be used)", serialization_alias="autoArchiveInterval")
     auto_delete_interval: Optional[StrictInt] = Field(default=None, description="Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)", serialization_alias="autoDeleteInterval")
+    ttl_minutes: Optional[StrictInt] = Field(default=None, description="Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived.", serialization_alias="ttlMinutes")
     volumes: Optional[List[SandboxVolume]] = Field(default=None, description="Array of volumes to attach to the sandbox")
     build_info: Optional[CreateBuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     linked_sandbox: Optional[StrictStr] = Field(default=None, description="ID or name of an existing sandbox to link the new sandbox to. The new sandbox will be scheduled on the same runner as the linked sandbox so a local network can be established between them. Linked sandboxes must be ephemeral (autoDeleteInterval=0) and cannot themselves be linked to another sandbox.", serialization_alias="linkedSandbox")
     secrets: Optional[List[Dict[str, StrictStr]]] = Field(default=None, description="Secrets to mount in this sandbox. Each entry maps an env var name to a vault secret name.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "linkedSandbox", "secrets"]
+    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -145,6 +146,7 @@ class CreateSandbox(BaseModel):
             "auto_pause_interval": obj.get("autoPauseInterval"),
             "auto_archive_interval": obj.get("autoArchiveInterval"),
             "auto_delete_interval": obj.get("autoDeleteInterval"),
+            "ttl_minutes": obj.get("ttlMinutes"),
             "volumes": [SandboxVolume.from_dict(_item) for _item in obj["volumes"]] if obj.get("volumes") is not None else None,
             "build_info": CreateBuildInfo.from_dict(obj["buildInfo"]) if obj.get("buildInfo") is not None else None,
             "linked_sandbox": obj.get("linkedSandbox"),

--- a/api-client-python/daytona_api_client/models/sandbox.py
+++ b/api-client-python/daytona_api_client/models/sandbox.py
@@ -62,7 +62,7 @@ class Sandbox(BaseModel):
     auto_pause_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-pause interval in minutes (0 means disabled)", serialization_alias="autoPauseInterval")
     auto_archive_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-archive interval in minutes", serialization_alias="autoArchiveInterval")
     auto_delete_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)", serialization_alias="autoDeleteInterval")
-    expires_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="expiresAt")
+    auto_destroy_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="autoDestroyAt")
     volumes: Optional[List[SandboxVolume]] = Field(default=None, description="Array of volumes attached to the sandbox")
     build_info: Optional[BuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
@@ -74,7 +74,7 @@ class Sandbox(BaseModel):
     linked_sandbox_id: Optional[StrictStr] = Field(default=None, description="ID of the sandbox this sandbox is linked to. When set, the sandbox is co-located on the same runner as the linked sandbox.", serialization_alias="linkedSandboxId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -170,7 +170,7 @@ class Sandbox(BaseModel):
             "auto_pause_interval": obj.get("autoPauseInterval"),
             "auto_archive_interval": obj.get("autoArchiveInterval"),
             "auto_delete_interval": obj.get("autoDeleteInterval"),
-            "expires_at": obj.get("expiresAt"),
+            "auto_destroy_at": obj.get("autoDestroyAt"),
             "volumes": [SandboxVolume.from_dict(_item) for _item in obj["volumes"]] if obj.get("volumes") is not None else None,
             "build_info": BuildInfo.from_dict(obj["buildInfo"]) if obj.get("buildInfo") is not None else None,
             "created_at": obj.get("createdAt"),

--- a/api-client-python/daytona_api_client/models/sandbox.py
+++ b/api-client-python/daytona_api_client/models/sandbox.py
@@ -62,6 +62,7 @@ class Sandbox(BaseModel):
     auto_pause_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-pause interval in minutes (0 means disabled)", serialization_alias="autoPauseInterval")
     auto_archive_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-archive interval in minutes", serialization_alias="autoArchiveInterval")
     auto_delete_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)", serialization_alias="autoDeleteInterval")
+    expires_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="expiresAt")
     volumes: Optional[List[SandboxVolume]] = Field(default=None, description="Array of volumes attached to the sandbox")
     build_info: Optional[BuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
@@ -73,7 +74,7 @@ class Sandbox(BaseModel):
     linked_sandbox_id: Optional[StrictStr] = Field(default=None, description="ID of the sandbox this sandbox is linked to. When set, the sandbox is co-located on the same runner as the linked sandbox.", serialization_alias="linkedSandboxId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -169,6 +170,7 @@ class Sandbox(BaseModel):
             "auto_pause_interval": obj.get("autoPauseInterval"),
             "auto_archive_interval": obj.get("autoArchiveInterval"),
             "auto_delete_interval": obj.get("autoDeleteInterval"),
+            "expires_at": obj.get("expiresAt"),
             "volumes": [SandboxVolume.from_dict(_item) for _item in obj["volumes"]] if obj.get("volumes") is not None else None,
             "build_info": BuildInfo.from_dict(obj["buildInfo"]) if obj.get("buildInfo") is not None else None,
             "created_at": obj.get("createdAt"),

--- a/api-client-python/daytona_api_client/models/sandbox_list_item.py
+++ b/api-client-python/daytona_api_client/models/sandbox_list_item.py
@@ -58,14 +58,14 @@ class SandboxListItem(BaseModel):
     auto_pause_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-pause interval in minutes (0 means disabled)", serialization_alias="autoPauseInterval")
     auto_archive_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-archive interval in minutes", serialization_alias="autoArchiveInterval")
     auto_delete_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)", serialization_alias="autoDeleteInterval")
-    expires_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="expiresAt")
+    auto_destroy_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="autoDestroyAt")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
     updated_at: Optional[StrictStr] = Field(default=None, description="The last update timestamp of the sandbox", serialization_alias="updatedAt")
     last_activity_at: Optional[StrictStr] = Field(default=None, description="The last activity timestamp of the sandbox", serialization_alias="lastActivityAt")
     daemon_version: Optional[StrictStr] = Field(default=None, description="The version of the daemon running in the sandbox", serialization_alias="daemonVersion")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -148,7 +148,7 @@ class SandboxListItem(BaseModel):
             "auto_pause_interval": obj.get("autoPauseInterval"),
             "auto_archive_interval": obj.get("autoArchiveInterval"),
             "auto_delete_interval": obj.get("autoDeleteInterval"),
-            "expires_at": obj.get("expiresAt"),
+            "auto_destroy_at": obj.get("autoDestroyAt"),
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
             "last_activity_at": obj.get("lastActivityAt"),

--- a/api-client-python/daytona_api_client/models/sandbox_list_item.py
+++ b/api-client-python/daytona_api_client/models/sandbox_list_item.py
@@ -58,13 +58,14 @@ class SandboxListItem(BaseModel):
     auto_pause_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-pause interval in minutes (0 means disabled)", serialization_alias="autoPauseInterval")
     auto_archive_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-archive interval in minutes", serialization_alias="autoArchiveInterval")
     auto_delete_interval: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)", serialization_alias="autoDeleteInterval")
+    expires_at: Optional[StrictStr] = Field(default=None, description="When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)", serialization_alias="expiresAt")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
     updated_at: Optional[StrictStr] = Field(default=None, description="The last update timestamp of the sandbox", serialization_alias="updatedAt")
     last_activity_at: Optional[StrictStr] = Field(default=None, description="The last activity timestamp of the sandbox", serialization_alias="lastActivityAt")
     daemon_version: Optional[StrictStr] = Field(default=None, description="The version of the daemon running in the sandbox", serialization_alias="daemonVersion")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "expiresAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -147,6 +148,7 @@ class SandboxListItem(BaseModel):
             "auto_pause_interval": obj.get("autoPauseInterval"),
             "auto_archive_interval": obj.get("autoArchiveInterval"),
             "auto_delete_interval": obj.get("autoDeleteInterval"),
+            "expires_at": obj.get("expiresAt"),
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
             "last_activity_at": obj.get("lastActivityAt"),

--- a/api-client-ruby/lib/daytona_api_client/api/sandbox_api.rb
+++ b/api-client-ruby/lib/daytona_api_client/api/sandbox_api.rb
@@ -2715,6 +2715,76 @@ module DaytonaApiClient
       return data, status_code, headers
     end
 
+    # Set sandbox TTL
+    # @param sandbox_id_or_name [String] ID or name of the sandbox
+    # @param ttl_minutes [Float] Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID
+    # @return [Sandbox]
+    def set_ttl(sandbox_id_or_name, ttl_minutes, opts = {})
+      data, _status_code, _headers = set_ttl_with_http_info(sandbox_id_or_name, ttl_minutes, opts)
+      data
+    end
+
+    # Set sandbox TTL
+    # @param sandbox_id_or_name [String] ID or name of the sandbox
+    # @param ttl_minutes [Float] Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID
+    # @return [Array<(Sandbox, Integer, Hash)>] Sandbox data, response status code and response headers
+    def set_ttl_with_http_info(sandbox_id_or_name, ttl_minutes, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: SandboxApi.set_ttl ...'
+      end
+      # verify the required parameter 'sandbox_id_or_name' is set
+      if @api_client.config.client_side_validation && sandbox_id_or_name.nil?
+        fail ArgumentError, "Missing the required parameter 'sandbox_id_or_name' when calling SandboxApi.set_ttl"
+      end
+      # verify the required parameter 'ttl_minutes' is set
+      if @api_client.config.client_side_validation && ttl_minutes.nil?
+        fail ArgumentError, "Missing the required parameter 'ttl_minutes' when calling SandboxApi.set_ttl"
+      end
+      # resource path
+      local_var_path = '/sandbox/{sandboxIdOrName}/ttl/{ttlMinutes}'.sub('{' + 'sandboxIdOrName' + '}', CGI.escape(sandbox_id_or_name.to_s)).sub('{' + 'ttlMinutes' + '}', CGI.escape(ttl_minutes.to_s))
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
+      header_params[:'X-Daytona-Organization-ID'] = opts[:'x_daytona_organization_id'] if !opts[:'x_daytona_organization_id'].nil?
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body]
+
+      # return_type
+      return_type = opts[:debug_return_type] || 'Sandbox'
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || ['bearer', 'oauth2']
+
+      new_options = opts.merge(
+        :operation => :"SandboxApi.set_ttl",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: SandboxApi#set_ttl\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # Start or resume sandbox
     # Starts a stopped or archived sandbox, or resumes a paused sandbox. The transition taken depends on the current sandbox state.
     # @param sandbox_id_or_name [String] ID or name of the sandbox

--- a/api-client-ruby/lib/daytona_api_client/models/create_sandbox.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/create_sandbox.rb
@@ -72,6 +72,9 @@ module DaytonaApiClient
     # Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
     attr_accessor :auto_delete_interval
 
+    # Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived.
+    attr_accessor :ttl_minutes
+
     # Array of volumes to attach to the sandbox
     attr_accessor :volumes
 
@@ -106,6 +109,7 @@ module DaytonaApiClient
         :'auto_pause_interval' => :'autoPauseInterval',
         :'auto_archive_interval' => :'autoArchiveInterval',
         :'auto_delete_interval' => :'autoDeleteInterval',
+        :'ttl_minutes' => :'ttlMinutes',
         :'volumes' => :'volumes',
         :'build_info' => :'buildInfo',
         :'linked_sandbox' => :'linkedSandbox',
@@ -145,6 +149,7 @@ module DaytonaApiClient
         :'auto_pause_interval' => :'Integer',
         :'auto_archive_interval' => :'Integer',
         :'auto_delete_interval' => :'Integer',
+        :'ttl_minutes' => :'Integer',
         :'volumes' => :'Array<SandboxVolume>',
         :'build_info' => :'CreateBuildInfo',
         :'linked_sandbox' => :'String',
@@ -256,6 +261,10 @@ module DaytonaApiClient
         self.auto_delete_interval = attributes[:'auto_delete_interval']
       end
 
+      if attributes.key?(:'ttl_minutes')
+        self.ttl_minutes = attributes[:'ttl_minutes']
+      end
+
       if attributes.key?(:'volumes')
         if (value = attributes[:'volumes']).is_a?(Array)
           self.volumes = value
@@ -316,6 +325,7 @@ module DaytonaApiClient
           auto_pause_interval == o.auto_pause_interval &&
           auto_archive_interval == o.auto_archive_interval &&
           auto_delete_interval == o.auto_delete_interval &&
+          ttl_minutes == o.ttl_minutes &&
           volumes == o.volumes &&
           build_info == o.build_info &&
           linked_sandbox == o.linked_sandbox &&
@@ -331,7 +341,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, target, cpu, gpu, gpu_type, memory, disk, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, volumes, build_info, linked_sandbox, secrets].hash
+      [name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, target, cpu, gpu, gpu_type, memory, disk, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, ttl_minutes, volumes, build_info, linked_sandbox, secrets].hash
     end
 
     # Builds the object from hash

--- a/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
@@ -96,6 +96,9 @@ module DaytonaApiClient
     # Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
     attr_accessor :auto_delete_interval
 
+    # When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
+    attr_accessor :expires_at
+
     # Array of volumes attached to the sandbox
     attr_accessor :volumes
 
@@ -178,6 +181,7 @@ module DaytonaApiClient
         :'auto_pause_interval' => :'autoPauseInterval',
         :'auto_archive_interval' => :'autoArchiveInterval',
         :'auto_delete_interval' => :'autoDeleteInterval',
+        :'expires_at' => :'expiresAt',
         :'volumes' => :'volumes',
         :'build_info' => :'buildInfo',
         :'created_at' => :'createdAt',
@@ -231,6 +235,7 @@ module DaytonaApiClient
         :'auto_pause_interval' => :'Float',
         :'auto_archive_interval' => :'Float',
         :'auto_delete_interval' => :'Float',
+        :'expires_at' => :'String',
         :'volumes' => :'Array<SandboxVolume>',
         :'build_info' => :'BuildInfo',
         :'created_at' => :'String',
@@ -402,6 +407,10 @@ module DaytonaApiClient
 
       if attributes.key?(:'auto_delete_interval')
         self.auto_delete_interval = attributes[:'auto_delete_interval']
+      end
+
+      if attributes.key?(:'expires_at')
+        self.expires_at = attributes[:'expires_at']
       end
 
       if attributes.key?(:'volumes')
@@ -730,6 +739,7 @@ module DaytonaApiClient
           auto_pause_interval == o.auto_pause_interval &&
           auto_archive_interval == o.auto_archive_interval &&
           auto_delete_interval == o.auto_delete_interval &&
+          expires_at == o.expires_at &&
           volumes == o.volumes &&
           build_info == o.build_info &&
           created_at == o.created_at &&
@@ -751,7 +761,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, target, cpu, gpu, gpu_type, memory, disk, state, desired_state, error_reason, recoverable, backup_state, backup_created_at, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, volumes, build_info, created_at, updated_at, last_activity_at, sandbox_class, daemon_version, runner_id, linked_sandbox_id, toolbox_proxy_url].hash
+      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, target, cpu, gpu, gpu_type, memory, disk, state, desired_state, error_reason, recoverable, backup_state, backup_created_at, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, expires_at, volumes, build_info, created_at, updated_at, last_activity_at, sandbox_class, daemon_version, runner_id, linked_sandbox_id, toolbox_proxy_url].hash
     end
 
     # Builds the object from hash

--- a/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
@@ -96,8 +96,8 @@ module DaytonaApiClient
     # Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
     attr_accessor :auto_delete_interval
 
-    # When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
-    attr_accessor :expires_at
+    # When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)
+    attr_accessor :auto_destroy_at
 
     # Array of volumes attached to the sandbox
     attr_accessor :volumes
@@ -181,7 +181,7 @@ module DaytonaApiClient
         :'auto_pause_interval' => :'autoPauseInterval',
         :'auto_archive_interval' => :'autoArchiveInterval',
         :'auto_delete_interval' => :'autoDeleteInterval',
-        :'expires_at' => :'expiresAt',
+        :'auto_destroy_at' => :'autoDestroyAt',
         :'volumes' => :'volumes',
         :'build_info' => :'buildInfo',
         :'created_at' => :'createdAt',
@@ -235,7 +235,7 @@ module DaytonaApiClient
         :'auto_pause_interval' => :'Float',
         :'auto_archive_interval' => :'Float',
         :'auto_delete_interval' => :'Float',
-        :'expires_at' => :'String',
+        :'auto_destroy_at' => :'String',
         :'volumes' => :'Array<SandboxVolume>',
         :'build_info' => :'BuildInfo',
         :'created_at' => :'String',
@@ -409,8 +409,8 @@ module DaytonaApiClient
         self.auto_delete_interval = attributes[:'auto_delete_interval']
       end
 
-      if attributes.key?(:'expires_at')
-        self.expires_at = attributes[:'expires_at']
+      if attributes.key?(:'auto_destroy_at')
+        self.auto_destroy_at = attributes[:'auto_destroy_at']
       end
 
       if attributes.key?(:'volumes')
@@ -739,7 +739,7 @@ module DaytonaApiClient
           auto_pause_interval == o.auto_pause_interval &&
           auto_archive_interval == o.auto_archive_interval &&
           auto_delete_interval == o.auto_delete_interval &&
-          expires_at == o.expires_at &&
+          auto_destroy_at == o.auto_destroy_at &&
           volumes == o.volumes &&
           build_info == o.build_info &&
           created_at == o.created_at &&
@@ -761,7 +761,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, target, cpu, gpu, gpu_type, memory, disk, state, desired_state, error_reason, recoverable, backup_state, backup_created_at, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, expires_at, volumes, build_info, created_at, updated_at, last_activity_at, sandbox_class, daemon_version, runner_id, linked_sandbox_id, toolbox_proxy_url].hash
+      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, target, cpu, gpu, gpu_type, memory, disk, state, desired_state, error_reason, recoverable, backup_state, backup_created_at, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, auto_destroy_at, volumes, build_info, created_at, updated_at, last_activity_at, sandbox_class, daemon_version, runner_id, linked_sandbox_id, toolbox_proxy_url].hash
     end
 
     # Builds the object from hash

--- a/api-client-ruby/lib/daytona_api_client/models/sandbox_list_item.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/sandbox_list_item.rb
@@ -87,8 +87,8 @@ module DaytonaApiClient
     # Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
     attr_accessor :auto_delete_interval
 
-    # When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
-    attr_accessor :expires_at
+    # When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)
+    attr_accessor :auto_destroy_at
 
     # The creation timestamp of the sandbox
     attr_accessor :created_at
@@ -154,7 +154,7 @@ module DaytonaApiClient
         :'auto_pause_interval' => :'autoPauseInterval',
         :'auto_archive_interval' => :'autoArchiveInterval',
         :'auto_delete_interval' => :'autoDeleteInterval',
-        :'expires_at' => :'expiresAt',
+        :'auto_destroy_at' => :'autoDestroyAt',
         :'created_at' => :'createdAt',
         :'updated_at' => :'updatedAt',
         :'last_activity_at' => :'lastActivityAt',
@@ -200,7 +200,7 @@ module DaytonaApiClient
         :'auto_pause_interval' => :'Float',
         :'auto_archive_interval' => :'Float',
         :'auto_delete_interval' => :'Float',
-        :'expires_at' => :'String',
+        :'auto_destroy_at' => :'String',
         :'created_at' => :'String',
         :'updated_at' => :'String',
         :'last_activity_at' => :'String',
@@ -351,8 +351,8 @@ module DaytonaApiClient
         self.auto_delete_interval = attributes[:'auto_delete_interval']
       end
 
-      if attributes.key?(:'expires_at')
-        self.expires_at = attributes[:'expires_at']
+      if attributes.key?(:'auto_destroy_at')
+        self.auto_destroy_at = attributes[:'auto_destroy_at']
       end
 
       if attributes.key?(:'created_at')
@@ -614,7 +614,7 @@ module DaytonaApiClient
           auto_pause_interval == o.auto_pause_interval &&
           auto_archive_interval == o.auto_archive_interval &&
           auto_delete_interval == o.auto_delete_interval &&
-          expires_at == o.expires_at &&
+          auto_destroy_at == o.auto_destroy_at &&
           created_at == o.created_at &&
           updated_at == o.updated_at &&
           last_activity_at == o.last_activity_at &&
@@ -631,7 +631,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, organization_id, name, target, runner_id, sandbox_class, state, desired_state, snapshot, user, error_reason, recoverable, public, cpu, gpu, gpu_type, memory, disk, labels, backup_state, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, expires_at, created_at, updated_at, last_activity_at, daemon_version, toolbox_proxy_url].hash
+      [id, organization_id, name, target, runner_id, sandbox_class, state, desired_state, snapshot, user, error_reason, recoverable, public, cpu, gpu, gpu_type, memory, disk, labels, backup_state, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, auto_destroy_at, created_at, updated_at, last_activity_at, daemon_version, toolbox_proxy_url].hash
     end
 
     # Builds the object from hash

--- a/api-client-ruby/lib/daytona_api_client/models/sandbox_list_item.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/sandbox_list_item.rb
@@ -87,6 +87,9 @@ module DaytonaApiClient
     # Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
     attr_accessor :auto_delete_interval
 
+    # When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
+    attr_accessor :expires_at
+
     # The creation timestamp of the sandbox
     attr_accessor :created_at
 
@@ -151,6 +154,7 @@ module DaytonaApiClient
         :'auto_pause_interval' => :'autoPauseInterval',
         :'auto_archive_interval' => :'autoArchiveInterval',
         :'auto_delete_interval' => :'autoDeleteInterval',
+        :'expires_at' => :'expiresAt',
         :'created_at' => :'createdAt',
         :'updated_at' => :'updatedAt',
         :'last_activity_at' => :'lastActivityAt',
@@ -196,6 +200,7 @@ module DaytonaApiClient
         :'auto_pause_interval' => :'Float',
         :'auto_archive_interval' => :'Float',
         :'auto_delete_interval' => :'Float',
+        :'expires_at' => :'String',
         :'created_at' => :'String',
         :'updated_at' => :'String',
         :'last_activity_at' => :'String',
@@ -344,6 +349,10 @@ module DaytonaApiClient
 
       if attributes.key?(:'auto_delete_interval')
         self.auto_delete_interval = attributes[:'auto_delete_interval']
+      end
+
+      if attributes.key?(:'expires_at')
+        self.expires_at = attributes[:'expires_at']
       end
 
       if attributes.key?(:'created_at')
@@ -605,6 +614,7 @@ module DaytonaApiClient
           auto_pause_interval == o.auto_pause_interval &&
           auto_archive_interval == o.auto_archive_interval &&
           auto_delete_interval == o.auto_delete_interval &&
+          expires_at == o.expires_at &&
           created_at == o.created_at &&
           updated_at == o.updated_at &&
           last_activity_at == o.last_activity_at &&
@@ -621,7 +631,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, organization_id, name, target, runner_id, sandbox_class, state, desired_state, snapshot, user, error_reason, recoverable, public, cpu, gpu, gpu_type, memory, disk, labels, backup_state, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, created_at, updated_at, last_activity_at, daemon_version, toolbox_proxy_url].hash
+      [id, organization_id, name, target, runner_id, sandbox_class, state, desired_state, snapshot, user, error_reason, recoverable, public, cpu, gpu, gpu_type, memory, disk, labels, backup_state, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, expires_at, created_at, updated_at, last_activity_at, daemon_version, toolbox_proxy_url].hash
     end
 
     # Builds the object from hash

--- a/api-client/src/api/sandbox-api.ts
+++ b/api-client/src/api/sandbox-api.ts
@@ -2073,6 +2073,54 @@ export const SandboxApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
+         * 
+         * @summary Set sandbox TTL
+         * @param {string} sandboxIdOrName ID or name of the sandbox
+         * @param {number} ttlMinutes Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived
+         * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        setTtl: async (sandboxIdOrName: string, ttlMinutes: number, xDaytonaOrganizationID?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'sandboxIdOrName' is not null or undefined
+            assertParamExists('setTtl', 'sandboxIdOrName', sandboxIdOrName)
+            // verify required parameter 'ttlMinutes' is not null or undefined
+            assertParamExists('setTtl', 'ttlMinutes', ttlMinutes)
+            const localVarPath = `/sandbox/{sandboxIdOrName}/ttl/{ttlMinutes}`
+                .replace(`{${"sandboxIdOrName"}}`, encodeURIComponent(String(sandboxIdOrName)))
+                .replace(`{${"ttlMinutes"}}`, encodeURIComponent(String(ttlMinutes)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication oauth2 required
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            if (xDaytonaOrganizationID != null) {
+                localVarHeaderParameter['X-Daytona-Organization-ID'] = String(xDaytonaOrganizationID);
+            }
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Starts a stopped or archived sandbox, or resumes a paused sandbox. The transition taken depends on the current sandbox state.
          * @summary Start or resume sandbox
          * @param {string} sandboxIdOrName ID or name of the sandbox
@@ -3040,6 +3088,21 @@ export const SandboxApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
+         * 
+         * @summary Set sandbox TTL
+         * @param {string} sandboxIdOrName ID or name of the sandbox
+         * @param {number} ttlMinutes Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived
+         * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async setTtl(sandboxIdOrName: string, ttlMinutes: number, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Sandbox>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.setTtl(sandboxIdOrName, ttlMinutes, xDaytonaOrganizationID, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['SandboxApi.setTtl']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * Starts a stopped or archived sandbox, or resumes a paused sandbox. The transition taken depends on the current sandbox state.
          * @summary Start or resume sandbox
          * @param {string} sandboxIdOrName ID or name of the sandbox
@@ -3637,6 +3700,18 @@ export const SandboxApiFactory = function (configuration?: Configuration, basePa
          */
         setAutostopInterval(sandboxIdOrName: string, interval: number, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): AxiosPromise<Sandbox> {
             return localVarFp.setAutostopInterval(sandboxIdOrName, interval, xDaytonaOrganizationID, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Set sandbox TTL
+         * @param {string} sandboxIdOrName ID or name of the sandbox
+         * @param {number} ttlMinutes Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived
+         * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        setTtl(sandboxIdOrName: string, ttlMinutes: number, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): AxiosPromise<Sandbox> {
+            return localVarFp.setTtl(sandboxIdOrName, ttlMinutes, xDaytonaOrganizationID, options).then((request) => request(axios, basePath));
         },
         /**
          * Starts a stopped or archived sandbox, or resumes a paused sandbox. The transition taken depends on the current sandbox state.
@@ -4245,6 +4320,19 @@ export class SandboxApi extends BaseAPI {
      */
     public setAutostopInterval(sandboxIdOrName: string, interval: number, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig) {
         return SandboxApiFp(this.configuration).setAutostopInterval(sandboxIdOrName, interval, xDaytonaOrganizationID, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Set sandbox TTL
+     * @param {string} sandboxIdOrName ID or name of the sandbox
+     * @param {number} ttlMinutes Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived
+     * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public setTtl(sandboxIdOrName: string, ttlMinutes: number, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig) {
+        return SandboxApiFp(this.configuration).setTtl(sandboxIdOrName, ttlMinutes, xDaytonaOrganizationID, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/api-client/src/models/create-sandbox.ts
+++ b/api-client/src/models/create-sandbox.ts
@@ -101,6 +101,10 @@ export interface CreateSandbox {
      */
     'autoDeleteInterval'?: number;
     /**
+     * Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived.
+     */
+    'ttlMinutes'?: number;
+    /**
      * Array of volumes to attach to the sandbox
      */
     'volumes'?: Array<SandboxVolume>;

--- a/api-client/src/models/sandbox-list-item.ts
+++ b/api-client/src/models/sandbox-list-item.ts
@@ -124,6 +124,10 @@ export interface SandboxListItem {
      */
     'autoDeleteInterval'?: number;
     /**
+     * When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
+     */
+    'expiresAt'?: string;
+    /**
      * The creation timestamp of the sandbox
      */
     'createdAt'?: string;

--- a/api-client/src/models/sandbox-list-item.ts
+++ b/api-client/src/models/sandbox-list-item.ts
@@ -124,9 +124,9 @@ export interface SandboxListItem {
      */
     'autoDeleteInterval'?: number;
     /**
-     * When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
+     * When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)
      */
-    'expiresAt'?: string;
+    'autoDestroyAt'?: string;
     /**
      * The creation timestamp of the sandbox
      */

--- a/api-client/src/models/sandbox.ts
+++ b/api-client/src/models/sandbox.ts
@@ -139,6 +139,10 @@ export interface Sandbox {
      */
     'autoDeleteInterval'?: number;
     /**
+     * When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
+     */
+    'expiresAt'?: string;
+    /**
      * Array of volumes attached to the sandbox
      */
     'volumes'?: Array<SandboxVolume>;

--- a/api-client/src/models/sandbox.ts
+++ b/api-client/src/models/sandbox.ts
@@ -139,9 +139,9 @@ export interface Sandbox {
      */
     'autoDeleteInterval'?: number;
     /**
-     * When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)
+     * When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)
      */
-    'expiresAt'?: string;
+    'autoDestroyAt'?: string;
     /**
      * Array of volumes attached to the sandbox
      */

--- a/artifacts/sdk-docs/go-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/go-sdk/daytona.mdx
@@ -4331,6 +4331,7 @@ type Sandbox struct {
     UpdatedAt       *string // When the sandbox was last updated
     LastActivityAt  *string // When the sandbox last had activity
     ToolboxProxyUrl string  // Toolbox proxy URL for the sandbox
+    ExpiresAt       *string // When the sandbox expires (based on TTL)
 
     // Env contains environment variables set in the sandbox.
     // Not populated by [Client.List]; call [Sandbox.RefreshData] on each item to populate.

--- a/artifacts/sdk-docs/go-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/go-sdk/daytona.mdx
@@ -4331,7 +4331,7 @@ type Sandbox struct {
     UpdatedAt       *string // When the sandbox was last updated
     LastActivityAt  *string // When the sandbox last had activity
     ToolboxProxyUrl string  // Toolbox proxy URL for the sandbox
-    ExpiresAt       *string // When the sandbox expires (based on TTL)
+    AutoDestroyAt   *string // When the sandbox will be automatically destroyed (based on TTL)
 
     // Env contains environment variables set in the sandbox.
     // Not populated by [Client.List]; call [Sandbox.RefreshData] on each item to populate.

--- a/artifacts/sdk-docs/go-sdk/types.mdx
+++ b/artifacts/sdk-docs/go-sdk/types.mdx
@@ -550,6 +550,7 @@ type SandboxBaseParams struct {
     AutoPauseInterval   *int // nil = server default when AutoStopInterval is also nil (60 for non-ephemeral pause-supporting classes, with auto-stop disabled), 0 = disabled. Only supported for sandbox classes that support pausing. Not allowed for ephemeral sandboxes. At most one of AutoPauseInterval and AutoStopInterval may be non-zero.
     AutoArchiveInterval *int // nil = no auto-archive, 0 = immediate archive
     AutoDeleteInterval  *int // nil = no auto-delete, 0 = immediate delete
+    TtlMinutes          *int // Wall-clock max lifetime in minutes; 0 disables TTL
     Volumes             []VolumeMount
     // Secrets maps an environment variable name to the name of an existing
     // organization secret. For each entry, the env var is injected into the

--- a/artifacts/sdk-docs/java-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/java-sdk/sandbox.mdx
@@ -742,9 +742,9 @@ public String getLastActivityAt()
 
 - `String` - when the Sandbox last had activity, or `null`.
 
-#### getExpiresAt()
+#### getAutoDestroyAt()
 ```java
-public String getExpiresAt()
+public String getAutoDestroyAt()
 ```
 
 **Returns**:

--- a/artifacts/sdk-docs/java-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/java-sdk/sandbox.mdx
@@ -238,8 +238,8 @@ public void setTtl(int ttlMinutes)
 ```
 
 Sets Sandbox TTL (time to live) in minutes. Set to 0 to disable the TTL.
-The deadline is computed server-side; call `#refreshData()` to read the updated
-`autoDestroyAt`.
+The deadline is computed server-side; call `#refreshData()` and read the updated
+value via `#getAutoDestroyAt()`.
 
 **Parameters**:
 

--- a/artifacts/sdk-docs/java-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/java-sdk/sandbox.mdx
@@ -232,6 +232,22 @@ Sets Sandbox auto-delete interval.
 
 - `DaytonaException` - if the update fails
 
+#### setTtl()
+```java
+public void setTtl(int ttlMinutes)
+```
+
+Sets Sandbox TTL (time to live) in minutes.
+
+**Parameters**:
+
+- `ttlMinutes` _int_ - minutes until the Sandbox expires
+
+**Throws**:
+
+- `IllegalArgumentException` - if ttlMinutes is negative
+- `DaytonaException` - if the update fails
+
 #### updateNetworkSettings()
 ```java
 public void updateNetworkSettings(UpdateSandboxNetworkSettings settings)
@@ -725,6 +741,15 @@ public String getLastActivityAt()
 **Returns**:
 
 - `String` - when the Sandbox last had activity, or `null`.
+
+#### getExpiresAt()
+```java
+public String getExpiresAt()
+```
+
+**Returns**:
+
+- `String` - when the Sandbox expires, or `null` if no TTL is set.
 
 #### getToolboxProxyUrl()
 ```java

--- a/artifacts/sdk-docs/java-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/java-sdk/sandbox.mdx
@@ -237,11 +237,13 @@ Sets Sandbox auto-delete interval.
 public void setTtl(int ttlMinutes)
 ```
 
-Sets Sandbox TTL (time to live) in minutes.
+Sets Sandbox TTL (time to live) in minutes. Set to 0 to disable the TTL.
+The deadline is computed server-side; call `#refreshData()` to read the updated
+`autoDestroyAt`.
 
 **Parameters**:
 
-- `ttlMinutes` _int_ - minutes until the Sandbox expires
+- `ttlMinutes` _int_ - minutes until the Sandbox is destroyed, or 0 to disable
 
 **Throws**:
 

--- a/artifacts/sdk-docs/python-sdk/async/async-daytona.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-daytona.mdx
@@ -501,6 +501,9 @@ Base parameters for creating a new Sandbox.
 - `auto_delete_interval` _int | None_ - Interval in minutes after which a continuously stopped Sandbox will
   automatically be deleted. By default, auto-delete is disabled.
   Negative value means disabled, 0 means delete immediately upon stopping.
+- `ttl_minutes` _int | None_ - Maximum time to live in minutes, counted as wall-clock time since
+  creation regardless of sandbox state. When it elapses the sandbox is destroyed, even if
+  it is stopped, paused, or archived. 0 means disabled.
 - `volumes` _list[VolumeMount] | None_ - List of volumes mounts to attach to the Sandbox.
 - `secrets` _dict[str, str] | None_ - Map of environment variable name to the name of an existing
   organization Secret to mount into the Sandbox. The env var is set to the Secret's opaque

--- a/artifacts/sdk-docs/python-sdk/async/async-sandbox.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-sandbox.mdx
@@ -53,6 +53,8 @@ Represents a Daytona Sandbox.
 - `created_at` _str | None_ - When the Sandbox was created.
 - `updated_at` _str | None_ - When the Sandbox was last updated.
 - `last_activity_at` _str | None_ - When the Sandbox last had activity.
+- `expires_at` _str | None_ - When the Sandbox will expire and be destroyed (only set when a TTL
+  is configured).
 - `network_block_all` _bool | None_ - Whether to block all network access for the Sandbox
   (not returned by list results; call `refresh_data()` on each item to populate).
 - `network_allow_list` _str | None_ - Comma-separated list of allowed CIDR network addresses for
@@ -504,6 +506,45 @@ Only supported for sandbox classes that support pausing.
 await sandbox.set_auto_pause_interval(60)
 # Or disable auto-pause
 await sandbox.set_auto_pause_interval(0)
+```
+
+#### AsyncSandbox.set\_ttl
+
+```python
+@intercept_errors(message_prefix="Failed to set TTL: ")
+@with_instrumentation()
+async def set_ttl(ttl_minutes: int,
+                  request_timeout: float | None = None) -> None
+```
+
+Sets the TTL (time to live) for the Sandbox.
+
+The Sandbox will be destroyed after the specified number of minutes, counted as
+wall-clock time from the current moment, regardless of its state (started, stopped,
+paused, or archived). Setting to 0 disables the TTL.
+
+**Arguments**:
+
+- `ttl_minutes` _int_ - Number of minutes until the Sandbox is destroyed.
+  Set to 0 to disable the TTL.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
+
+**Raises**:
+
+- `DaytonaValidationError` - If ttl_minutes is negative
+  
+
+**Example**:
+
+```python
+# Set TTL to 1 hour
+await sandbox.set_ttl(60)
+# Or disable TTL
+await sandbox.set_ttl(0)
 ```
 
 #### AsyncSandbox.set\_auto\_archive\_interval

--- a/artifacts/sdk-docs/python-sdk/async/async-sandbox.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-sandbox.mdx
@@ -53,7 +53,7 @@ Represents a Daytona Sandbox.
 - `created_at` _str | None_ - When the Sandbox was created.
 - `updated_at` _str | None_ - When the Sandbox was last updated.
 - `last_activity_at` _str | None_ - When the Sandbox last had activity.
-- `expires_at` _str | None_ - When the Sandbox will expire and be destroyed (only set when a TTL
+- `auto_destroy_at` _str | None_ - When the Sandbox will be automatically destroyed (only set when a TTL
   is configured).
 - `network_block_all` _bool | None_ - Whether to block all network access for the Sandbox
   (not returned by list results; call `refresh_data()` on each item to populate).

--- a/artifacts/sdk-docs/python-sdk/sync/daytona.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/daytona.mdx
@@ -447,6 +447,9 @@ Base parameters for creating a new Sandbox.
 - `auto_delete_interval` _int | None_ - Interval in minutes after which a continuously stopped Sandbox will
   automatically be deleted. By default, auto-delete is disabled.
   Negative value means disabled, 0 means delete immediately upon stopping.
+- `ttl_minutes` _int | None_ - Maximum time to live in minutes, counted as wall-clock time since
+  creation regardless of sandbox state. When it elapses the sandbox is destroyed, even if
+  it is stopped, paused, or archived. 0 means disabled.
 - `volumes` _list[VolumeMount] | None_ - List of volumes mounts to attach to the Sandbox.
 - `secrets` _dict[str, str] | None_ - Map of environment variable name to the name of an existing
   organization Secret to mount into the Sandbox. The env var is set to the Secret's opaque

--- a/artifacts/sdk-docs/python-sdk/sync/sandbox.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/sandbox.mdx
@@ -53,6 +53,8 @@ Represents a Daytona Sandbox.
 - `created_at` _str | None_ - When the Sandbox was created.
 - `updated_at` _str | None_ - When the Sandbox was last updated.
 - `last_activity_at` _str | None_ - When the Sandbox last had activity.
+- `expires_at` _str | None_ - When the Sandbox will expire and be destroyed (only set when a TTL
+  is configured).
 - `network_block_all` _bool | None_ - Whether to block all network access for the Sandbox
   (not returned by list results; call `refresh_data()` on each item to populate).
 - `network_allow_list` _str | None_ - Comma-separated list of allowed CIDR network addresses for
@@ -503,6 +505,44 @@ Only supported for sandbox classes that support pausing.
 sandbox.set_auto_pause_interval(60)
 # Or disable auto-pause
 sandbox.set_auto_pause_interval(0)
+```
+
+#### Sandbox.set\_ttl
+
+```python
+@intercept_errors(message_prefix="Failed to set TTL: ")
+@with_instrumentation()
+def set_ttl(ttl_minutes: int, request_timeout: float | None = None) -> None
+```
+
+Sets the TTL (time to live) for the Sandbox.
+
+The Sandbox will be destroyed after the specified number of minutes, counted as
+wall-clock time from the current moment, regardless of its state (started, stopped,
+paused, or archived). Setting to 0 disables the TTL.
+
+**Arguments**:
+
+- `ttl_minutes` _int_ - Number of minutes until the Sandbox is destroyed.
+  Set to 0 to disable the TTL.
+- `request_timeout` _float | None_ - Optional client-side request timeout in seconds. Client-side
+  only. It bounds how long the SDK waits for the HTTP response and does not cancel
+  the operation on the server. Positive values under 1 second are rounded up to 1
+  second; 0 disables the client-side timeout and negative values are rejected.
+  
+
+**Raises**:
+
+- `DaytonaValidationError` - If ttl_minutes is negative
+  
+
+**Example**:
+
+```python
+# Set TTL to 1 hour
+sandbox.set_ttl(60)
+# Or disable TTL
+sandbox.set_ttl(0)
 ```
 
 #### Sandbox.set\_auto\_archive\_interval

--- a/artifacts/sdk-docs/python-sdk/sync/sandbox.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/sandbox.mdx
@@ -53,7 +53,7 @@ Represents a Daytona Sandbox.
 - `created_at` _str | None_ - When the Sandbox was created.
 - `updated_at` _str | None_ - When the Sandbox was last updated.
 - `last_activity_at` _str | None_ - When the Sandbox last had activity.
-- `expires_at` _str | None_ - When the Sandbox will expire and be destroyed (only set when a TTL
+- `auto_destroy_at` _str | None_ - When the Sandbox will be automatically destroyed (only set when a TTL
   is configured).
 - `network_block_all` _bool | None_ - Whether to block all network access for the Sandbox
   (not returned by list results; call `refresh_data()` on each item to populate).

--- a/artifacts/sdk-docs/ruby-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/ruby-sdk/daytona.mdx
@@ -146,7 +146,7 @@ Creates a sandbox with the specified parameters
 
 **Raises**:
 
-- `Daytona:Sdk:Error` - If auto_stop_interval, auto_pause_interval, or auto_archive_interval is negative,
+- `Daytona:Sdk:Error` - If auto_stop_interval, auto_pause_interval, auto_archive_interval, or ttl_minutes is negative,
 or if auto_stop_interval and auto_pause_interval are both non-zero
 
 #### delete()

--- a/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
@@ -322,16 +322,16 @@ def build_info()
 created from a dynamic build.
 Not returned by list results; call #refresh on each item to populate.
 
-#### expires_at()
+#### auto_destroy_at()
 
 ```ruby
-def expires_at()
+def auto_destroy_at()
 
 ```
 
 **Returns**:
 
-- `String, nil` - The expiration timestamp of the sandbox (nil if no TTL is set)
+- `String, nil` - When the sandbox will be automatically destroyed (nil if no TTL is set)
 
 #### created_at()
 

--- a/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
@@ -322,6 +322,17 @@ def build_info()
 created from a dynamic build.
 Not returned by list results; call #refresh on each item to populate.
 
+#### expires_at()
+
+```ruby
+def expires_at()
+
+```
+
+**Returns**:
+
+- `String, nil` - The expiration timestamp of the sandbox (nil if no TTL is set)
+
 #### created_at()
 
 ```ruby
@@ -614,6 +625,29 @@ Interactions using Sandbox Previews are not included.
 **Returns**:
 
 - `Integer`
+
+**Raises**:
+
+- `Daytona:Sdk:Error` -
+
+#### ttl_minutes=()
+
+```ruby
+def ttl_minutes=(minutes)
+
+```
+
+Sets the TTL (time to live) for the Sandbox.
+The TTL is re-anchored from the current time. When it elapses the Sandbox is destroyed,
+regardless of its current state. Use 0 to disable.
+
+**Parameters**:
+
+- `minutes` _Integer_ -
+
+**Returns**:
+
+- `void`
 
 **Raises**:
 

--- a/artifacts/sdk-docs/typescript-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/daytona.mdx
@@ -397,6 +397,7 @@ Base parameters for creating a new Sandbox.
 - `networkBlockAll?` _boolean_ - Whether to block all network access for the Sandbox
 - `public?` _boolean_ - Is the Sandbox port preview public
 - `secrets?` _Record\<string, string\>_ - Optional map of environment variable name to the name of an existing organization Secret to mount into the Sandbox. The env var is set to the Secret's opaque placeholder; the real value is substituted transparently on outbound requests to the Secret's allowed hosts. Every referenced Secret name must already exist in the organization.
+- `ttlMinutes?` _number_ - Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled). When it elapses the Sandbox is destroyed, even if it is stopped, paused, or archived.
 - `user?` _string_ - Optional os user to use for the Sandbox
 - `volumes?` _VolumeMount\[\]_ - Optional array of volumes to mount to the Sandbox
 ## CreateSandboxFromImageParams
@@ -424,6 +425,7 @@ Parameters for creating a new Sandbox.
 - `resources?` _Resources_ - Resource allocation for the Sandbox. If not provided, sandbox will
     have default resources.
 - `secrets?` _Record\<string, string\>_
+- `ttlMinutes?` _number_
 - `user?` _string_
 - `volumes?` _VolumeMount\[\]_
 ## CreateSandboxFromSnapshotParams
@@ -448,6 +450,7 @@ Parameters for creating a new Sandbox from a snapshot.
 - `public?` _boolean_
 - `secrets?` _Record\<string, string\>_
 - `snapshot?` _string_ - Name of the snapshot to use for the Sandbox.
+- `ttlMinutes?` _number_
 - `user?` _string_
 - `volumes?` _VolumeMount\[\]_
 ## DaytonaConfig

--- a/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
@@ -12,6 +12,7 @@ Represents a Daytona Sandbox.
 
 - `autoArchiveInterval?` _number_ - Auto-archive interval in minutes
 - `autoDeleteInterval?` _number_ - Auto-delete interval in minutes
+- `autoDestroyAt?` _string_ - When the Sandbox will be automatically destroyed (only set when a TTL is configured)
 - `autoPauseInterval?` _number_ - Auto-pause interval in minutes
 - `autoStopInterval?` _number_ - Auto-stop interval in minutes
 - `backupCreatedAt?` _string_ - When the backup was created (not returned by list results;
@@ -30,7 +31,6 @@ Represents a Daytona Sandbox.
 - `env?` _Record\<string, string\>_ - Environment variables set in the Sandbox
     (not returned by list results; call `refreshData()` on each item to populate)
 - `errorReason?` _string_ - Error message if Sandbox is in error state
-- `expiresAt?` _string_ - When the Sandbox will expire and be destroyed (only set when a TTL is configured)
 - `fs` _FileSystem_ - File system operations interface
 - `git` _Git_ - Git operations interface
 - `gpu` _number_ - Number of GPUs allocated to the Sandbox
@@ -816,7 +816,7 @@ Set the TTL (maximum time to live) for the Sandbox.
 
 The Sandbox will be destroyed once the TTL elapses, counted as wall-clock time regardless of the
 Sandbox state - even if it is stopped, paused, or archived. Calling this method re-anchors the
-deadline from the current time. Call `refreshData()` afterwards to read the updated `expiresAt`.
+deadline from the current time. Call `refreshData()` afterwards to read the updated `autoDestroyAt`.
 
 **Parameters**:
 

--- a/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
@@ -30,6 +30,7 @@ Represents a Daytona Sandbox.
 - `env?` _Record\<string, string\>_ - Environment variables set in the Sandbox
     (not returned by list results; call `refreshData()` on each item to populate)
 - `errorReason?` _string_ - Error message if Sandbox is in error state
+- `expiresAt?` _string_ - When the Sandbox will expire and be destroyed (only set when a TTL is configured)
 - `fs` _FileSystem_ - File system operations interface
 - `git` _Git_ - Git operations interface
 - `gpu` _number_ - Number of GPUs allocated to the Sandbox
@@ -801,6 +802,43 @@ await sandbox.setLabels({
   environment: 'development',
   team: 'backend'
 });
+```
+
+***
+
+#### setTtl()
+
+```ts
+setTtl(ttlMinutes: number): Promise<void>
+```
+
+Set the TTL (maximum time to live) for the Sandbox.
+
+The Sandbox will be destroyed once the TTL elapses, counted as wall-clock time regardless of the
+Sandbox state - even if it is stopped, paused, or archived. Calling this method re-anchors the
+deadline from the current time. Call `refreshData()` afterwards to read the updated `expiresAt`.
+
+**Parameters**:
+
+- `ttlMinutes` _number_ - Number of minutes from now after which the Sandbox will be destroyed.
+    Set to 0 to disable the TTL.
+
+
+**Returns**:
+
+- `Promise<void>`
+
+**Throws**:
+
+- `DaytonaError` - If ttlMinutes is not a non-negative integer
+
+**Example:**
+
+```ts
+// Destroy the Sandbox 1 hour from now
+await sandbox.setTtl(60);
+// Or disable the TTL
+await sandbox.setTtl(0);
 ```
 
 ***

--- a/cli/cmd/sandbox/create.go
+++ b/cli/cmd/sandbox/create.go
@@ -102,6 +102,12 @@ var CreateCmd = &cobra.Command{
 			createSandbox.SetAutoArchiveInterval(autoArchiveFlag)
 		}
 		createSandbox.SetAutoDeleteInterval(autoDeleteFlag)
+		if cmd.Flags().Changed("ttl") {
+			if ttlFlag < 0 {
+				return fmt.Errorf("ttl must be a non-negative integer")
+			}
+			createSandbox.SetTtlMinutes(ttlFlag)
+		}
 
 		createSandbox.SetNetworkBlockAll(networkBlockAllFlag)
 		if networkAllowListFlag != "" {
@@ -216,6 +222,7 @@ var (
 	autoPauseFlag        int32
 	autoArchiveFlag      int32
 	autoDeleteFlag       int32
+	ttlFlag              int32
 	volumesFlag          []string
 	dockerfileFlag       string
 	contextFlag          []string
@@ -239,6 +246,7 @@ func init() {
 	CreateCmd.Flags().Int32Var(&autoPauseFlag, "auto-pause", 60, "Auto-pause interval in minutes (0 means disabled). Only supported for sandbox classes that support pausing. Not allowed for ephemeral sandboxes. Mutually exclusive with --auto-stop")
 	CreateCmd.Flags().Int32Var(&autoArchiveFlag, "auto-archive", 10080, "Auto-archive interval in minutes (0 means the maximum interval will be used)")
 	CreateCmd.Flags().Int32Var(&autoDeleteFlag, "auto-delete", -1, "Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)")
+	CreateCmd.Flags().Int32Var(&ttlFlag, "ttl", 0, "Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived")
 	CreateCmd.Flags().StringArrayVarP(&volumesFlag, "volume", "v", []string{}, "Volumes to mount (format: VOLUME_ID_OR_NAME:MOUNT_PATH)")
 	CreateCmd.Flags().StringVarP(&dockerfileFlag, "dockerfile", "f", "", "Path to Dockerfile for Sandbox snapshot")
 	CreateCmd.Flags().StringArrayVarP(&contextFlag, "context", "c", []string{}, "Files or directories to include in the build context (can be specified multiple times)")

--- a/cli/mcp/tools/create_sandbox.go
+++ b/cli/mcp/tools/create_sandbox.go
@@ -30,6 +30,7 @@ type CreateSandboxArgs struct {
 	Memory              *int32                     `json:"memory,omitempty"`
 	Disk                *int32                     `json:"disk,omitempty"`
 	AutoStopInterval    *int32                     `json:"autoStopInterval,omitempty"`
+	TtlMinutes          *int32                     `json:"ttlMinutes,omitempty"`
 	AutoPauseInterval   *int32                     `json:"autoPauseInterval,omitempty"`
 	AutoArchiveInterval *int32                     `json:"autoArchiveInterval,omitempty"`
 	AutoDeleteInterval  *int32                     `json:"autoDeleteInterval,omitempty"`
@@ -55,6 +56,7 @@ func GetCreateSandboxTool() mcp.Tool {
 		mcp.WithNumber("memory", mcp.Description("Memory allocated to the sandbox in GB. Cannot specify sandbox resources when using a snapshot."), mcp.Max(8)),
 		mcp.WithNumber("disk", mcp.Description("Disk space allocated to the sandbox in GB. Cannot specify sandbox resources when using a snapshot."), mcp.Max(10)),
 		mcp.WithNumber("autoStopInterval", mcp.DefaultNumber(15), mcp.Min(0), mcp.Description("Auto-stop interval in minutes (0 means disabled) for the sandbox.")),
+		mcp.WithNumber("ttlMinutes", mcp.Min(0), mcp.Description("Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled) for the sandbox. When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived.")),
 		mcp.WithNumber("autoPauseInterval", mcp.Min(0), mcp.Description("Auto-pause interval in minutes (0 means disabled) for the sandbox. Only supported for sandbox classes that support pausing. Not allowed for ephemeral sandboxes. Mutually exclusive with autoStopInterval.")),
 		mcp.WithNumber("autoArchiveInterval", mcp.DefaultNumber(10080), mcp.Min(0), mcp.Description("Auto-archive interval in minutes (0 means the maximum interval will be used) for the sandbox.")),
 		mcp.WithNumber("autoDeleteInterval", mcp.DefaultNumber(-1), mcp.Description("Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping) for the sandbox.")),
@@ -153,6 +155,10 @@ func createSandboxRequest(args CreateSandboxArgs) (*apiclient.CreateSandbox, err
 		return nil, fmt.Errorf("autoStopInterval must be a non-negative integer")
 	}
 
+	if args.TtlMinutes != nil && *args.TtlMinutes < 0 {
+		return nil, fmt.Errorf("ttlMinutes must be a non-negative integer")
+	}
+
 	if args.AutoPauseInterval != nil && args.AutoStopInterval != nil && *args.AutoPauseInterval > 0 && *args.AutoStopInterval > 0 {
 		return nil, fmt.Errorf("autoStopInterval and autoPauseInterval are mutually exclusive. Set at most one of them to a non-zero value")
 	}
@@ -167,6 +173,10 @@ func createSandboxRequest(args CreateSandboxArgs) (*apiclient.CreateSandbox, err
 
 	if args.AutoStopInterval != nil {
 		createSandbox.SetAutoStopInterval(*args.AutoStopInterval)
+	}
+
+	if args.TtlMinutes != nil {
+		createSandbox.SetTtlMinutes(*args.TtlMinutes)
 	}
 
 	if args.AutoArchiveInterval != nil {

--- a/openapi-specs/api.json
+++ b/openapi-specs/api.json
@@ -4294,6 +4294,68 @@
         ]
       }
     },
+    "/sandbox/{sandboxIdOrName}/ttl/{ttlMinutes}": {
+      "post": {
+        "operationId": "setTtl",
+        "parameters": [
+          {
+            "name": "X-Daytona-Organization-ID",
+            "in": "header",
+            "description": "Use with JWT to specify the organization ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sandboxIdOrName",
+            "required": true,
+            "in": "path",
+            "description": "ID or name of the sandbox",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ttlMinutes",
+            "required": true,
+            "in": "path",
+            "description": "Maximum time to live in minutes, re-anchored from the current time (0 to disable). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "TTL has been set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Sandbox"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "oauth2": [
+              "openid",
+              "profile",
+              "email"
+            ]
+          }
+        ],
+        "summary": "Set sandbox TTL",
+        "tags": [
+          "sandbox"
+        ]
+      }
+    },
     "/sandbox/{sandboxIdOrName}/autoarchive/{interval}": {
       "post": {
         "operationId": "setAutoArchiveInterval",
@@ -12004,6 +12066,11 @@
             "description": "Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)",
             "example": 30
           },
+          "expiresAt": {
+            "type": "string",
+            "description": "When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)",
+            "example": "2026-07-15T12:00:00.000Z"
+          },
           "createdAt": {
             "type": "string",
             "description": "The creation timestamp of the sandbox",
@@ -12298,6 +12365,11 @@
             "description": "Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)",
             "example": 30
           },
+          "expiresAt": {
+            "type": "string",
+            "description": "When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)",
+            "example": "2026-07-15T12:00:00.000Z"
+          },
           "volumes": {
             "description": "Array of volumes attached to the sandbox",
             "type": "array",
@@ -12545,6 +12617,11 @@
             "type": "integer",
             "description": "Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)",
             "example": 30
+          },
+          "ttlMinutes": {
+            "type": "integer",
+            "description": "Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled). When it elapses the sandbox is destroyed, even if it is stopped, paused, or archived.",
+            "example": 1440
           },
           "volumes": {
             "description": "Array of volumes to attach to the sandbox",

--- a/openapi-specs/api.json
+++ b/openapi-specs/api.json
@@ -12066,9 +12066,9 @@
             "description": "Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)",
             "example": 30
           },
-          "expiresAt": {
+          "autoDestroyAt": {
             "type": "string",
-            "description": "When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)",
+            "description": "When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)",
             "example": "2026-07-15T12:00:00.000Z"
           },
           "createdAt": {
@@ -12365,9 +12365,9 @@
             "description": "Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)",
             "example": 30
           },
-          "expiresAt": {
+          "autoDestroyAt": {
             "type": "string",
-            "description": "When the sandbox will expire and be destroyed, regardless of its state (only set when a TTL is configured)",
+            "description": "When the sandbox will be automatically destroyed, regardless of its state (only set when a TTL is configured)",
             "example": "2026-07-15T12:00:00.000Z"
           },
           "volumes": {

--- a/sdk-go/pkg/daytona/client.go
+++ b/sdk-go/pkg/daytona/client.go
@@ -504,6 +504,9 @@ func (c *Client) doCreate(ctx context.Context, params any, opts ...func(*options
 	if baseParams.AutoArchiveInterval != nil && *baseParams.AutoArchiveInterval < 0 {
 		return nil, errors.NewDaytonaError("autoArchiveInterval must be a non-negative integer", 0, nil)
 	}
+	if baseParams.TtlMinutes != nil && *baseParams.TtlMinutes < 0 {
+		return nil, errors.NewDaytonaError("ttlMinutes must be a non-negative integer", 0, nil)
+	}
 
 	// Handle ephemeral sandboxes
 	if baseParams.Ephemeral {
@@ -549,6 +552,9 @@ func (c *Client) doCreate(ctx context.Context, params any, opts ...func(*options
 	}
 	if baseParams.AutoDeleteInterval != nil {
 		createReq.SetAutoDeleteInterval(int32(*baseParams.AutoDeleteInterval))
+	}
+	if baseParams.TtlMinutes != nil {
+		createReq.SetTtlMinutes(int32(*baseParams.TtlMinutes))
 	}
 	// Convert SDK VolumeMount to API SandboxVolume
 	if len(baseParams.Volumes) > 0 {

--- a/sdk-go/pkg/daytona/client_test.go
+++ b/sdk-go/pkg/daytona/client_test.go
@@ -529,6 +529,17 @@ func TestCreateValidation(t *testing.T) {
 			errorContains: "autoArchiveInterval must be a non-negative integer",
 		},
 		{
+			name: "invalid ttl minutes - negative",
+			params: types.ImageParams{
+				SandboxBaseParams: types.SandboxBaseParams{
+					TtlMinutes: intPtr(-1),
+				},
+				Image: "test-image",
+			},
+			expectedError: true,
+			errorContains: "ttlMinutes must be a non-negative integer",
+		},
+		{
 			name: "valid auto intervals",
 			params: types.ImageParams{
 				SandboxBaseParams: types.SandboxBaseParams{

--- a/sdk-go/pkg/daytona/sandbox.go
+++ b/sdk-go/pkg/daytona/sandbox.go
@@ -100,7 +100,7 @@ type Sandbox struct {
 	UpdatedAt      *string // When the sandbox was last updated
 	LastActivityAt *string // When the sandbox last had activity
 	ToolboxProxyUrl string  // Toolbox proxy URL for the sandbox
-	ExpiresAt      *string // When the sandbox expires (based on TTL)
+	AutoDestroyAt  *string // When the sandbox will be automatically destroyed (based on TTL)
 
 	// Env contains environment variables set in the sandbox.
 	// Not populated by [Client.List]; call [Sandbox.RefreshData] on each item to populate.
@@ -177,7 +177,7 @@ type sandboxDTO interface {
 	GetCreatedAt() string
 	GetUpdatedAt() string
 	GetLastActivityAt() string
-	GetExpiresAt() string
+	GetAutoDestroyAt() string
 	GetToolboxProxyUrl() string
 
 	// *Ok accessors used to distinguish unset optional fields from zero values.
@@ -192,7 +192,7 @@ type sandboxDTO interface {
 	GetCreatedAtOk() (*string, bool)
 	GetUpdatedAtOk() (*string, bool)
 	GetLastActivityAtOk() (*string, bool)
-	GetExpiresAtOk() (*string, bool)
+	GetAutoDestroyAtOk() (*string, bool)
 }
 
 // ListSandboxesQuery contains query parameters for filtering and sorting when listing sandboxes.
@@ -411,8 +411,8 @@ func (s *Sandbox) populateFromDTO(dto sandboxDTO) {
 	if v, ok := dto.GetLastActivityAtOk(); ok {
 		s.LastActivityAt = v
 	}
-	if v, ok := dto.GetExpiresAtOk(); ok {
-		s.ExpiresAt = v
+	if v, ok := dto.GetAutoDestroyAtOk(); ok {
+		s.AutoDestroyAt = v
 	}
 
 	// Fields only present on the full apiclient.Sandbox DTO (not returned by

--- a/sdk-go/pkg/daytona/sandbox.go
+++ b/sdk-go/pkg/daytona/sandbox.go
@@ -96,10 +96,11 @@ type Sandbox struct {
 	// Set to 0 to delete immediately upon stopping.
 	AutoDeleteInterval int
 
-	CreatedAt       *string // When the sandbox was created
-	UpdatedAt       *string // When the sandbox was last updated
-	LastActivityAt  *string // When the sandbox last had activity
+	CreatedAt      *string // When the sandbox was created
+	UpdatedAt      *string // When the sandbox was last updated
+	LastActivityAt *string // When the sandbox last had activity
 	ToolboxProxyUrl string  // Toolbox proxy URL for the sandbox
+	ExpiresAt      *string // When the sandbox expires (based on TTL)
 
 	// Env contains environment variables set in the sandbox.
 	// Not populated by [Client.List]; call [Sandbox.RefreshData] on each item to populate.
@@ -176,6 +177,7 @@ type sandboxDTO interface {
 	GetCreatedAt() string
 	GetUpdatedAt() string
 	GetLastActivityAt() string
+	GetExpiresAt() string
 	GetToolboxProxyUrl() string
 
 	// *Ok accessors used to distinguish unset optional fields from zero values.
@@ -190,6 +192,7 @@ type sandboxDTO interface {
 	GetCreatedAtOk() (*string, bool)
 	GetUpdatedAtOk() (*string, bool)
 	GetLastActivityAtOk() (*string, bool)
+	GetExpiresAtOk() (*string, bool)
 }
 
 // ListSandboxesQuery contains query parameters for filtering and sorting when listing sandboxes.
@@ -407,6 +410,9 @@ func (s *Sandbox) populateFromDTO(dto sandboxDTO) {
 	}
 	if v, ok := dto.GetLastActivityAtOk(); ok {
 		s.LastActivityAt = v
+	}
+	if v, ok := dto.GetExpiresAtOk(); ok {
+		s.ExpiresAt = v
 	}
 
 	// Fields only present on the full apiclient.Sandbox DTO (not returned by

--- a/sdk-go/pkg/daytona/sandbox.go
+++ b/sdk-go/pkg/daytona/sandbox.go
@@ -96,11 +96,11 @@ type Sandbox struct {
 	// Set to 0 to delete immediately upon stopping.
 	AutoDeleteInterval int
 
-	CreatedAt      *string // When the sandbox was created
-	UpdatedAt      *string // When the sandbox was last updated
-	LastActivityAt *string // When the sandbox last had activity
+	CreatedAt       *string // When the sandbox was created
+	UpdatedAt       *string // When the sandbox was last updated
+	LastActivityAt  *string // When the sandbox last had activity
 	ToolboxProxyUrl string  // Toolbox proxy URL for the sandbox
-	AutoDestroyAt  *string // When the sandbox will be automatically destroyed (based on TTL)
+	AutoDestroyAt   *string // When the sandbox will be automatically destroyed (based on TTL)
 
 	// Env contains environment variables set in the sandbox.
 	// Not populated by [Client.List]; call [Sandbox.RefreshData] on each item to populate.

--- a/sdk-go/pkg/daytona/sandbox.go
+++ b/sdk-go/pkg/daytona/sandbox.go
@@ -411,9 +411,8 @@ func (s *Sandbox) populateFromDTO(dto sandboxDTO) {
 	if v, ok := dto.GetLastActivityAtOk(); ok {
 		s.LastActivityAt = v
 	}
-	if v, ok := dto.GetAutoDestroyAtOk(); ok {
-		s.AutoDestroyAt = v
-	}
+	autoDestroyAt, _ := dto.GetAutoDestroyAtOk()
+	s.AutoDestroyAt = autoDestroyAt
 
 	// Fields only present on the full apiclient.Sandbox DTO (not returned by
 	// the list endpoint).

--- a/sdk-go/pkg/types/types.go
+++ b/sdk-go/pkg/types/types.go
@@ -96,6 +96,7 @@ type SandboxBaseParams struct {
 	AutoPauseInterval   *int // nil = server default when AutoStopInterval is also nil (60 for non-ephemeral pause-supporting classes, with auto-stop disabled), 0 = disabled. Only supported for sandbox classes that support pausing. Not allowed for ephemeral sandboxes. At most one of AutoPauseInterval and AutoStopInterval may be non-zero.
 	AutoArchiveInterval *int // nil = no auto-archive, 0 = immediate archive
 	AutoDeleteInterval  *int // nil = no auto-delete, 0 = immediate delete
+	TtlMinutes          *int // Wall-clock max lifetime in minutes; 0 disables TTL
 	Volumes             []VolumeMount
 	// Secrets maps an environment variable name to the name of an existing
 	// organization secret. For each entry, the env var is injected into the

--- a/sdk-java/src/main/java/io/daytona/sdk/Daytona.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Daytona.java
@@ -549,6 +549,10 @@ public class Daytona implements AutoCloseable {
             return body;
         }
 
+        if (params.getTtlMinutes() != null && params.getTtlMinutes() < 0) {
+            throw new IllegalArgumentException("ttlMinutes must be a non-negative integer");
+        }
+
         if (params.getName() != null) body.setName(params.getName());
         if (params.getUser() != null) body.setUser(params.getUser());
         if (params.getEnvVars() != null) body.setEnv(params.getEnvVars());
@@ -571,6 +575,7 @@ public class Daytona implements AutoCloseable {
         if (params.getAutoPauseInterval() != null) body.setAutoPauseInterval(params.getAutoPauseInterval());
         if (params.getAutoArchiveInterval() != null) body.setAutoArchiveInterval(params.getAutoArchiveInterval());
         if (params.getAutoDeleteInterval() != null) body.setAutoDeleteInterval(params.getAutoDeleteInterval());
+        if (params.getTtlMinutes() != null) body.setTtlMinutes(params.getTtlMinutes());
         if (params.getNetworkBlockAll() != null) body.setNetworkBlockAll(params.getNetworkBlockAll());
         if (params.getDomainAllowList() != null) body.setDomainAllowList(params.getDomainAllowList());
         if (params.getLinkedSandbox() != null) body.setLinkedSandbox(params.getLinkedSandbox());

--- a/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
@@ -470,9 +470,11 @@ public class Sandbox {
     }
 
     /**
-     * Sets Sandbox TTL (time to live) in minutes.
+     * Sets Sandbox TTL (time to live) in minutes. Set to 0 to disable the TTL.
+     * The deadline is computed server-side; call {@link #refreshData()} to read the updated
+     * {@code autoDestroyAt}.
      *
-     * @param ttlMinutes minutes until the Sandbox expires
+     * @param ttlMinutes minutes until the Sandbox is destroyed, or 0 to disable
      * @throws IllegalArgumentException if ttlMinutes is negative
      * @throws DaytonaException if the update fails
      */
@@ -480,10 +482,7 @@ public class Sandbox {
         if (ttlMinutes < 0) {
             throw new IllegalArgumentException("ttlMinutes must be a non-negative integer");
         }
-        io.daytona.api.client.model.Sandbox response = ExceptionMapper.callMain(() -> sandboxApi.setTtl(id, BigDecimal.valueOf(ttlMinutes), null));
-        if (response != null) {
-            populateFromDTO(response);
-        }
+        ExceptionMapper.callMain(() -> sandboxApi.setTtl(id, BigDecimal.valueOf(ttlMinutes), null));
     }
 
     /**

--- a/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
@@ -151,6 +151,7 @@ public class Sandbox {
     private String createdAt;
     private String updatedAt;
     private String lastActivityAt;
+    private String expiresAt;
     private String toolboxProxyUrl;
 
     // Fields only present on the full Sandbox DTO; not populated by Daytona.list() —
@@ -469,6 +470,23 @@ public class Sandbox {
     }
 
     /**
+     * Sets Sandbox TTL (time to live) in minutes.
+     *
+     * @param ttlMinutes minutes until the Sandbox expires
+     * @throws IllegalArgumentException if ttlMinutes is negative
+     * @throws DaytonaException if the update fails
+     */
+    public void setTtl(int ttlMinutes) {
+        if (ttlMinutes < 0) {
+            throw new IllegalArgumentException("ttlMinutes must be a non-negative integer");
+        }
+        io.daytona.api.client.model.Sandbox response = ExceptionMapper.callMain(() -> sandboxApi.setTtl(id, BigDecimal.valueOf(ttlMinutes), null));
+        if (response != null) {
+            populateFromDTO(response);
+        }
+    }
+
+    /**
      * Updates outbound network policy on the runner (block all, restore access, or CIDR allow list).
      *
      * @param settings request body; at least one of networkBlockAll or networkAllowList must be set
@@ -743,7 +761,7 @@ public class Sandbox {
                 d.getErrorReason(), d.getRecoverable(),
                 d.getBackupState() == null ? null : d.getBackupState().getValue(),
                 d.getAutoStopInterval(), d.getAutoPauseInterval(), d.getAutoArchiveInterval(), d.getAutoDeleteInterval(),
-                d.getCreatedAt(), d.getUpdatedAt(), d.getLastActivityAt(),
+                d.getCreatedAt(), d.getUpdatedAt(), d.getLastActivityAt(), d.getExpiresAt(),
                 d.getToolboxProxyUrl()
         );
 
@@ -776,7 +794,7 @@ public class Sandbox {
                 d.getErrorReason(), d.getRecoverable(),
                 d.getBackupState() == null ? null : d.getBackupState().getValue(),
                 d.getAutoStopInterval(), d.getAutoPauseInterval(), d.getAutoArchiveInterval(), d.getAutoDeleteInterval(),
-                d.getCreatedAt(), d.getUpdatedAt(), d.getLastActivityAt(),
+                d.getCreatedAt(), d.getUpdatedAt(), d.getLastActivityAt(), d.getExpiresAt(),
                 d.getToolboxProxyUrl()
         );
 
@@ -792,7 +810,7 @@ public class Sandbox {
             BigDecimal cpu, BigDecimal gpu, BigDecimal memory, BigDecimal disk,
             String errorReason, Boolean recoverable, String backupState,
             BigDecimal autoStopInterval, BigDecimal autoPauseInterval, BigDecimal autoArchiveInterval, BigDecimal autoDeleteInterval,
-            String createdAt, String updatedAt, String lastActivityAt,
+            String createdAt, String updatedAt, String lastActivityAt, String expiresAt,
             String toolboxProxyUrl) {
         this.id = asString(id);
         this.name = asString(name);
@@ -821,6 +839,7 @@ public class Sandbox {
             this.toolboxApiClient.setBasePath(trimTrailingSlash(newProxyUrl) + "/" + this.id);
         }
         this.toolboxProxyUrl = newProxyUrl;
+        this.expiresAt = expiresAt;
     }
 
     private void applyState(String newState) {
@@ -1218,6 +1237,8 @@ public class Sandbox {
     public String getUpdatedAt() { return updatedAt; }
     /** @return when the Sandbox last had activity, or {@code null}. */
     public String getLastActivityAt() { return lastActivityAt; }
+    /** @return when the Sandbox expires, or {@code null} if no TTL is set. */
+    public String getExpiresAt() { return expiresAt; }
     /** @return toolbox proxy URL. */
     public String getToolboxProxyUrl() { return toolboxProxyUrl; }
 

--- a/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
@@ -471,8 +471,8 @@ public class Sandbox {
 
     /**
      * Sets Sandbox TTL (time to live) in minutes. Set to 0 to disable the TTL.
-     * The deadline is computed server-side; call {@link #refreshData()} to read the updated
-     * {@code autoDestroyAt}.
+     * The deadline is computed server-side; call {@link #refreshData()} and read the updated
+     * value via {@link #getAutoDestroyAt()}.
      *
      * @param ttlMinutes minutes until the Sandbox is destroyed, or 0 to disable
      * @throws IllegalArgumentException if ttlMinutes is negative

--- a/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
@@ -151,7 +151,7 @@ public class Sandbox {
     private String createdAt;
     private String updatedAt;
     private String lastActivityAt;
-    private String expiresAt;
+    private String autoDestroyAt;
     private String toolboxProxyUrl;
 
     // Fields only present on the full Sandbox DTO; not populated by Daytona.list() —
@@ -761,7 +761,7 @@ public class Sandbox {
                 d.getErrorReason(), d.getRecoverable(),
                 d.getBackupState() == null ? null : d.getBackupState().getValue(),
                 d.getAutoStopInterval(), d.getAutoPauseInterval(), d.getAutoArchiveInterval(), d.getAutoDeleteInterval(),
-                d.getCreatedAt(), d.getUpdatedAt(), d.getLastActivityAt(), d.getExpiresAt(),
+                d.getCreatedAt(), d.getUpdatedAt(), d.getLastActivityAt(), d.getAutoDestroyAt(),
                 d.getToolboxProxyUrl()
         );
 
@@ -794,7 +794,7 @@ public class Sandbox {
                 d.getErrorReason(), d.getRecoverable(),
                 d.getBackupState() == null ? null : d.getBackupState().getValue(),
                 d.getAutoStopInterval(), d.getAutoPauseInterval(), d.getAutoArchiveInterval(), d.getAutoDeleteInterval(),
-                d.getCreatedAt(), d.getUpdatedAt(), d.getLastActivityAt(), d.getExpiresAt(),
+                d.getCreatedAt(), d.getUpdatedAt(), d.getLastActivityAt(), d.getAutoDestroyAt(),
                 d.getToolboxProxyUrl()
         );
 
@@ -810,7 +810,7 @@ public class Sandbox {
             BigDecimal cpu, BigDecimal gpu, BigDecimal memory, BigDecimal disk,
             String errorReason, Boolean recoverable, String backupState,
             BigDecimal autoStopInterval, BigDecimal autoPauseInterval, BigDecimal autoArchiveInterval, BigDecimal autoDeleteInterval,
-            String createdAt, String updatedAt, String lastActivityAt, String expiresAt,
+            String createdAt, String updatedAt, String lastActivityAt, String autoDestroyAt,
             String toolboxProxyUrl) {
         this.id = asString(id);
         this.name = asString(name);
@@ -839,7 +839,7 @@ public class Sandbox {
             this.toolboxApiClient.setBasePath(trimTrailingSlash(newProxyUrl) + "/" + this.id);
         }
         this.toolboxProxyUrl = newProxyUrl;
-        this.expiresAt = expiresAt;
+        this.autoDestroyAt = autoDestroyAt;
     }
 
     private void applyState(String newState) {
@@ -1238,7 +1238,7 @@ public class Sandbox {
     /** @return when the Sandbox last had activity, or {@code null}. */
     public String getLastActivityAt() { return lastActivityAt; }
     /** @return when the Sandbox expires, or {@code null} if no TTL is set. */
-    public String getExpiresAt() { return expiresAt; }
+    public String getAutoDestroyAt() { return autoDestroyAt; }
     /** @return toolbox proxy URL. */
     public String getToolboxProxyUrl() { return toolboxProxyUrl; }
 

--- a/sdk-java/src/main/java/io/daytona/sdk/model/CreateSandboxParams.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/model/CreateSandboxParams.java
@@ -26,6 +26,7 @@ public class CreateSandboxParams {
     private Integer autoPauseInterval;
     private Integer autoArchiveInterval;
     private Integer autoDeleteInterval;
+    private Integer ttlMinutes;
     private List<VolumeMount> volumes;
     private Map<String, String> secrets;
     private Boolean networkBlockAll;
@@ -177,6 +178,20 @@ public class CreateSandboxParams {
      * @param autoDeleteInterval deletion delay in minutes
      */
     public void setAutoDeleteInterval(Integer autoDeleteInterval) { this.autoDeleteInterval = autoDeleteInterval; }
+
+    /**
+     * Returns TTL (time to live) in minutes.
+     *
+     * @return minutes until the Sandbox expires, or {@code null} if unset
+     */
+    public Integer getTtlMinutes() { return ttlMinutes; }
+
+    /**
+     * Sets TTL (time to live) in minutes.
+     *
+     * @param ttlMinutes minutes until the Sandbox expires
+     */
+    public void setTtlMinutes(Integer ttlMinutes) { this.ttlMinutes = ttlMinutes; }
 
     /**
      * Returns volume mounts to attach.

--- a/sdk-java/src/test/java/io/daytona/sdk/DaytonaTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/DaytonaTest.java
@@ -343,6 +343,30 @@ class DaytonaTest {
     }
 
     @Test
+    void createFromSnapshotRejectsNegativeTtlMinutes() {
+        CreateSandboxFromSnapshotParams params = new CreateSandboxFromSnapshotParams();
+        params.setTtlMinutes(-1);
+
+        assertThatThrownBy(() -> daytona.create(params, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ttlMinutes must be a non-negative integer");
+    }
+
+    @Test
+    void createFromSnapshotWiresTtlMinutesToBody() {
+        when(sandboxApi.createSandbox(any(), isNull())).thenReturn(TestSupport.mainSandbox("sb-ttl", SandboxState.STARTED));
+
+        CreateSandboxFromSnapshotParams params = new CreateSandboxFromSnapshotParams();
+        params.setTtlMinutes(30);
+
+        daytona.create(params, 1);
+
+        ArgumentCaptor<CreateSandbox> captor = ArgumentCaptor.forClass(CreateSandbox.class);
+        org.mockito.Mockito.verify(sandboxApi).createSandbox(captor.capture(), isNull());
+        assertThat(captor.getValue().getTtlMinutes()).isEqualTo(30);
+    }
+
+    @Test
     void createFromImageWithoutImageLeavesBuildInfoUnset() {
         when(sandboxApi.createSandbox(any(), isNull())).thenReturn(TestSupport.mainSandbox("sb-10", SandboxState.STARTED));
         when(sandboxApi.getSandbox("sb-10", null, null)).thenReturn(TestSupport.mainSandbox("sb-10", SandboxState.STARTED));

--- a/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
@@ -259,6 +259,27 @@ class SandboxTest {
     }
 
     @Test
+    void setTtlCallsApiAndRejectsNegative() {
+        sandbox.setTtl(60);
+
+        verify(sandboxApi).setTtl("sb-1", BigDecimal.valueOf(60), null);
+
+        assertThatThrownBy(() -> sandbox.setTtl(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ttlMinutes must be a non-negative integer");
+    }
+
+    @Test
+    void expiresAtIsPopulatedFromDTO() {
+        io.daytona.api.client.model.Sandbox model = TestSupport.mainSandbox("sb-exp", SandboxState.STARTED);
+        model.setExpiresAt("2026-09-15T12:00:00Z");
+
+        Sandbox loaded = new Sandbox(sandboxApi, TestSupport.config(), model, () -> null);
+
+        assertThat(loaded.getExpiresAt()).isEqualTo("2026-09-15T12:00:00Z");
+    }
+
+    @Test
     void updateSecretsSendsSingletonMapListAndUpdatesLocalState() {
         io.daytona.api.client.model.Sandbox refreshed = TestSupport.mainSandbox("sb-1", SandboxState.STARTED);
         refreshed.setLabels(Collections.singletonMap("team", "sdk"));

--- a/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
@@ -274,7 +274,7 @@ class SandboxTest {
         io.daytona.api.client.model.Sandbox model = TestSupport.mainSandbox("sb-exp", SandboxState.STARTED);
         model.setAutoDestroyAt("2026-09-15T12:00:00Z");
 
-        Sandbox loaded = new Sandbox(sandboxApi, TestSupport.config(), model, () -> null);
+        Sandbox loaded = new Sandbox(sandboxApi, TestSupport.config(), model, () -> null, mockSubscriptionManager());
 
         assertThat(loaded.getAutoDestroyAt()).isEqualTo("2026-09-15T12:00:00Z");
     }

--- a/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
@@ -270,13 +270,13 @@ class SandboxTest {
     }
 
     @Test
-    void expiresAtIsPopulatedFromDTO() {
+    void autoDestroyAtIsPopulatedFromDTO() {
         io.daytona.api.client.model.Sandbox model = TestSupport.mainSandbox("sb-exp", SandboxState.STARTED);
-        model.setExpiresAt("2026-09-15T12:00:00Z");
+        model.setAutoDestroyAt("2026-09-15T12:00:00Z");
 
         Sandbox loaded = new Sandbox(sandboxApi, TestSupport.config(), model, () -> null);
 
-        assertThat(loaded.getExpiresAt()).isEqualTo("2026-09-15T12:00:00Z");
+        assertThat(loaded.getAutoDestroyAt()).isEqualTo("2026-09-15T12:00:00Z");
     }
 
     @Test

--- a/sdk-python/src/daytona/_async/daytona.py
+++ b/sdk-python/src/daytona/_async/daytona.py
@@ -602,6 +602,9 @@ class AsyncDaytona:
         if params.auto_archive_interval is not None and params.auto_archive_interval < 0:
             raise DaytonaValidationError("auto_archive_interval must be a non-negative integer")
 
+        if params.ttl_minutes is not None and params.ttl_minutes < 0:
+            raise DaytonaValidationError("ttl_minutes must be a non-negative integer")
+
         target = self._target
 
         volumes = []
@@ -627,6 +630,7 @@ class AsyncDaytona:
             auto_pause_interval=params.auto_pause_interval,
             auto_archive_interval=params.auto_archive_interval,
             auto_delete_interval=params.auto_delete_interval,
+            ttl_minutes=params.ttl_minutes,
             volumes=volumes,
             secrets=secrets,
             network_block_all=params.network_block_all,

--- a/sdk-python/src/daytona/_async/sandbox.py
+++ b/sdk-python/src/daytona/_async/sandbox.py
@@ -148,6 +148,8 @@ class AsyncSandbox(SandboxDto):
         created_at (str | None): When the Sandbox was created.
         updated_at (str | None): When the Sandbox was last updated.
         last_activity_at (str | None): When the Sandbox last had activity.
+        expires_at (str | None): When the Sandbox will expire and be destroyed (only set when a TTL
+            is configured).
         network_block_all (bool | None): Whether to block all network access for the Sandbox
             (not returned by list results; call `refresh_data()` on each item to populate).
         network_allow_list (str | None): Comma-separated list of allowed CIDR network addresses for
@@ -649,6 +651,39 @@ class AsyncSandbox(SandboxDto):
 
         _ = await self._sandbox_api.set_auto_pause_interval(self.id, interval)
         self.auto_pause_interval = interval
+
+    @intercept_errors(message_prefix="Failed to set TTL: ")
+    @with_instrumentation()
+    async def set_ttl(self, ttl_minutes: int, request_timeout: float | None = None) -> None:
+        """Sets the TTL (time to live) for the Sandbox.
+
+        The Sandbox will be destroyed after the specified number of minutes, counted as
+        wall-clock time from the current moment, regardless of its state (started, stopped,
+        paused, or archived). Setting to 0 disables the TTL.
+
+        Args:
+            ttl_minutes (int): Number of minutes until the Sandbox is destroyed.
+                Set to 0 to disable the TTL.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
+
+        Raises:
+            DaytonaValidationError: If ttl_minutes is negative
+
+        Example:
+            ```python
+            # Set TTL to 1 hour
+            await sandbox.set_ttl(60)
+            # Or disable TTL
+            await sandbox.set_ttl(0)
+            ```
+        """
+        if ttl_minutes < 0:
+            raise DaytonaValidationError("TTL must be a non-negative integer")
+
+        _ = await self._sandbox_api.set_ttl(self.id, ttl_minutes, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to set auto-archive interval: ")
     @with_instrumentation()
@@ -1306,6 +1341,7 @@ class AsyncSandbox(SandboxDto):
             if new_proxy_url != self.toolbox_proxy_url and hasattr(self, "_toolbox_api"):
                 self._toolbox_api._toolbox_base_url = new_proxy_url
             self.toolbox_proxy_url: str = new_proxy_url
+        self.expires_at: str | None = sandbox_dto.expires_at
 
         # Fields only present in the full SandboxDto (not returned by list results
         if isinstance(sandbox_dto, SandboxDto):

--- a/sdk-python/src/daytona/_async/sandbox.py
+++ b/sdk-python/src/daytona/_async/sandbox.py
@@ -148,7 +148,7 @@ class AsyncSandbox(SandboxDto):
         created_at (str | None): When the Sandbox was created.
         updated_at (str | None): When the Sandbox was last updated.
         last_activity_at (str | None): When the Sandbox last had activity.
-        expires_at (str | None): When the Sandbox will expire and be destroyed (only set when a TTL
+        auto_destroy_at (str | None): When the Sandbox will be automatically destroyed (only set when a TTL
             is configured).
         network_block_all (bool | None): Whether to block all network access for the Sandbox
             (not returned by list results; call `refresh_data()` on each item to populate).
@@ -1341,7 +1341,7 @@ class AsyncSandbox(SandboxDto):
             if new_proxy_url != self.toolbox_proxy_url and hasattr(self, "_toolbox_api"):
                 self._toolbox_api._toolbox_base_url = new_proxy_url
             self.toolbox_proxy_url: str = new_proxy_url
-        self.expires_at: str | None = sandbox_dto.expires_at
+        self.auto_destroy_at: str | None = sandbox_dto.auto_destroy_at
 
         # Fields only present in the full SandboxDto (not returned by list results
         if isinstance(sandbox_dto, SandboxDto):

--- a/sdk-python/src/daytona/_sync/daytona.py
+++ b/sdk-python/src/daytona/_sync/daytona.py
@@ -469,6 +469,9 @@ class Daytona:
         if params.auto_archive_interval is not None and params.auto_archive_interval < 0:
             raise DaytonaValidationError("auto_archive_interval must be a non-negative integer")
 
+        if params.ttl_minutes is not None and params.ttl_minutes < 0:
+            raise DaytonaValidationError("ttl_minutes must be a non-negative integer")
+
         target = self._target
 
         volumes = []
@@ -494,6 +497,7 @@ class Daytona:
             auto_pause_interval=params.auto_pause_interval,
             auto_archive_interval=params.auto_archive_interval,
             auto_delete_interval=params.auto_delete_interval,
+            ttl_minutes=params.ttl_minutes,
             volumes=volumes,
             secrets=secrets,
             network_block_all=params.network_block_all,

--- a/sdk-python/src/daytona/_sync/sandbox.py
+++ b/sdk-python/src/daytona/_sync/sandbox.py
@@ -131,7 +131,7 @@ class Sandbox(SandboxDto):
         created_at (str | None): When the Sandbox was created.
         updated_at (str | None): When the Sandbox was last updated.
         last_activity_at (str | None): When the Sandbox last had activity.
-        expires_at (str | None): When the Sandbox will expire and be destroyed (only set when a TTL
+        auto_destroy_at (str | None): When the Sandbox will be automatically destroyed (only set when a TTL
             is configured).
         network_block_all (bool | None): Whether to block all network access for the Sandbox
             (not returned by list results; call `refresh_data()` on each item to populate).
@@ -1331,7 +1331,7 @@ class Sandbox(SandboxDto):
             if new_proxy_url != self.toolbox_proxy_url and hasattr(self, "_toolbox_api"):
                 self._toolbox_api._toolbox_base_url = new_proxy_url
             self.toolbox_proxy_url: str = new_proxy_url
-        self.expires_at: str | None = sandbox_dto.expires_at
+        self.auto_destroy_at: str | None = sandbox_dto.auto_destroy_at
 
         # Fields only present in the full SandboxDto (not returned by list results
         if isinstance(sandbox_dto, SandboxDto):

--- a/sdk-python/src/daytona/_sync/sandbox.py
+++ b/sdk-python/src/daytona/_sync/sandbox.py
@@ -131,6 +131,8 @@ class Sandbox(SandboxDto):
         created_at (str | None): When the Sandbox was created.
         updated_at (str | None): When the Sandbox was last updated.
         last_activity_at (str | None): When the Sandbox last had activity.
+        expires_at (str | None): When the Sandbox will expire and be destroyed (only set when a TTL
+            is configured).
         network_block_all (bool | None): Whether to block all network access for the Sandbox
             (not returned by list results; call `refresh_data()` on each item to populate).
         network_allow_list (str | None): Comma-separated list of allowed CIDR network addresses for
@@ -636,6 +638,39 @@ class Sandbox(SandboxDto):
 
         _ = self._sandbox_api.set_auto_pause_interval(self.id, interval)
         self.auto_pause_interval = interval
+
+    @intercept_errors(message_prefix="Failed to set TTL: ")
+    @with_instrumentation()
+    def set_ttl(self, ttl_minutes: int, request_timeout: float | None = None) -> None:
+        """Sets the TTL (time to live) for the Sandbox.
+
+        The Sandbox will be destroyed after the specified number of minutes, counted as
+        wall-clock time from the current moment, regardless of its state (started, stopped,
+        paused, or archived). Setting to 0 disables the TTL.
+
+        Args:
+            ttl_minutes (int): Number of minutes until the Sandbox is destroyed.
+                Set to 0 to disable the TTL.
+            request_timeout (float | None): Optional client-side request timeout in seconds. Client-side
+                only. It bounds how long the SDK waits for the HTTP response and does not cancel
+                the operation on the server. Positive values under 1 second are rounded up to 1
+                second; 0 disables the client-side timeout and negative values are rejected.
+
+        Raises:
+            DaytonaValidationError: If ttl_minutes is negative
+
+        Example:
+            ```python
+            # Set TTL to 1 hour
+            sandbox.set_ttl(60)
+            # Or disable TTL
+            sandbox.set_ttl(0)
+            ```
+        """
+        if ttl_minutes < 0:
+            raise DaytonaValidationError("TTL must be a non-negative integer")
+
+        _ = self._sandbox_api.set_ttl(self.id, ttl_minutes, _request_timeout=http_timeout(request_timeout))
 
     @intercept_errors(message_prefix="Failed to set auto-archive interval: ")
     @with_instrumentation()
@@ -1296,6 +1331,7 @@ class Sandbox(SandboxDto):
             if new_proxy_url != self.toolbox_proxy_url and hasattr(self, "_toolbox_api"):
                 self._toolbox_api._toolbox_base_url = new_proxy_url
             self.toolbox_proxy_url: str = new_proxy_url
+        self.expires_at: str | None = sandbox_dto.expires_at
 
         # Fields only present in the full SandboxDto (not returned by list results
         if isinstance(sandbox_dto, SandboxDto):

--- a/sdk-python/src/daytona/common/daytona.py
+++ b/sdk-python/src/daytona/common/daytona.py
@@ -157,6 +157,9 @@ class CreateSandboxBaseParams(BaseModel):
         auto_delete_interval (int | None): Interval in minutes after which a continuously stopped Sandbox will
             automatically be deleted. By default, auto-delete is disabled.
             Negative value means disabled, 0 means delete immediately upon stopping.
+        ttl_minutes (int | None): Maximum time to live in minutes, counted as wall-clock time since
+            creation regardless of sandbox state. When it elapses the sandbox is destroyed, even if
+            it is stopped, paused, or archived. 0 means disabled.
         volumes (list[VolumeMount] | None): List of volumes mounts to attach to the Sandbox.
         secrets (dict[str, str] | None): Map of environment variable name to the name of an existing
             organization Secret to mount into the Sandbox. The env var is set to the Secret's opaque
@@ -184,6 +187,7 @@ class CreateSandboxBaseParams(BaseModel):
     auto_pause_interval: int | None = None
     auto_archive_interval: int | None = None
     auto_delete_interval: int | None = None
+    ttl_minutes: int | None = None
     volumes: list[VolumeMount] | None = None
     secrets: dict[str, str] | None = None
     network_block_all: bool | None = None

--- a/sdk-python/tests/conftest.py
+++ b/sdk-python/tests/conftest.py
@@ -73,6 +73,7 @@ def make_sandbox_dto(
         network_block_all=cast(bool, kwargs.get("network_block_all", False)),
         network_allow_list=cast(str | None, kwargs.get("network_allow_list", None)),
         domain_allow_list=cast(str | None, kwargs.get("domain_allow_list", None)),
+        expires_at=cast(str | None, kwargs.get("expires_at", None)),
         toolbox_proxy_url=cast(str, kwargs.get("toolbox_proxy_url", "http://localhost:2280")),
     )
 

--- a/sdk-python/tests/conftest.py
+++ b/sdk-python/tests/conftest.py
@@ -73,7 +73,7 @@ def make_sandbox_dto(
         network_block_all=cast(bool, kwargs.get("network_block_all", False)),
         network_allow_list=cast(str | None, kwargs.get("network_allow_list", None)),
         domain_allow_list=cast(str | None, kwargs.get("domain_allow_list", None)),
-        expires_at=cast(str | None, kwargs.get("expires_at", None)),
+        auto_destroy_at=cast(str | None, kwargs.get("auto_destroy_at", None)),
         toolbox_proxy_url=cast(str, kwargs.get("toolbox_proxy_url", "http://localhost:2280")),
     )
 

--- a/sdk-python/tests/test_async_sandbox.py
+++ b/sdk-python/tests/test_async_sandbox.py
@@ -108,6 +108,19 @@ class TestAsyncSandboxLifecycleSettings:
         await sandbox.set_auto_delete_interval(120)
         assert sandbox.auto_delete_interval == 120
 
+    @pytest.mark.asyncio
+    async def test_negative_ttl_raises(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        with pytest.raises(DaytonaValidationError, match="TTL must be a non-negative"):
+            await sandbox.set_ttl(-1)
+
+    @pytest.mark.asyncio
+    async def test_valid_ttl_calls_api(self, sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        sandbox = make_async_sandbox(sandbox_dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+        mock_async_sandbox_api.set_ttl = AsyncMock(return_value=None)
+        await sandbox.set_ttl(60)
+        mock_async_sandbox_api.set_ttl.assert_called_once_with(sandbox.id, 60, _request_timeout=None)
+
 
 class TestAsyncSandboxOperations:
     @pytest.mark.asyncio

--- a/sdk-python/tests/test_daytona.py
+++ b/sdk-python/tests/test_daytona.py
@@ -176,6 +176,11 @@ class TestDaytonaCreateValidation:
                 timeout=60,
             )
 
+    def test_negative_ttl_raises(self, env_with_api_key):
+        daytona = _make_daytona()
+        with pytest.raises(DaytonaValidationError, match="ttl_minutes must be a non-negative"):
+            daytona._create(CreateSandboxFromSnapshotParams(language="python", ttl_minutes=-1), timeout=60)
+
     def test_negative_auto_archive_raises(self, env_with_api_key):
         daytona = _make_daytona()
         with pytest.raises(DaytonaValidationError, match="auto_archive_interval must be a non-negative"):

--- a/sdk-python/tests/test_sandbox.py
+++ b/sdk-python/tests/test_sandbox.py
@@ -95,6 +95,16 @@ class TestSandboxLifecycleSettings:
         sandbox.set_auto_delete_interval(-1)
         assert sandbox.auto_delete_interval == -1
 
+    def test_negative_ttl_raises(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+        sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
+        with pytest.raises(DaytonaValidationError, match="TTL must be a non-negative"):
+            sandbox.set_ttl(-1)
+
+    def test_valid_ttl_calls_api(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):
+        sandbox = make_sandbox(sandbox_dto, mock_toolbox_api_client, mock_sandbox_api)
+        sandbox.set_ttl(60)
+        mock_sandbox_api.set_ttl.assert_called_once_with(sandbox.id, 60, _request_timeout=None)
+
 
 class TestSandboxOperations:
     def test_set_labels(self, sandbox_dto, mock_toolbox_api_client, mock_sandbox_api):

--- a/sdk-ruby/lib/daytona/common/daytona.rb
+++ b/sdk-ruby/lib/daytona/common/daytona.rb
@@ -56,6 +56,9 @@ module Daytona
     # @return [String, nil] Comma-separated list of allowed domains for the Sandbox
     attr_accessor :domain_allow_list
 
+    # @return [Integer, nil] Time to live in minutes (0 to disable)
+    attr_accessor :ttl_minutes
+
     # @return [Boolean, nil] Whether the Sandbox should be ephemeral
     attr_accessor :ephemeral
 
@@ -83,6 +86,7 @@ module Daytona
     # @param network_block_all [Boolean, nil] Whether to block all network access for the Sandbox
     # @param network_allow_list [String, nil] Comma-separated list of allowed CIDR network addresses for the Sandbox
     # @param domain_allow_list [String, nil] Comma-separated list of allowed domains for the Sandbox
+    # @param ttl_minutes [Integer, nil] Time to live in minutes (0 to disable)
     # @param ephemeral [Boolean, nil] Whether the Sandbox should be ephemeral
     # @param linked_sandbox [String, nil] ID or name of an existing Sandbox to link the new Sandbox to
     def initialize( # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
@@ -96,6 +100,7 @@ module Daytona
       auto_pause_interval: nil,
       auto_archive_interval: nil,
       auto_delete_interval: nil,
+      ttl_minutes: nil,
       volumes: nil,
       secrets: nil,
       network_block_all: nil,
@@ -114,6 +119,7 @@ module Daytona
       @auto_pause_interval = auto_pause_interval
       @auto_archive_interval = auto_archive_interval
       @auto_delete_interval = auto_delete_interval
+      @ttl_minutes = ttl_minutes
       @volumes = volumes
       @secrets = secrets
       @network_block_all = network_block_all
@@ -141,6 +147,7 @@ module Daytona
         auto_pause_interval:,
         auto_archive_interval:,
         auto_delete_interval:,
+        ttl_minutes:,
         volumes:,
         secrets:,
         network_block_all:,
@@ -193,6 +200,7 @@ module Daytona
     # @param auto_pause_interval [Integer, nil] Auto-pause interval in minutes
     # @param auto_archive_interval [Integer, nil] Auto-archive interval in minutes
     # @param auto_delete_interval [Integer, nil] Auto-delete interval in minutes
+    # @param ttl_minutes [Integer, nil] Time to live in minutes (0 to disable)
     # @param volumes [Array<DaytonaApiClient::SandboxVolume>, nil] List of volumes mounts to attach to the Sandbox
     # @param secrets [Hash<String, String>, nil] Organization Secrets to expose in the Sandbox, as a
     #   mapping of env var name to existing Secret name
@@ -235,6 +243,7 @@ module Daytona
     # @param auto_pause_interval [Integer, nil] Auto-pause interval in minutes
     # @param auto_archive_interval [Integer, nil] Auto-archive interval in minutes
     # @param auto_delete_interval [Integer, nil] Auto-delete interval in minutes
+    # @param ttl_minutes [Integer, nil] Time to live in minutes (0 to disable)
     # @param volumes [Array<DaytonaApiClient::SandboxVolume>, nil] List of volumes mounts to attach to the Sandbox
     # @param secrets [Hash<String, String>, nil] Organization Secrets to expose in the Sandbox, as a
     #   mapping of env var name to existing Secret name

--- a/sdk-ruby/lib/daytona/daytona.rb
+++ b/sdk-ruby/lib/daytona/daytona.rb
@@ -99,7 +99,7 @@ module Daytona
     #
     # @param params [Daytona::CreateSandboxFromSnapshotParams, Daytona::CreateSandboxFromImageParams, Nil] Sandbox creation parameters
     # @return [Daytona::Sandbox] The created sandbox
-    # @raise [Daytona::Sdk::Error] If auto_stop_interval, auto_pause_interval, or auto_archive_interval is negative,
+    # @raise [Daytona::Sdk::Error] If auto_stop_interval, auto_pause_interval, auto_archive_interval, or ttl_minutes is negative,
     #   or if auto_stop_interval and auto_pause_interval are both non-zero
     def create(params = nil, on_snapshot_create_logs: nil)
       if params.nil?
@@ -237,7 +237,7 @@ module Daytona
     # @param timeout [Numeric] Maximum wait time in seconds (defaults to 60 s).
     # @param on_snapshot_create_logs [Proc]
     # @return [Daytona::Sandbox] The created sandbox
-    # @raise [Daytona::Sdk::Error] If auto_stop_interval, auto_pause_interval, or auto_archive_interval is negative,
+    # @raise [Daytona::Sdk::Error] If auto_stop_interval, auto_pause_interval, auto_archive_interval, or ttl_minutes is negative,
     #   or if auto_stop_interval and auto_pause_interval are both non-zero
     def _create(params, timeout: 60, on_snapshot_create_logs: nil)
       raise Sdk::Error, 'Timeout must be a non-negative number' if timeout.negative?
@@ -261,6 +261,8 @@ module Daytona
         raise Sdk::Error, 'auto_archive_interval must be a non-negative integer'
       end
 
+      raise Sdk::Error, 'ttl_minutes must be a non-negative integer' if params.ttl_minutes&.negative?
+
       labels = params.labels&.dup || {}
       labels[CODE_TOOLBOX_LANGUAGE_LABEL] = params.language.to_s if params.language
 
@@ -274,6 +276,7 @@ module Daytona
         auto_pause_interval: params.auto_pause_interval,
         auto_archive_interval: params.auto_archive_interval,
         auto_delete_interval: params.auto_delete_interval,
+        ttl_minutes: params.ttl_minutes,
         volumes: params.volumes,
         secrets: params.secrets&.map { |env_var, secret_name| { env_var.to_s => secret_name.to_s } },
         network_block_all: params.network_block_all,

--- a/sdk-ruby/lib/daytona/sandbox.rb
+++ b/sdk-ruby/lib/daytona/sandbox.rb
@@ -140,8 +140,8 @@ module Daytona
     #   Not returned by list results; call #refresh on each item to populate.
     attr_reader :build_info
 
-    # @return [String, nil] The expiration timestamp of the sandbox (nil if no TTL is set)
-    attr_reader :expires_at
+    # @return [String, nil] When the sandbox will be automatically destroyed (nil if no TTL is set)
+    attr_reader :auto_destroy_at
 
     # @return [String] The creation timestamp of the sandbox
     attr_reader :created_at
@@ -989,7 +989,7 @@ module Daytona
       @auto_pause_interval = sandbox_dto.auto_pause_interval
       @auto_archive_interval = sandbox_dto.auto_archive_interval
       @auto_delete_interval = sandbox_dto.auto_delete_interval
-      @expires_at = sandbox_dto.expires_at
+      @auto_destroy_at = sandbox_dto.auto_destroy_at
       @created_at = sandbox_dto.created_at
       @updated_at = sandbox_dto.updated_at
       @last_activity_at = sandbox_dto.last_activity_at

--- a/sdk-ruby/lib/daytona/sandbox.rb
+++ b/sdk-ruby/lib/daytona/sandbox.rb
@@ -836,7 +836,8 @@ module Daytona
                 :wait_for_sandbox_stop, :resize, :wait_for_resize_complete,
                 :experimental_fork, :experimental_create_snapshot, :pause
 
-    instrument :archive, :auto_archive_interval=, :auto_delete_interval=, :auto_pause_interval=, :auto_stop_interval=, :ttl_minutes=,
+    instrument :archive, :auto_archive_interval=, :auto_delete_interval=, :auto_pause_interval=, :auto_stop_interval=,
+               :ttl_minutes=,
                :update_network_settings, :update_secrets, :update_env,
                :create_ssh_access, :delete, :get_user_home_dir, :get_work_dir, :get_metrics, :get_metrics_latest,
                :labels=,

--- a/sdk-ruby/lib/daytona/sandbox.rb
+++ b/sdk-ruby/lib/daytona/sandbox.rb
@@ -140,6 +140,9 @@ module Daytona
     #   Not returned by list results; call #refresh on each item to populate.
     attr_reader :build_info
 
+    # @return [String, nil] The expiration timestamp of the sandbox (nil if no TTL is set)
+    attr_reader :expires_at
+
     # @return [String] The creation timestamp of the sandbox
     attr_reader :created_at
 
@@ -352,6 +355,19 @@ module Daytona
 
       sandbox_api.set_auto_pause_interval(id, interval)
       @auto_pause_interval = interval
+    end
+
+    # Sets the TTL (time to live) for the Sandbox.
+    # The TTL is re-anchored from the current time. When it elapses the Sandbox is destroyed,
+    # regardless of its current state. Use 0 to disable.
+    #
+    # @param minutes [Integer]
+    # @return [void]
+    # @raise [Daytona::Sdk::Error]
+    def ttl_minutes=(minutes)
+      raise Sdk::Error, 'TTL must be a non-negative integer' if minutes.negative?
+
+      sandbox_api.set_ttl(id, minutes)
     end
 
     # Creates an SSH access token for the sandbox.
@@ -820,7 +836,7 @@ module Daytona
                 :wait_for_sandbox_stop, :resize, :wait_for_resize_complete,
                 :experimental_fork, :experimental_create_snapshot, :pause
 
-    instrument :archive, :auto_archive_interval=, :auto_delete_interval=, :auto_pause_interval=, :auto_stop_interval=,
+    instrument :archive, :auto_archive_interval=, :auto_delete_interval=, :auto_pause_interval=, :auto_stop_interval=, :ttl_minutes=,
                :update_network_settings, :update_secrets, :update_env,
                :create_ssh_access, :delete, :get_user_home_dir, :get_work_dir, :get_metrics, :get_metrics_latest,
                :labels=,
@@ -973,6 +989,7 @@ module Daytona
       @auto_pause_interval = sandbox_dto.auto_pause_interval
       @auto_archive_interval = sandbox_dto.auto_archive_interval
       @auto_delete_interval = sandbox_dto.auto_delete_interval
+      @expires_at = sandbox_dto.expires_at
       @created_at = sandbox_dto.created_at
       @updated_at = sandbox_dto.updated_at
       @last_activity_at = sandbox_dto.last_activity_at

--- a/sdk-ruby/spec/daytona/daytona_spec.rb
+++ b/sdk-ruby/spec/daytona/daytona_spec.rb
@@ -283,6 +283,14 @@ RSpec.describe Daytona::Daytona do
         .to raise_error(Daytona::Sdk::Error, /auto_archive_interval must be a non-negative integer/)
     end
 
+    it 'raises on negative ttl_minutes' do
+      params = Daytona::CreateSandboxFromSnapshotParams.new(snapshot: 'snap-1', language: :python,
+                                                            ttl_minutes: -1)
+
+      expect { described_class.new(config).create(params) }
+        .to raise_error(Daytona::Sdk::Error, /ttl_minutes must be a non-negative integer/)
+    end
+
     it 'creates a sandbox from a string image and merges labels' do
       params = Daytona::CreateSandboxFromImageParams.new(
         image: 'ruby:3.4',

--- a/sdk-ruby/spec/daytona/sandbox_spec.rb
+++ b/sdk-ruby/spec/daytona/sandbox_spec.rb
@@ -161,6 +161,21 @@ RSpec.describe Daytona::Sandbox do
     end
   end
 
+  describe '#ttl_minutes=' do
+    it 'sets TTL via API' do
+      allow(sandbox_api).to receive(:set_ttl).with('sandbox-123', 30)
+
+      sandbox.ttl_minutes = 30
+
+      expect(sandbox_api).to have_received(:set_ttl).with('sandbox-123', 30)
+    end
+
+    it 'raises on negative value' do
+      expect { sandbox.ttl_minutes = -1 }
+        .to raise_error(Daytona::Sdk::Error, /TTL must be a non-negative integer/)
+    end
+  end
+
   describe '#create_ssh_access' do
     it 'delegates to sandbox_api' do
       ssh_dto = instance_double(DaytonaApiClient::SshAccessDto)

--- a/sdk-ruby/spec/spec_helper.rb
+++ b/sdk-ruby/spec/spec_helper.rb
@@ -83,6 +83,7 @@ def build_sandbox_dto(overrides = {}) # rubocop:disable Metrics/MethodLength
     auto_stop_interval: 15,
     auto_archive_interval: 10_080,
     auto_delete_interval: -1,
+    expires_at: nil,
     volumes: [],
     build_info: nil,
     created_at: '2025-01-01T00:00:00Z',

--- a/sdk-ruby/spec/spec_helper.rb
+++ b/sdk-ruby/spec/spec_helper.rb
@@ -83,7 +83,7 @@ def build_sandbox_dto(overrides = {}) # rubocop:disable Metrics/MethodLength
     auto_stop_interval: 15,
     auto_archive_interval: 10_080,
     auto_delete_interval: -1,
-    expires_at: nil,
+    auto_destroy_at: nil,
     volumes: [],
     build_info: nil,
     created_at: '2025-01-01T00:00:00Z',

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -165,6 +165,7 @@ export interface Resources {
  * @property {number} [autoPauseInterval] - Auto-pause interval in minutes (0 means disabled). Only supported for sandbox classes that support pausing. Not allowed for ephemeral sandboxes. At most one of autoStopInterval and autoPauseInterval may be non-zero. For non-ephemeral sandbox classes that support pausing, defaults to 60 minutes (with auto-stop disabled) when neither interval is provided.
  * @property {number} [autoArchiveInterval] - Auto-archive interval in minutes (0 means the maximum interval will be used). Default is 7 days.
  * @property {number} [autoDeleteInterval] - Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping). By default, auto-delete is disabled.
+ * @property {number} [ttlMinutes] - Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled). When it elapses the Sandbox is destroyed, even if it is stopped, paused, or archived.
  * @property {VolumeMount[]} [volumes] - Optional array of volumes to mount to the Sandbox
  * @property {boolean} [networkBlockAll] - Whether to block all network access for the Sandbox
  * @property {string} [networkAllowList] - Comma-separated list of allowed CIDR network addresses for the Sandbox
@@ -184,6 +185,7 @@ export type CreateSandboxBaseParams = {
   autoPauseInterval?: number
   autoArchiveInterval?: number
   autoDeleteInterval?: number
+  ttlMinutes?: number
   volumes?: VolumeMount[]
   networkBlockAll?: boolean
   networkAllowList?: string
@@ -594,6 +596,10 @@ export class Daytona implements AsyncDisposable {
       throw new DaytonaValidationError('autoArchiveInterval must be a non-negative integer')
     }
 
+    if (params.ttlMinutes !== undefined && (!Number.isInteger(params.ttlMinutes) || params.ttlMinutes < 0)) {
+      throw new DaytonaValidationError('ttlMinutes must be a non-negative integer')
+    }
+
     try {
       let buildInfo: any | undefined
       let snapshot: string | undefined
@@ -645,6 +651,7 @@ export class Daytona implements AsyncDisposable {
           autoPauseInterval: params.autoPauseInterval,
           autoArchiveInterval: params.autoArchiveInterval,
           autoDeleteInterval: params.autoDeleteInterval,
+          ttlMinutes: params.ttlMinutes,
           volumes: params.volumes,
           networkBlockAll: params.networkBlockAll,
           networkAllowList: params.networkAllowList,

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -93,6 +93,7 @@ function withEvents<This, Args extends unknown[], Return>(
  * @property {number} [autoPauseInterval] - Auto-pause interval in minutes
  * @property {number} [autoArchiveInterval] - Auto-archive interval in minutes
  * @property {number} [autoDeleteInterval] - Auto-delete interval in minutes
+ * @property {string} [expiresAt] - When the Sandbox will expire and be destroyed (only set when a TTL is configured)
  * @property {Array<SandboxVolume>} [volumes] - Volumes attached to the Sandbox (not returned by
  * list results; call `refreshData()` on each item to populate)
  * @property {BuildInfo} [buildInfo] - Build information for the Sandbox if it was created from dynamic build
@@ -140,6 +141,7 @@ export class Sandbox {
   public autoPauseInterval?: number
   public autoArchiveInterval?: number
   public autoDeleteInterval?: number
+  public expiresAt?: string
   public volumes?: Array<SandboxVolume>
   public buildInfo?: BuildInfo
   public createdAt?: string
@@ -807,6 +809,33 @@ export class Sandbox {
   }
 
   /**
+   * Set the TTL (maximum time to live) for the Sandbox.
+   *
+   * The Sandbox will be destroyed once the TTL elapses, counted as wall-clock time regardless of the
+   * Sandbox state - even if it is stopped, paused, or archived. Calling this method re-anchors the
+   * deadline from the current time. Call `refreshData()` afterwards to read the updated `expiresAt`.
+   *
+   * @param {number} ttlMinutes - Number of minutes from now after which the Sandbox will be destroyed.
+   *                           Set to 0 to disable the TTL.
+   * @returns {Promise<void>}
+   * @throws {DaytonaError} - `DaytonaError` - If ttlMinutes is not a non-negative integer
+   *
+   * @example
+   * // Destroy the Sandbox 1 hour from now
+   * await sandbox.setTtl(60);
+   * // Or disable the TTL
+   * await sandbox.setTtl(0);
+   */
+  @WithInstrumentation()
+  public async setTtl(ttlMinutes: number): Promise<void> {
+    if (!Number.isInteger(ttlMinutes) || ttlMinutes < 0) {
+      throw new DaytonaValidationError('ttlMinutes must be a non-negative integer')
+    }
+
+    await this.sandboxApi.setTtl(this.id, ttlMinutes)
+  }
+
+  /**
    * Set the auto-archive interval for the Sandbox.
    *
    * The Sandbox will automatically archive after being continuously stopped for the specified interval.
@@ -1324,6 +1353,7 @@ export class Sandbox {
     this.autoPauseInterval = sandboxDto.autoPauseInterval
     this.autoArchiveInterval = sandboxDto.autoArchiveInterval
     this.autoDeleteInterval = sandboxDto.autoDeleteInterval
+    this.expiresAt = sandboxDto.expiresAt
     this.createdAt = sandboxDto.createdAt
     this.updatedAt = sandboxDto.updatedAt
     this.lastActivityAt = sandboxDto.lastActivityAt

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -93,7 +93,7 @@ function withEvents<This, Args extends unknown[], Return>(
  * @property {number} [autoPauseInterval] - Auto-pause interval in minutes
  * @property {number} [autoArchiveInterval] - Auto-archive interval in minutes
  * @property {number} [autoDeleteInterval] - Auto-delete interval in minutes
- * @property {string} [expiresAt] - When the Sandbox will expire and be destroyed (only set when a TTL is configured)
+ * @property {string} [autoDestroyAt] - When the Sandbox will be automatically destroyed (only set when a TTL is configured)
  * @property {Array<SandboxVolume>} [volumes] - Volumes attached to the Sandbox (not returned by
  * list results; call `refreshData()` on each item to populate)
  * @property {BuildInfo} [buildInfo] - Build information for the Sandbox if it was created from dynamic build
@@ -141,7 +141,7 @@ export class Sandbox {
   public autoPauseInterval?: number
   public autoArchiveInterval?: number
   public autoDeleteInterval?: number
-  public expiresAt?: string
+  public autoDestroyAt?: string
   public volumes?: Array<SandboxVolume>
   public buildInfo?: BuildInfo
   public createdAt?: string
@@ -813,7 +813,7 @@ export class Sandbox {
    *
    * The Sandbox will be destroyed once the TTL elapses, counted as wall-clock time regardless of the
    * Sandbox state - even if it is stopped, paused, or archived. Calling this method re-anchors the
-   * deadline from the current time. Call `refreshData()` afterwards to read the updated `expiresAt`.
+   * deadline from the current time. Call `refreshData()` afterwards to read the updated `autoDestroyAt`.
    *
    * @param {number} ttlMinutes - Number of minutes from now after which the Sandbox will be destroyed.
    *                           Set to 0 to disable the TTL.
@@ -1353,7 +1353,7 @@ export class Sandbox {
     this.autoPauseInterval = sandboxDto.autoPauseInterval
     this.autoArchiveInterval = sandboxDto.autoArchiveInterval
     this.autoDeleteInterval = sandboxDto.autoDeleteInterval
-    this.expiresAt = sandboxDto.expiresAt
+    this.autoDestroyAt = sandboxDto.autoDestroyAt
     this.createdAt = sandboxDto.createdAt
     this.updatedAt = sandboxDto.updatedAt
     this.lastActivityAt = sandboxDto.lastActivityAt

--- a/sdk-typescript/src/__tests__/Daytona.test.ts
+++ b/sdk-typescript/src/__tests__/Daytona.test.ts
@@ -353,6 +353,7 @@ describe('Daytona', () => {
         autoPauseInterval?: number
         autoArchiveInterval?: number
         autoDeleteInterval?: number
+        ttlMinutes?: number
         ephemeral?: boolean
       },
     ]
@@ -376,6 +377,7 @@ describe('Daytona', () => {
       { autoPauseInterval: 60, autoDeleteInterval: 0 },
     ],
     [{}, 'autoArchiveInterval must be a non-negative integer', { autoArchiveInterval: -1 }],
+    [{}, 'ttlMinutes must be a non-negative integer', { ttlMinutes: -1 }],
   ])('validates create input %#', async (optionsPart, message, params) => {
     const { Daytona } = await import('../Daytona')
     const instance = new Daytona({ apiKey: 'k', apiUrl: 'http://api', target: 'us' })

--- a/sdk-typescript/src/__tests__/Sandbox.test.ts
+++ b/sdk-typescript/src/__tests__/Sandbox.test.ts
@@ -76,6 +76,7 @@ const makeSandbox = (
     setAutoPauseInterval: jest.fn(),
     setAutoArchiveInterval: jest.fn(),
     setAutoDeleteInterval: jest.fn(),
+    setTtl: jest.fn(),
     getPortPreviewUrl: jest.fn(),
     getSignedPortPreviewUrl: jest.fn(),
     expireSignedPortPreviewUrl: jest.fn(),
@@ -180,6 +181,7 @@ describe('Sandbox', () => {
     ['setAutostopInterval', -1, 'autoStopInterval must be a non-negative integer'],
     ['setAutoPauseInterval', -1, 'autoPauseInterval must be a non-negative integer'],
     ['setAutoArchiveInterval', -1, 'autoArchiveInterval must be a non-negative integer'],
+    ['setTtl', -1, 'ttlMinutes must be a non-negative integer'],
   ])('validates %s', async (method, arg, message) => {
     const { sandbox } = makeSandbox()
     const call = (sandbox as unknown as Record<string, (n: number) => Promise<void>>)[method].bind(sandbox)
@@ -191,14 +193,18 @@ describe('Sandbox', () => {
     sandboxApi.replaceLabels.mockResolvedValue(createApiResponse({ labels: { env: 'dev' } }))
 
     await expect(sandbox.setLabels({ env: 'dev' })).resolves.toEqual({ env: 'dev' })
+    sandboxApi.setTtl.mockResolvedValue(createApiResponse({}))
+
     await sandbox.setAutostopInterval(20)
     await sandbox.setAutoArchiveInterval(30)
     await sandbox.setAutoDeleteInterval(0)
+    await sandbox.setTtl(60)
 
     expect(sandbox.labels).toEqual({ env: 'dev' })
     expect(sandbox.autoStopInterval).toBe(20)
     expect(sandbox.autoArchiveInterval).toBe(30)
     expect(sandbox.autoDeleteInterval).toBe(0)
+    expect(sandboxApi.setTtl).toHaveBeenCalledWith(sandbox.id, 60)
   })
 
   it('handles preview link, archive, resize, refresh calls', async () => {


### PR DESCRIPTION
Client-side support for the new sandbox TTL (maximum time to live) feature.

## What TTL is

A wall-clock deadline after which a sandbox is **destroyed regardless of its state** (started, stopped, paused, archived). Class-agnostic and orthogonal to the idle-based intervals — no mutual exclusivity, no ephemeral/class gating.

## API surface (all SDKs + CLI + MCP)

- **`ttlMinutes`** — input-only create parameter (minutes; `0` = disabled). Client-side validated as a non-negative integer. Never stored or returned on the sandbox object.
- **`expiresAt`** — read-only field on the sandbox object, mapped from the DTO. Only set when a TTL is configured.
- **`setTtl(minutes)`** — re-anchors the deadline from the current time (sliding, so it can extend or shorten the remaining lifetime); `0` disables.
- **CLI**: `daytona sandbox create --ttl <minutes>`; **MCP**: `ttlMinutes` arg on the `create_sandbox` tool.

## Setter semantics

- The setter **returns void and does not mutate local state** — the server computes the deadline.
- Read the updated deadline via `refreshData()` / `refresh_data()`, which populates `expiresAt`.

Per-language surface:

| SDK | Create param | Read field | Setter |
|---|---|---|---|
| TypeScript | `ttlMinutes` | `sandbox.expiresAt` | `sandbox.setTtl()` |
| Python (sync + async) | `ttl_minutes` | `sandbox.expires_at` | `sandbox.set_ttl()` |
| Go | `TtlMinutes` | `Sandbox.ExpiresAt` | — (mirrors existing convention: no interval setters) |
| Java | `ttlMinutes` | `getExpiresAt()` | `setTtl(int)` |
| Ruby | `ttl_minutes` | `#expires_at` | `#ttl_minutes=` |

## Generated clients

`openapi-specs/api.json` synced with the new API surface; all `api-client*` regenerated (`setTtl` operation, `CreateSandbox.ttlMinutes`, `Sandbox.expiresAt`). Regeneration is byte-stable against the committed spec.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add sandbox TTL across SDKs and CLI. Users can set a wall-clock expiration that destroys a sandbox when it elapses; the deadline is exposed as `autoDestroyAt`.

- **New Features**
  - API: POST `/sandbox/{sandboxIdOrName}/ttl/{ttlMinutes}` (`setTtl`). `openapi-specs/api.json` updated; all `api-client*` regenerated.
  - SDKs: Add create param `ttlMinutes` and read-only `autoDestroyAt` in `sdk-typescript`, `sdk-python` (sync/async), `sdk-java`, `sdk-ruby`, `sdk-go`. Setters: TypeScript `sandbox.setTtl(minutes)`, Python `sandbox.set_ttl(minutes)` / `async_sandbox.set_ttl(minutes)`, Java `sandbox.setTtl(int)`, Ruby `sandbox.ttl_minutes = minutes`; Go exposes `AutoDestroyAt` and accepts `TtlMinutes` on create.
  - Behavior: `0` disables TTL. Setter re-anchors from now; server computes the deadline. Call `refreshData()` / `refresh_data()` / `#refresh` to read updated `autoDestroyAt`.
  - Validation: All SDKs and CLI reject negative TTL with clear errors.
  - CLI/MCP: `daytona sandbox create --ttl <minutes>`; MCP `create_sandbox` supports `ttlMinutes`.
  - Docs: SDK docs updated to cover TTL and `autoDestroyAt`.

- **Refactors**
  - Rename `expiresAt` to `autoDestroyAt` across SDKs, API clients, and docs.
  - Go: refresh now populates `AutoDestroyAt`; minor cleanup.
  - Java: `Sandbox.setTtl` validates non-negative input and delegates to the API without mutating local state; Java SDK docs fixed/clarified for TTL and `getAutoDestroyAt()`.

<sup>Written for commit 340ee6bf91191a7d7fe645a239096d3364d7892a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

