### PR TITLE
fix(sdk-go): make HTTP timeout configurable and honor long execution timeouts

### DIFF
--- a/artifacts/sdk-docs/go-sdk/options.mdx
+++ b/artifacts/sdk-docs/go-sdk/options.mdx
@@ -250,7 +250,9 @@ result, err := sandbox.Process.CodeRun(ctx, code,
 func WithCodeRunTimeout(timeout time.Duration) func(*CodeRun)
 ```
 
+WithCodeRunTimeout sets the timeout for code execution.
 
+If the code doesn't complete within the timeout, it will be terminated. The HTTP request waits for the full timeout, even beyond the client\-wide HTTP timeout. A zero value disables the server\-side limit \(the wait is bounded only by ctx\); negative values are rejected by the API. Values are rounded up to whole seconds \(the API granularity\).
 
 <a name="WithCommandEnv"></a>
 ## func WithCommandEnv
@@ -422,13 +424,13 @@ func WithExecuteTimeout(timeout time.Duration) func(*ExecuteCommand)
 
 WithExecuteTimeout sets the timeout for command execution.
 
-If the command doesn't complete within the timeout, it will be terminated.
+If the command doesn't complete within the timeout, it will be terminated. The HTTP request waits for the full timeout, even beyond the client\-wide HTTP timeout. A zero value disables the server\-side limit \(the wait is bounded only by ctx\); negative values are rejected by the API. Values are rounded up to whole seconds \(the API granularity\).
 
 Example:
 
 ```
 result, err := sandbox.Process.ExecuteCommand(ctx, "sleep 60",
-    options.WithExecuteTimeout(5*time.Second),
+    options.WithExecuteTimeout(5*time.Minute),
 )
 ```
 

--- a/artifacts/sdk-docs/go-sdk/types.mdx
+++ b/artifacts/sdk-docs/go-sdk/types.mdx
@@ -164,7 +164,14 @@ type DaytonaConfig struct {
     // streaming is the default and falls back to polling automatically when
     // WebSockets are unavailable.
     UseDeprecatedPolling *bool
-    Experimental         *ExperimentalConfig
+    // Timeout overrides the default per-request HTTP timeout (60s). A
+    // non-positive value disables the client-wide timeout entirely. Executions
+    // with an explicit execution timeout are not capped by this value.
+    Timeout *time.Duration
+    // HTTPClient supplies a custom *http.Client for API requests. It is copied
+    // before use (Transport shared); Timeout, when set, overrides the copy's.
+    HTTPClient   *http.Client
+    Experimental *ExperimentalConfig
 }
 ```
 

--- a/sdk-go/pkg/daytona/client.go
+++ b/sdk-go/pkg/daytona/client.go
@@ -169,9 +169,7 @@ func NewClient() (*Client, error) {
 func NewClientWithConfig(config *types.DaytonaConfig) (*Client, error) {
 	client := &Client{
 		defaultLanguage: types.CodeLanguagePython,
-		httpClient: &http.Client{
-			Timeout: defaultTimeout,
-		},
+		httpClient:      buildHTTPClient(config),
 	}
 
 	// Set configuration from config or environment variables
@@ -337,6 +335,26 @@ func (c *Client) getAnalyticsAPIURL(ctx context.Context) (string, error) {
 	c.analyticsAPIURL = cfg.GetAnalyticsApiUrl()
 	c.analyticsAPIURLFetched = true
 	return c.analyticsAPIURL, nil
+}
+
+// buildHTTPClient resolves the HTTP client from DaytonaConfig. A caller-provided
+// client is shallow-copied (Transport shared) so the SDK's later otel Transport
+// wrapping never mutates the caller's instance.
+func buildHTTPClient(config *types.DaytonaConfig) *http.Client {
+	httpClient := &http.Client{Timeout: defaultTimeout}
+	if config == nil {
+		return httpClient
+	}
+
+	if config.HTTPClient != nil {
+		clientCopy := *config.HTTPClient
+		httpClient = &clientCopy
+	}
+	if config.Timeout != nil {
+		httpClient.Timeout = *config.Timeout
+	}
+
+	return httpClient
 }
 
 // handleAPIError converts API client errors to Daytona error types

--- a/sdk-go/pkg/daytona/client_test.go
+++ b/sdk-go/pkg/daytona/client_test.go
@@ -772,6 +772,44 @@ func TestClientTimeout(t *testing.T) {
 	assert.Equal(t, defaultTimeout, client.httpClient.Timeout)
 }
 
+func TestClientTimeoutConfig(t *testing.T) {
+	t.Setenv("DAYTONA_API_KEY", "test-api-key")
+	t.Setenv("DAYTONA_API_URL", "")
+	t.Setenv("DAYTONA_JWT_TOKEN", "")
+	t.Setenv("DAYTONA_ORGANIZATION_ID", "")
+
+	t.Run("config timeout overrides default", func(t *testing.T) {
+		timeout := 5 * time.Minute
+		client, err := NewClientWithConfig(&types.DaytonaConfig{Timeout: &timeout})
+		require.NoError(t, err)
+		assert.Equal(t, timeout, client.httpClient.Timeout)
+	})
+
+	t.Run("custom http client is copied, not mutated", func(t *testing.T) {
+		userTransport := &http.Transport{}
+		userClient := &http.Client{Timeout: 42 * time.Second, Transport: userTransport}
+		timeout := 2 * time.Minute
+
+		client, err := NewClientWithConfig(&types.DaytonaConfig{
+			HTTPClient: userClient,
+			Timeout:    &timeout,
+		})
+		require.NoError(t, err)
+
+		assert.NotSame(t, userClient, client.httpClient)
+		assert.Equal(t, timeout, client.httpClient.Timeout)
+		assert.Equal(t, 42*time.Second, userClient.Timeout)
+		assert.Same(t, userTransport, client.httpClient.Transport.(*http.Transport))
+	})
+
+	t.Run("custom http client keeps its timeout when config timeout unset", func(t *testing.T) {
+		userClient := &http.Client{Timeout: 42 * time.Second}
+		client, err := NewClientWithConfig(&types.DaytonaConfig{HTTPClient: userClient})
+		require.NoError(t, err)
+		assert.Equal(t, 42*time.Second, client.httpClient.Timeout)
+	})
+}
+
 // TestServerURLConstruction tests proper server URL construction
 func TestServerURLConstruction(t *testing.T) {
 	tests := []struct {

--- a/sdk-go/pkg/daytona/client_test.go
+++ b/sdk-go/pkg/daytona/client_test.go
@@ -777,6 +777,8 @@ func TestClientTimeoutConfig(t *testing.T) {
 	t.Setenv("DAYTONA_API_URL", "")
 	t.Setenv("DAYTONA_JWT_TOKEN", "")
 	t.Setenv("DAYTONA_ORGANIZATION_ID", "")
+	t.Setenv("DAYTONA_OTEL_ENABLED", "")
+	t.Setenv("DAYTONA_EXPERIMENTAL_OTEL_ENABLED", "")
 
 	t.Run("config timeout overrides default", func(t *testing.T) {
 		timeout := 5 * time.Minute
@@ -799,7 +801,9 @@ func TestClientTimeoutConfig(t *testing.T) {
 		assert.NotSame(t, userClient, client.httpClient)
 		assert.Equal(t, timeout, client.httpClient.Timeout)
 		assert.Equal(t, 42*time.Second, userClient.Timeout)
-		assert.Same(t, userTransport, client.httpClient.Transport.(*http.Transport))
+		transport, ok := client.httpClient.Transport.(*http.Transport)
+		require.True(t, ok, "transport should be *http.Transport, got %T", client.httpClient.Transport)
+		assert.Same(t, userTransport, transport)
 	})
 
 	t.Run("custom http client keeps its timeout when config timeout unset", func(t *testing.T) {

--- a/sdk-go/pkg/daytona/process.go
+++ b/sdk-go/pkg/daytona/process.go
@@ -12,7 +12,6 @@ import (
 	"math"
 	"net/url"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/daytona/clients/sdk-go/pkg/common"
@@ -60,9 +59,6 @@ type ProcessService struct {
 	toolboxClient *toolbox.APIClient
 	otel          *otelState
 	language      types.CodeLanguage
-
-	longRunningOnce   sync.Once
-	longRunningClient *toolbox.APIClient
 }
 
 // executeTimeoutBuffer pads the per-request HTTP deadline over the execution
@@ -86,22 +82,23 @@ func (p *ProcessService) execContext(ctx context.Context, execTimeout *time.Dura
 		return p.toolboxClient, ctx, func() {}
 	}
 
-	p.longRunningOnce.Do(func() {
-		cfg := *p.toolboxClient.GetConfig()
-		if cfg.HTTPClient != nil {
-			clientCopy := *cfg.HTTPClient
-			clientCopy.Timeout = 0
-			cfg.HTTPClient = &clientCopy
-		}
-		p.longRunningClient = toolbox.NewAPIClient(&cfg)
-	})
+	// Rebuilt per execution (not cached): the shared config's proxy URL can be
+	// refreshed in place by Sandbox.updateFromAPIResponse, and a cached copy
+	// would keep targeting the old proxy.
+	cfg := *p.toolboxClient.GetConfig()
+	if cfg.HTTPClient != nil {
+		clientCopy := *cfg.HTTPClient
+		clientCopy.Timeout = 0
+		cfg.HTTPClient = &clientCopy
+	}
+	execClient := toolbox.NewAPIClient(&cfg)
 
 	if *execTimeout <= 0 {
-		return p.longRunningClient, ctx, func() {}
+		return execClient, ctx, func() {}
 	}
 
 	deadlineCtx, cancel := context.WithTimeout(ctx, *execTimeout+executeTimeoutBuffer)
-	return p.longRunningClient, deadlineCtx, cancel
+	return execClient, deadlineCtx, cancel
 }
 
 // NewProcessService creates a new ProcessService with the provided toolbox client.

--- a/sdk-go/pkg/daytona/process.go
+++ b/sdk-go/pkg/daytona/process.go
@@ -9,8 +9,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/url"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/daytona/clients/sdk-go/pkg/common"
 	"github.com/daytona/clients/sdk-go/pkg/errors"
@@ -57,6 +60,48 @@ type ProcessService struct {
 	toolboxClient *toolbox.APIClient
 	otel          *otelState
 	language      types.CodeLanguage
+
+	longRunningOnce   sync.Once
+	longRunningClient *toolbox.APIClient
+}
+
+// executeTimeoutBuffer pads the per-request HTTP deadline over the execution
+// timeout, mirroring the Python SDK's `_request_timeout = timeout + 5`.
+const executeTimeoutBuffer = 5 * time.Second
+
+// timeoutSeconds converts an execution timeout to the API's integer seconds,
+// rounding up: truncation would turn sub-second values into 0 ("no limit") and
+// kill commands up to a second before the requested bound.
+func timeoutSeconds(d time.Duration) int32 {
+	return int32(math.Ceil(d.Seconds()))
+}
+
+// execContext returns the toolbox client and context for a synchronous
+// execution. With an explicit execution timeout, a Timeout-free client copy is
+// used (an http.Client Timeout is a hard cap a context cannot extend) and the
+// wait is bounded by a context deadline of timeout + buffer instead; a
+// non-positive timeout leaves the wait bounded only by the caller's ctx.
+func (p *ProcessService) execContext(ctx context.Context, execTimeout *time.Duration) (*toolbox.APIClient, context.Context, context.CancelFunc) {
+	if execTimeout == nil {
+		return p.toolboxClient, ctx, func() {}
+	}
+
+	p.longRunningOnce.Do(func() {
+		cfg := *p.toolboxClient.GetConfig()
+		if cfg.HTTPClient != nil {
+			clientCopy := *cfg.HTTPClient
+			clientCopy.Timeout = 0
+			cfg.HTTPClient = &clientCopy
+		}
+		p.longRunningClient = toolbox.NewAPIClient(&cfg)
+	})
+
+	if *execTimeout <= 0 {
+		return p.longRunningClient, ctx, func() {}
+	}
+
+	deadlineCtx, cancel := context.WithTimeout(ctx, *execTimeout+executeTimeoutBuffer)
+	return p.longRunningClient, deadlineCtx, cancel
 }
 
 // NewProcessService creates a new ProcessService with the provided toolbox client.
@@ -112,13 +157,16 @@ func (p *ProcessService) ExecuteCommand(ctx context.Context, command string, opt
 			req.SetCwd(*execOpts.Cwd)
 		}
 		if execOpts.Timeout != nil {
-			req.SetTimeout(int32(execOpts.Timeout.Seconds()))
+			req.SetTimeout(timeoutSeconds(*execOpts.Timeout))
 		}
 		if execOpts.Env != nil {
 			req.SetEnvs(execOpts.Env)
 		}
 
-		resp, httpResp, err := p.toolboxClient.ProcessAPI.ExecuteCommand(ctx).Request(*req).Execute()
+		execClient, execCtx, cancel := p.execContext(ctx, execOpts.Timeout)
+		defer cancel()
+
+		resp, httpResp, err := execClient.ProcessAPI.ExecuteCommand(execCtx).Request(*req).Execute()
 		if err != nil {
 			return nil, errors.ConvertToolboxError(err, httpResp)
 		}
@@ -191,10 +239,13 @@ func (p *ProcessService) CodeRun(ctx context.Context, code string, opts ...func(
 			}
 		}
 		if codeRunOpts.Timeout != nil {
-			req.SetTimeout(int32(codeRunOpts.Timeout.Seconds()))
+			req.SetTimeout(timeoutSeconds(*codeRunOpts.Timeout))
 		}
 
-		resp, httpResp, err := p.toolboxClient.ProcessAPI.CodeRun(ctx).Request(*req).Execute()
+		execClient, execCtx, cancel := p.execContext(ctx, codeRunOpts.Timeout)
+		defer cancel()
+
+		resp, httpResp, err := execClient.ProcessAPI.CodeRun(execCtx).Request(*req).Execute()
 		if err != nil {
 			return nil, errors.ConvertToolboxError(err, httpResp)
 		}

--- a/sdk-go/pkg/daytona/process_test.go
+++ b/sdk-go/pkg/daytona/process_test.go
@@ -392,6 +392,105 @@ func TestProcessCodeRunAndSessionOperations(t *testing.T) {
 	})
 }
 
+func TestProcessTimeoutSecondsRounding(t *testing.T) {
+	assert.Equal(t, int32(1), timeoutSeconds(500*time.Millisecond))
+	assert.Equal(t, int32(3), timeoutSeconds(2100*time.Millisecond))
+	assert.Equal(t, int32(45), timeoutSeconds(45*time.Second))
+	assert.Equal(t, int32(0), timeoutSeconds(0))
+	assert.Equal(t, int32(-5), timeoutSeconds(-5*time.Second))
+
+	var gotTimeout float64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotTimeout, _ = body["timeout"].(float64)
+		writeJSONResponse(t, w, http.StatusOK, map[string]any{"result": "ok", "exitCode": 0})
+	}))
+	defer server.Close()
+
+	service := NewProcessService(createTestToolboxClient(server), nil, types.CodeLanguagePython)
+	_, err := service.ExecuteCommand(context.Background(), "true",
+		options.WithExecuteTimeout(500*time.Millisecond))
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), gotTimeout)
+}
+
+func TestProcessExecuteTimeoutExceedsHTTPClientTimeout(t *testing.T) {
+	newSlowServer := func(delay time.Duration) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case <-time.After(delay):
+				writeJSONResponse(t, w, http.StatusOK, map[string]any{"result": "slow ok", "exitCode": 0})
+			case <-r.Context().Done():
+			}
+		}))
+	}
+
+	newCappedService := func(server *httptest.Server, clientTimeout time.Duration) *ProcessService {
+		cfg := toolbox.NewConfiguration()
+		cfg.Servers = toolbox.ServerConfigurations{{URL: server.URL}}
+		cfg.HTTPClient = &http.Client{Timeout: clientTimeout}
+		return NewProcessService(toolbox.NewAPIClient(cfg), nil, types.CodeLanguagePython)
+	}
+
+	t.Run("execute with explicit timeout is not capped by client timeout", func(t *testing.T) {
+		server := newSlowServer(300 * time.Millisecond)
+		defer server.Close()
+
+		service := newCappedService(server, 50*time.Millisecond)
+		result, err := service.ExecuteCommand(context.Background(), "sleep 1",
+			options.WithExecuteTimeout(10*time.Second))
+		require.NoError(t, err)
+		assert.Equal(t, "slow ok", result.Result)
+	})
+
+	t.Run("code run with explicit timeout is not capped by client timeout", func(t *testing.T) {
+		server := newSlowServer(300 * time.Millisecond)
+		defer server.Close()
+
+		service := newCappedService(server, 50*time.Millisecond)
+		result, err := service.CodeRun(context.Background(), "time.sleep(1)",
+			options.WithCodeRunTimeout(10*time.Second))
+		require.NoError(t, err)
+		assert.Equal(t, "slow ok", result.Result)
+	})
+
+	t.Run("without explicit timeout the client timeout still applies", func(t *testing.T) {
+		server := newSlowServer(300 * time.Millisecond)
+		defer server.Close()
+
+		service := newCappedService(server, 50*time.Millisecond)
+		_, err := service.ExecuteCommand(context.Background(), "sleep 1")
+		require.Error(t, err)
+	})
+
+	t.Run("caller context deadline still wins over execute timeout", func(t *testing.T) {
+		server := newSlowServer(2 * time.Second)
+		defer server.Close()
+
+		service := newCappedService(server, 50*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		_, err := service.ExecuteCommand(ctx, "sleep 10",
+			options.WithExecuteTimeout(10*time.Second))
+		require.Error(t, err)
+		assert.Less(t, time.Since(start), time.Second)
+	})
+
+	t.Run("non-positive execute timeout waits without deadline", func(t *testing.T) {
+		server := newSlowServer(300 * time.Millisecond)
+		defer server.Close()
+
+		service := newCappedService(server, 50*time.Millisecond)
+		result, err := service.ExecuteCommand(context.Background(), "sleep 1",
+			options.WithExecuteTimeout(0))
+		require.NoError(t, err)
+		assert.Equal(t, "slow ok", result.Result)
+	})
+}
+
 func TestFlushToChannelAndChartConversion(t *testing.T) {
 	stdout := make(chan string, 1)
 	stderr := make(chan string, 1)

--- a/sdk-go/pkg/options/process.go
+++ b/sdk-go/pkg/options/process.go
@@ -48,11 +48,15 @@ func WithCommandEnv(env map[string]string) func(*ExecuteCommand) {
 // WithExecuteTimeout sets the timeout for command execution.
 //
 // If the command doesn't complete within the timeout, it will be terminated.
+// The HTTP request waits for the full timeout, even beyond the client-wide
+// HTTP timeout. A zero value disables the server-side limit (the wait is
+// bounded only by ctx); negative values are rejected by the API. Values are
+// rounded up to whole seconds (the API granularity).
 //
 // Example:
 //
 //	result, err := sandbox.Process.ExecuteCommand(ctx, "sleep 60",
-//	    options.WithExecuteTimeout(5*time.Second),
+//	    options.WithExecuteTimeout(5*time.Minute),
 //	)
 func WithExecuteTimeout(timeout time.Duration) func(*ExecuteCommand) {
 	return func(opts *ExecuteCommand) {
@@ -86,6 +90,13 @@ func WithCodeRunLanguage(language types.CodeLanguage) func(*CodeRun) {
 	}
 }
 
+// WithCodeRunTimeout sets the timeout for code execution.
+//
+// If the code doesn't complete within the timeout, it will be terminated.
+// The HTTP request waits for the full timeout, even beyond the client-wide
+// HTTP timeout. A zero value disables the server-side limit (the wait is
+// bounded only by ctx); negative values are rejected by the API. Values are
+// rounded up to whole seconds (the API granularity).
 func WithCodeRunTimeout(timeout time.Duration) func(*CodeRun) {
 	return func(opts *CodeRun) {
 		opts.Timeout = &timeout

--- a/sdk-go/pkg/types/types.go
+++ b/sdk-go/pkg/types/types.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"net/http"
 	"time"
 
 	apiclient "github.com/daytona/clients/api-client-go"
@@ -65,7 +66,14 @@ type DaytonaConfig struct {
 	// streaming is the default and falls back to polling automatically when
 	// WebSockets are unavailable.
 	UseDeprecatedPolling *bool
-	Experimental         *ExperimentalConfig
+	// Timeout overrides the default per-request HTTP timeout (60s). A
+	// non-positive value disables the client-wide timeout entirely. Executions
+	// with an explicit execution timeout are not capped by this value.
+	Timeout *time.Duration
+	// HTTPClient supplies a custom *http.Client for API requests. It is copied
+	// before use (Transport shared); Timeout, when set, overrides the copy's.
+	HTTPClient   *http.Client
+	Experimental *ExperimentalConfig
 }
 
 // Resources represents resource allocation for a sandbox.

--- a/sdk-typescript/runtime-tests/nuxt/package.json
+++ b/sdk-typescript/runtime-tests/nuxt/package.json
@@ -7,5 +7,8 @@
   },
   "dependencies": {
     "nuxt": "^3.13.0"
+  },
+  "overrides": {
+    "@vitejs/devtools": "0.3.1"
   }
 }

--- a/sdk-typescript/runtime-tests/nuxt/run.sh
+++ b/sdk-typescript/runtime-tests/nuxt/run.sh
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 rm -rf node_modules package-lock.json .nuxt .output
+# package.json pins @vitejs/devtools to 0.3.1 via overrides: 0.4.2 (2026-07-21)
+# introduced a circular peer set (devtools-oxc/-rolldown/-vite) that crashes
+# npm's arborist ("Cannot read properties of null (reading 'edgesOut')").
+# Drop the override once npm or @vitejs/devtools ships a fix.
 npm install --silent
 npm install --silent "$API_CLIENT_TARBALL" "$TOOLBOX_API_CLIENT_TARBALL" "$ANALYTICS_API_CLIENT_TARBALL" "$SDK_TARBALL"
 npm run build >/dev/null


### PR DESCRIPTION
## Summary

Fixes #97 — the Go SDK's hardcoded 60s `http.Client` timeout blocked synchronous `ExecuteCommand` / `CodeRun` calls longer than 60s, even when a longer execution timeout was passed via options.

`http.Client.Timeout` is a hard cap that a context deadline cannot extend, so a config knob alone wouldn't fix the documented `WithExecuteTimeout(5*time.Minute)` case. This PR does both: adds a config escape hatch **and** makes the long-running exec paths honor their execution timeout automatically.

## Changes

- **`DaytonaConfig.Timeout` / `DaytonaConfig.HTTPClient`** — configurable per-request timeout and custom client. Default stays **60s** for all normal API calls. A caller-supplied client is shallow-copied (Transport shared) so the SDK's otel wrapping never mutates the caller's instance.
- **`ExecuteCommand` / `CodeRun`** — when an execution timeout is set, requests go through a `Timeout`-free client copy bounded instead by a context deadline of `execTimeout + 5s` (mirrors the Python SDK's `timeout + 5`). Caller `ctx` deadlines still win when earlier.
- **Sub-second timeouts round up** — `500ms` now maps to `timeout: 1` on the wire instead of truncating to `0` ("no limit"); avoids killing commands up to a second early. Exact-second values are unchanged.
- **Docs** — `WithExecuteTimeout` / `WithCodeRunTimeout` godoc corrected; the multi-minute example is now truthful. Regenerated sdk-docs artifacts.

## Behavior of edge values

| Value | Effect |
|---|---|
| `Timeout` ≤ 0 (config) | disables the client-wide timeout (Go stdlib semantics) |
| exec timeout `0` | no server-side limit; wait bounded only by `ctx` (no buffer added) |
| exec timeout `< 0` | rejected by the API (`400`), fails fast — passed through for cross-SDK parity |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Go SDK HTTP timeout configurable and fixes long-running ExecuteCommand/CodeRun calls being cut off at 60s. Synchronous executions now wait up to their specified timeout (with a small buffer) instead of the client-wide cap.

- **Bug Fixes**
  - ExecuteCommand and CodeRun honor their execution timeout by using a client copy without http.Client.Timeout, bounded by a context deadline of timeout + 5s. The caller’s context deadline still wins if earlier.
  - Sub-second execution timeouts round up to whole seconds to avoid truncating to 0 (“no limit”). 0 disables the server-side limit; negative values are rejected by the API.
  - Pin `@vitejs/devtools` to 0.3.1 in `sdk-typescript/runtime-tests/nuxt` to unblock Nuxt CI.

- **New Features**
  - DaytonaConfig.Timeout to override per-request HTTP timeout (≤0 disables the client-wide timeout).
  - DaytonaConfig.HTTPClient to supply a custom `*http.Client`; it’s shallow-copied (Transport shared). When both are set, Timeout overrides the copy’s.
  - Updated docs for WithExecuteTimeout and WithCodeRunTimeout to reflect the new behavior and correct examples.

<sup>Written for commit b8c94f754e2e4734525d2ee23649e3bb7d7ef5ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

