### PR TITLE
chore(sdk): publish analytics clients via SDK deps instead of standalone job

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -48,8 +48,6 @@ jobs:
         include:
           - name: TypeScript SDK
             projects: sdk-typescript
-          - name: Analytics API Client
-            projects: analytics-api-client
           - name: Python SDK
             projects: sdk-python
           - name: Ruby SDK

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ PATH
   specs:
     daytona (0.0.0.pre.dev)
       aws-sdk-s3 (~> 1.0)
+      daytona_analytics_api_client (= 0.0.0.pre.dev)
       daytona_api_client (= 0.0.0.pre.dev)
       daytona_toolbox_api_client (= 0.0.0.pre.dev)
       dotenv (~> 2.0)

--- a/sdk-java/project.json
+++ b/sdk-java/project.json
@@ -41,7 +41,7 @@
         "set-version",
         {
           "target": "build",
-          "projects": ["api-client-java", "toolbox-api-client-java"]
+          "projects": ["api-client-java", "toolbox-api-client-java", "analytics-api-client-java"]
         }
       ]
     },
@@ -55,7 +55,7 @@
         "set-version",
         {
           "target": "publish",
-          "projects": ["api-client-java", "toolbox-api-client-java"]
+          "projects": ["api-client-java", "toolbox-api-client-java", "analytics-api-client-java"]
         }
       ]
     },
@@ -72,7 +72,8 @@
       "inputs": [
         "default",
         "{workspaceRoot}/api-client-java/**/*",
-        "{workspaceRoot}/toolbox-api-client-java/**/*"
+        "{workspaceRoot}/toolbox-api-client-java/**/*",
+        "{workspaceRoot}/analytics-api-client-java/**/*"
       ],
       "outputs": [],
       "options": {

--- a/sdk-python/project.json
+++ b/sdk-python/project.json
@@ -20,7 +20,9 @@
         "{workspaceRoot}/api-client-python/**/*",
         "{workspaceRoot}/api-client-python-async/**/*",
         "{workspaceRoot}/toolbox-api-client-python/**/*",
-        "{workspaceRoot}/toolbox-api-client-python-async/**/*"
+        "{workspaceRoot}/toolbox-api-client-python-async/**/*",
+        "{workspaceRoot}/analytics-api-client-python/**/*",
+        "{workspaceRoot}/analytics-api-client-python-async/**/*"
       ],
       "outputs": [],
       "options": {
@@ -48,7 +50,9 @@
             "api-client-python",
             "api-client-python-async",
             "toolbox-api-client-python",
-            "toolbox-api-client-python-async"
+            "toolbox-api-client-python-async",
+            "analytics-api-client-python",
+            "analytics-api-client-python-async"
           ]
         }
       ]

--- a/sdk-python/scripts/add-api-clients.sh
+++ b/sdk-python/scripts/add-api-clients.sh
@@ -31,7 +31,9 @@ while true; do
     "daytona_api_client@$version" \
     "daytona_api_client_async@$version" \
     "daytona_toolbox_api_client@$version" \
-    "daytona_toolbox_api_client_async@$version" 2>&1); then
+    "daytona_toolbox_api_client_async@$version" \
+    "daytona_analytics_api_client@$version" \
+    "daytona_analytics_api_client_async@$version" 2>&1); then
     echo "Successfully added API clients"
     exit 0
   fi

--- a/sdk-ruby/Gemfile
+++ b/sdk-ruby/Gemfile
@@ -14,5 +14,6 @@ gem 'solargraph', '~> 0.57'
 gem 'webmock', '~> 3.25'
 gem 'yard-markdown', '~> 0.5.0'
 
+gem 'daytona_analytics_api_client', '>= 0.0.0.pre.dev', path: '../analytics-api-client-ruby'
 gem 'daytona_api_client', '>= 0.0.0.pre.dev', path: '../api-client-ruby'
 gem 'daytona_toolbox_api_client', '>= 0.0.0.pre.dev', path: '../toolbox-api-client-ruby'

--- a/sdk-ruby/daytona.gemspec
+++ b/sdk-ruby/daytona.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-sdk', '~> 1.4'
 
   spec.add_dependency 'aws-sdk-s3', '~> 1.0'
+  spec.add_dependency 'daytona_analytics_api_client', Daytona::Sdk::VERSION
   spec.add_dependency 'daytona_api_client', Daytona::Sdk::VERSION
   spec.add_dependency 'daytona_toolbox_api_client', Daytona::Sdk::VERSION
   spec.add_dependency 'dotenv', '~> 2.0'

--- a/sdk-ruby/project.json
+++ b/sdk-ruby/project.json
@@ -15,7 +15,7 @@
       "dependsOn": [
         {
           "target": "build",
-          "projects": ["api-client-ruby", "toolbox-api-client-ruby"]
+          "projects": ["api-client-ruby", "toolbox-api-client-ruby", "analytics-api-client-ruby"]
         },
         "set-version"
       ],
@@ -47,7 +47,8 @@
       "inputs": [
         "default",
         "{workspaceRoot}/api-client-ruby/**/*",
-        "{workspaceRoot}/toolbox-api-client-ruby/**/*"
+        "{workspaceRoot}/toolbox-api-client-ruby/**/*",
+        "{workspaceRoot}/analytics-api-client-ruby/**/*"
       ],
       "outputs": [],
       "options": {
@@ -91,7 +92,7 @@
       "dependsOn": [
         {
           "target": "publish",
-          "projects": ["api-client-ruby", "toolbox-api-client-ruby"]
+          "projects": ["api-client-ruby", "toolbox-api-client-ruby", "analytics-api-client-ruby"]
         },
         "build"
       ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publish analytics API clients via the Java, Python, and Ruby SDK pipelines instead of a standalone workflow. This aligns versions and simplifies releases.

- **Refactors**
  - Removed analytics client from `.github/workflows/sdk_publish.yaml` matrix.
  - Java: added `analytics-api-client-java` to `set-version`/`publish` and pipeline inputs.
  - Python: added `analytics-api-client-python` and `analytics-api-client-python-async` to inputs/deps; updated add script to include `daytona_analytics_api_client` and `daytona_analytics_api_client_async`.
  - Ruby: added `daytona_analytics_api_client` to Gemfile and gemspec; included `analytics-api-client-ruby` in build/publish deps and pipeline inputs.

<sup>Written for commit d5b08aaff3d299364a1c281cda3f927c95bf9129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

