### PR TITLE
fix(sdk-python,sdk-ruby): share one expiry worker across event subscriptions

### DIFF
--- a/sdk-python/src/daytona/internal/event_subscription_manager.py
+++ b/sdk-python/src/daytona/internal/event_subscription_manager.py
@@ -4,11 +4,16 @@
 from __future__ import annotations
 
 import asyncio
+import heapq
+import logging
 import threading
+import time
 import uuid
 from typing import Callable
 
 from .event_dispatcher import AsyncEventDispatcher, AsyncEventHandler, EventHandler, SyncEventDispatcher
+
+logger = logging.getLogger(__name__)
 
 _SUBSCRIPTION_TTL: float = 300.0
 
@@ -18,7 +23,7 @@ class _Subscription:
 
     resource_id: str
     unsubscribe_fn: Callable[[], None]
-    timer: threading.Timer | asyncio.TimerHandle | None
+    timer: asyncio.TimerHandle | None
 
     def __init__(
         self,
@@ -28,6 +33,24 @@ class _Subscription:
         self.resource_id = resource_id
         self.unsubscribe_fn = unsubscribe_fn
         self.timer = None
+
+
+class _SyncSubscription:
+    __slots__: tuple[str, ...] = ("resource_id", "unsubscribe_fn", "expires_at")
+
+    resource_id: str
+    unsubscribe_fn: Callable[[], None]
+    expires_at: float
+
+    def __init__(
+        self,
+        resource_id: str,
+        unsubscribe_fn: Callable[[], None],
+        expires_at: float,
+    ) -> None:
+        self.resource_id = resource_id
+        self.unsubscribe_fn = unsubscribe_fn
+        self.expires_at = expires_at
 
 
 class AsyncEventSubscriptionManager:
@@ -117,17 +140,34 @@ class AsyncEventSubscriptionManager:
 
 
 class SyncEventSubscriptionManager:
-    """Thread-safe variant of AsyncEventSubscriptionManager."""
+    """Thread-safe variant of AsyncEventSubscriptionManager.
+
+    All subscriptions share ONE lazily started expiry worker thread instead of a
+    ``threading.Timer`` (a dedicated OS thread) per subscription. Listing many
+    sandboxes therefore costs one thread total, not one thread each
+    (https://github.com/daytona/clients/issues/108). ``refresh()`` only bumps the
+    subscription deadline — it never creates or cancels threads.
+    """
 
     _dispatcher: SyncEventDispatcher | None
-    _subscriptions: dict[str, _Subscription]
-    _lock: threading.Lock
+    _subscriptions: dict[str, _SyncSubscription]
+    _expiry_heap: list[tuple[float, str]]
+    _cond: threading.Condition
+    _worker: threading.Thread | None
+    _ttl: float
     _closed: bool
 
-    def __init__(self, dispatcher: SyncEventDispatcher | None) -> None:
+    def __init__(self, dispatcher: SyncEventDispatcher | None, ttl_seconds: float = _SUBSCRIPTION_TTL) -> None:
         self._dispatcher = dispatcher
         self._subscriptions = {}
-        self._lock = threading.Lock()
+        # Min-heap of (deadline, sub_id). Entries are lazily invalidated: a popped
+        # entry is discarded when its subscription is gone, or re-pushed at the
+        # current deadline when the subscription was refreshed in the meantime.
+        # Invariant: every live subscription has at least one heap entry.
+        self._expiry_heap = []
+        self._cond = threading.Condition()
+        self._worker = None
+        self._ttl = ttl_seconds
         self._closed = False
 
     @property
@@ -146,21 +186,27 @@ class SyncEventSubscriptionManager:
         unsubscribe_fn = self._dispatcher.subscribe(resource_id, handler, events)
 
         sub_id = uuid.uuid4().hex
-        sub = _Subscription(resource_id=resource_id, unsubscribe_fn=unsubscribe_fn)
+        sub = _SyncSubscription(
+            resource_id=resource_id,
+            unsubscribe_fn=unsubscribe_fn,
+            expires_at=time.monotonic() + self._ttl,
+        )
 
-        with self._lock:
+        with self._cond:
             if self._closed:
                 # shutdown() raced between the check above and here — undo the
                 # dispatcher listener we just created instead of leaking it.
                 unsubscribe_fn()
                 return ""
             self._subscriptions[sub_id] = sub
-            self._start_timer_locked(sub_id)
+            heapq.heappush(self._expiry_heap, (sub.expires_at, sub_id))
+            self._ensure_worker_locked()
+            self._cond.notify()
 
         return sub_id
 
     def refresh(self, sub_id: str) -> bool:
-        with self._lock:
+        with self._cond:
             if self._closed:
                 return False
 
@@ -168,54 +214,74 @@ class SyncEventSubscriptionManager:
             if sub is None:
                 return False
 
-            self._start_timer_locked(sub_id)
+            # No heap entry or worker wake-up needed: when the old deadline pops,
+            # the worker sees the newer expires_at and re-queues the subscription.
+            sub.expires_at = time.monotonic() + self._ttl
             return True
 
     def unsubscribe(self, sub_id: str) -> None:
-        with self._lock:
+        with self._cond:
             sub = self._subscriptions.pop(sub_id, None)
             if sub is None:
                 return
-            if sub.timer is not None:
-                sub.timer.cancel()
+            # The stale heap entry is discarded when the worker pops it.
 
         sub.unsubscribe_fn()
 
-    # ------------------------------------------------------------------
-    # Timer management — must be called while holding self._lock.
-    # ------------------------------------------------------------------
+    def _ensure_worker_locked(self) -> None:
+        """Start the shared expiry worker if it is not running. Caller holds self._cond."""
+        if self._worker is None:
+            worker = threading.Thread(
+                target=self._expiry_loop,
+                name="daytona-subscription-expiry",
+                daemon=True,
+            )
+            self._worker = worker
+            worker.start()
 
-    def _start_timer_locked(self, sub_id: str) -> None:
-        sub = self._subscriptions.get(sub_id)
-        if sub is None:
-            return
+    def _expiry_loop(self) -> None:
+        while True:
+            expired: list[_SyncSubscription] = []
+            with self._cond:
+                while not expired:
+                    if self._closed:
+                        return
+                    if not self._expiry_heap:
+                        # No live subscriptions remain (see heap invariant above):
+                        # exit and let the next subscribe() start a fresh worker.
+                        self._worker = None
+                        return
+                    now = time.monotonic()
+                    deadline = self._expiry_heap[0][0]
+                    if deadline > now:
+                        _ = self._cond.wait(deadline - now)
+                        continue
+                    while self._expiry_heap and self._expiry_heap[0][0] <= now:
+                        _, sub_id = heapq.heappop(self._expiry_heap)
+                        sub = self._subscriptions.get(sub_id)
+                        if sub is None:
+                            continue
+                        if sub.expires_at > now:
+                            heapq.heappush(self._expiry_heap, (sub.expires_at, sub_id))
+                            continue
+                        del self._subscriptions[sub_id]
+                        expired.append(sub)
 
-        if sub.timer is not None:
-            sub.timer.cancel()
-
-        current_timer: threading.Timer | None = None
-
-        def _expire() -> None:
-            with self._lock:
-                s = self._subscriptions.get(sub_id)
-                if s is None or s.timer is not current_timer:
-                    return
-                _ = self._subscriptions.pop(sub_id, None)
-
-            s.unsubscribe_fn()
-
-        current_timer = threading.Timer(_SUBSCRIPTION_TTL, _expire)
-        current_timer.daemon = True
-        sub.timer = current_timer
-        current_timer.start()
+            for sub in expired:
+                try:
+                    sub.unsubscribe_fn()
+                except Exception:  # pylint: disable=broad-exception-caught
+                    # One failing dispatcher unsubscribe must not kill the shared
+                    # worker and silently stop expiry for every other subscription.
+                    logger.debug("Unsubscribe error for %s", sub.resource_id, exc_info=True)
 
     def shutdown(self) -> None:
-        with self._lock:
+        with self._cond:
             self._closed = True
             subs = list(self._subscriptions.values())
             self._subscriptions.clear()
+            self._expiry_heap.clear()
+            self._cond.notify_all()
 
         for sub in subs:
-            if sub.timer is not None:
-                sub.timer.cancel()
             sub.unsubscribe_fn()

--- a/sdk-python/src/daytona/internal/event_subscription_manager.py
+++ b/sdk-python/src/daytona/internal/event_subscription_manager.py
@@ -224,13 +224,23 @@ class SyncEventSubscriptionManager:
             sub = self._subscriptions.pop(sub_id, None)
             if sub is None:
                 return
-            # The stale heap entry is discarded when the worker pops it.
+            # The stale heap entry is discarded when the worker pops it — except
+            # when it was the last subscription: drop the leftovers and wake the
+            # worker so it exits now instead of idling until the old deadline.
+            if not self._subscriptions:
+                self._expiry_heap.clear()
+                self._cond.notify()
 
         sub.unsubscribe_fn()
 
     def _ensure_worker_locked(self) -> None:
-        """Start the shared expiry worker if it is not running. Caller holds self._cond."""
-        if self._worker is None:
+        """Start the shared expiry worker if it is not running. Caller holds self._cond.
+
+        The is_alive() check is a safety net: a worker that crashed for any reason
+        leaves a dead-but-set reference, and a plain None check would then block
+        replacements forever, silently disabling expiry.
+        """
+        if self._worker is None or not self._worker.is_alive():
             worker = threading.Thread(
                 target=self._expiry_loop,
                 name="daytona-subscription-expiry",

--- a/sdk-python/tests/test_event_subscription_manager.py
+++ b/sdk-python/tests/test_event_subscription_manager.py
@@ -174,3 +174,32 @@ class TestSyncEventSubscriptionManagerRobustness:
 
         assert _wait_until(lambda: "sandbox-good" in dispatcher.unsubscribed)
         manager.shutdown()
+
+    def test_worker_is_replaced_when_it_died_unexpectedly(self):
+        """A crashed worker leaves a dead-but-set thread reference; the next
+        subscribe must detect it via is_alive() and start a replacement.
+        """
+        dispatcher = FakeSyncDispatcher()
+        manager = SyncEventSubscriptionManager(dispatcher, ttl_seconds=0.1)
+
+        dead_thread = threading.Thread(target=lambda: None)
+        dead_thread.start()
+        dead_thread.join()
+        with manager._cond:  # pylint: disable=protected-access
+            manager._worker = dead_thread  # pylint: disable=protected-access
+
+        manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"])
+
+        assert _wait_until(lambda: dispatcher.unsubscribed == ["sandbox-1"])
+        manager.shutdown()
+
+    def test_worker_exits_promptly_after_last_unsubscribe(self):
+        dispatcher = FakeSyncDispatcher()
+        manager = SyncEventSubscriptionManager(dispatcher, ttl_seconds=60.0)
+        threads_before = threading.active_count()
+        sub_id = manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"])
+
+        manager.unsubscribe(sub_id)
+
+        assert _wait_until(lambda: threading.active_count() == threads_before, timeout=2.0)
+        manager.shutdown()

--- a/sdk-python/tests/test_event_subscription_manager.py
+++ b/sdk-python/tests/test_event_subscription_manager.py
@@ -1,0 +1,176 @@
+# Copyright Daytona Platforms Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Callable
+
+from daytona.internal.event_subscription_manager import SyncEventSubscriptionManager
+
+
+class FakeSyncDispatcher:
+    """Minimal SyncEventDispatcher stand-in that records subscribe/unsubscribe calls."""
+
+    def __init__(self, failing_resources: set[str] | None = None) -> None:
+        self.subscribe_calls: list[str] = []
+        self.unsubscribed: list[str] = []
+        self._failing_resources = failing_resources or set()
+        self._lock = threading.Lock()
+
+    def subscribe(
+        self,
+        resource_id: str,
+        handler: Callable[[str, Any], None],
+        events: list[str],
+    ) -> Callable[[], None]:
+        del handler, events
+        with self._lock:
+            self.subscribe_calls.append(resource_id)
+
+        def unsubscribe() -> None:
+            if resource_id in self._failing_resources:
+                raise RuntimeError(f"unsubscribe failed for {resource_id}")
+            with self._lock:
+                self.unsubscribed.append(resource_id)
+
+        return unsubscribe
+
+
+def _noop_handler(_event_name: str, _data: Any) -> None:
+    pass
+
+
+def _wait_until(condition: Callable[[], bool], timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return True
+        time.sleep(0.01)
+    return condition()
+
+
+class TestSyncEventSubscriptionManagerThreadUsage:
+    def test_many_subscriptions_share_one_expiry_thread(self):
+        """Regression test for daytona/clients#108: listing ~10k sandboxes created
+        one threading.Timer (OS thread) per subscription and OOMed 512MiB containers.
+        """
+        dispatcher = FakeSyncDispatcher()
+        manager = SyncEventSubscriptionManager(dispatcher)
+        threads_before = threading.active_count()
+
+        sub_ids = [manager.subscribe(f"sandbox-{i}", _noop_handler, ["sandbox.state.updated"]) for i in range(500)]
+
+        threads_after = threading.active_count()
+        assert all(sub_ids)
+        # A single shared expiry worker is allowed; one thread per subscription is the bug.
+        assert threads_after - threads_before <= 1
+        manager.shutdown()
+
+    def test_refresh_does_not_spawn_threads(self):
+        dispatcher = FakeSyncDispatcher()
+        manager = SyncEventSubscriptionManager(dispatcher)
+        sub_id = manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"])
+        threads_before = threading.active_count()
+
+        for _ in range(100):
+            assert manager.refresh(sub_id)
+
+        assert threading.active_count() == threads_before
+        manager.shutdown()
+
+
+class TestSyncEventSubscriptionManagerTtl:
+    def test_subscription_expires_after_ttl(self):
+        dispatcher = FakeSyncDispatcher()
+        manager = SyncEventSubscriptionManager(dispatcher, ttl_seconds=0.1)
+
+        sub_id = manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"])
+
+        assert _wait_until(lambda: dispatcher.unsubscribed == ["sandbox-1"])
+        assert not manager.refresh(sub_id)
+
+    def test_refresh_extends_ttl(self):
+        dispatcher = FakeSyncDispatcher()
+        manager = SyncEventSubscriptionManager(dispatcher, ttl_seconds=0.3)
+
+        sub_id = manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"])
+        # Keep refreshing past the original deadline.
+        for _ in range(4):
+            time.sleep(0.15)
+            assert manager.refresh(sub_id)
+        assert dispatcher.unsubscribed == []
+
+        # Stop refreshing: the subscription must now expire.
+        assert _wait_until(lambda: dispatcher.unsubscribed == ["sandbox-1"])
+        manager.shutdown()
+
+    def test_subscribe_works_after_all_subscriptions_expired(self):
+        """The expiry worker may exit when idle; a later subscribe must still expire."""
+        dispatcher = FakeSyncDispatcher()
+        manager = SyncEventSubscriptionManager(dispatcher, ttl_seconds=0.1)
+
+        manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"])
+        assert _wait_until(lambda: dispatcher.unsubscribed == ["sandbox-1"])
+
+        manager.subscribe("sandbox-2", _noop_handler, ["sandbox.state.updated"])
+        assert _wait_until(lambda: dispatcher.unsubscribed == ["sandbox-1", "sandbox-2"])
+        manager.shutdown()
+
+
+class TestSyncEventSubscriptionManagerLifecycle:
+    def test_unsubscribe_calls_dispatcher_once(self):
+        dispatcher = FakeSyncDispatcher()
+        manager = SyncEventSubscriptionManager(dispatcher)
+        sub_id = manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"])
+
+        manager.unsubscribe(sub_id)
+        manager.unsubscribe(sub_id)
+
+        assert dispatcher.unsubscribed == ["sandbox-1"]
+        assert not manager.refresh(sub_id)
+        manager.shutdown()
+
+    def test_shutdown_unsubscribes_all_and_blocks_new_subscriptions(self):
+        dispatcher = FakeSyncDispatcher()
+        manager = SyncEventSubscriptionManager(dispatcher)
+        manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"])
+        manager.subscribe("sandbox-2", _noop_handler, ["sandbox.state.updated"])
+
+        manager.shutdown()
+
+        assert sorted(dispatcher.unsubscribed) == ["sandbox-1", "sandbox-2"]
+        assert manager.subscribe("sandbox-3", _noop_handler, ["sandbox.state.updated"]) == ""
+
+    def test_shutdown_stops_expiry_worker(self):
+        dispatcher = FakeSyncDispatcher()
+        manager = SyncEventSubscriptionManager(dispatcher, ttl_seconds=60.0)
+        manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"])
+        assert threading.active_count() >= 2
+
+        threads_expected = threading.active_count() - 1
+        manager.shutdown()
+
+        assert _wait_until(lambda: threading.active_count() == threads_expected)
+
+    def test_subscribe_without_dispatcher_is_noop(self):
+        manager = SyncEventSubscriptionManager(None)
+        assert manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"]) == ""
+        assert not manager.refresh("missing")
+
+
+class TestSyncEventSubscriptionManagerRobustness:
+    def test_raising_unsubscribe_does_not_kill_the_expiry_worker(self):
+        """A failing dispatcher unsubscribe for one subscription must not stop
+        TTL expiry for every other subscription (the old per-thread design only
+        lost the one thread; the shared worker must be at least as robust).
+        """
+        dispatcher = FakeSyncDispatcher(failing_resources={"sandbox-faulty"})
+        manager = SyncEventSubscriptionManager(dispatcher, ttl_seconds=0.1)
+
+        manager.subscribe("sandbox-faulty", _noop_handler, ["sandbox.state.updated"])
+        manager.subscribe("sandbox-good", _noop_handler, ["sandbox.state.updated"])
+
+        assert _wait_until(lambda: "sandbox-good" in dispatcher.unsubscribed)
+        manager.shutdown()

--- a/sdk-ruby/lib/daytona/common/event_subscription_manager.rb
+++ b/sdk-ruby/lib/daytona/common/event_subscription_manager.rb
@@ -6,14 +6,29 @@
 require 'securerandom'
 
 module Daytona
+  # Tracks dispatcher subscriptions with TTL auto-expiry.
+  #
+  # All subscriptions share ONE lazily started expiry worker thread instead of a
+  # dedicated sleeping thread per subscription, so listing many sandboxes costs
+  # one thread total, not one thread each
+  # (https://github.com/daytona/clients/issues/108). #refresh only bumps the
+  # subscription deadline — it never creates or kills threads.
   class EventSubscriptionManager
     SUBSCRIPTION_TTL = 300
     private_constant :SUBSCRIPTION_TTL
 
-    def initialize(dispatcher = nil)
+    def initialize(dispatcher = nil, ttl_seconds: SUBSCRIPTION_TTL)
       @dispatcher = dispatcher
+      @ttl = ttl_seconds
       @subscriptions = {}
+      # Deadline-ordered [expires_at, sub_id] entries. Entries are lazily
+      # invalidated: a popped entry is discarded when its subscription is gone,
+      # or re-queued at the current deadline when it was refreshed meanwhile.
+      # Invariant: every live subscription has at least one queue entry.
+      @expiry_queue = []
       @mutex = Mutex.new
+      @cond = ConditionVariable.new
+      @worker = nil
       @closed = false
     end
 
@@ -24,7 +39,6 @@ module Daytona
 
       unsubscribe = @dispatcher.subscribe(resource_id, events:, &handler)
       sub_id = SecureRandom.hex(16)
-      timer_to_stop = nil
       rollback_unsubscribe = nil
 
       @mutex.synchronize do
@@ -34,8 +48,11 @@ module Daytona
           next
         end
 
-        @subscriptions[sub_id] = { unsubscribe:, timer: nil }
-        timer_to_stop = start_timer_locked(sub_id)
+        expires_at = monotonic_now + @ttl
+        @subscriptions[sub_id] = { unsubscribe:, expires_at: }
+        push_entry_locked(expires_at, sub_id)
+        ensure_worker_locked
+        @cond.signal
       end
 
       if rollback_unsubscribe
@@ -43,44 +60,27 @@ module Daytona
         return nil
       end
 
-      stop_thread(timer_to_stop)
       sub_id
     end
 
     def refresh(sub_id)
       @mutex.synchronize do
-        # Reject after shutdown to prevent use-after-close
         return false if @closed
+
+        subscription = @subscriptions[sub_id]
+        return false unless subscription
+
+        # No queue entry or worker wake-up needed: when the old deadline pops,
+        # the worker sees the newer expires_at and re-queues the subscription.
+        subscription[:expires_at] = monotonic_now + @ttl
+        true
       end
-
-      timer_to_stop = nil
-
-      @mutex.synchronize do
-        return false unless @subscriptions.key?(sub_id)
-
-        timer_to_stop = start_timer_locked(sub_id)
-      end
-
-      stop_thread(timer_to_stop)
-      true
     end
 
     def unsubscribe(sub_id)
-      subscription = nil
-      timer = nil
-
-      @mutex.synchronize do
-        subscription = @subscriptions.delete(sub_id)
-        if subscription
-          timer = subscription[:timer]
-          subscription[:timer] = nil
-        end
-      end
-
-      return unless subscription
-
-      stop_thread(timer)
-      subscription[:unsubscribe].call
+      subscription = @mutex.synchronize { @subscriptions.delete(sub_id) }
+      # The stale queue entry is discarded when the worker pops it.
+      subscription&.dig(:unsubscribe)&.call
     end
 
     def shutdown
@@ -90,55 +90,93 @@ module Daytona
         @closed = true
         subscriptions = @subscriptions.values
         @subscriptions = {}
+        @expiry_queue.clear
+        @cond.broadcast
       end
 
-      subscriptions.each do |subscription|
-        stop_thread(subscription[:timer])
-        subscription[:unsubscribe].call
-      end
+      subscriptions.each { |subscription| subscription[:unsubscribe].call }
     end
 
     private
 
-    def start_timer_locked(sub_id)
-      subscription = @subscriptions[sub_id]
-      return unless subscription
+    def monotonic_now
+      ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+    end
 
-      previous_timer = cancel_timer_locked(sub_id)
-      timer = Thread.new do
-        sleep(SUBSCRIPTION_TTL)
+    # Caller must hold @mutex.
+    def push_entry_locked(expires_at, sub_id)
+      index = @expiry_queue.bsearch_index { |entry| entry[0] > expires_at } || @expiry_queue.length
+      @expiry_queue.insert(index, [expires_at, sub_id])
+    end
 
-        unsubscribe = @mutex.synchronize do
-          current_subscription = @subscriptions[sub_id]
-          next unless current_subscription && current_subscription[:timer] == Thread.current
+    # Caller must hold @mutex.
+    def ensure_worker_locked
+      return if @worker
 
-          @subscriptions.delete(sub_id)&.dig(:unsubscribe)
+      @worker = Thread.new { expiry_loop }
+      @worker.abort_on_exception = false
+    end
+
+    def expiry_loop
+      loop do
+        expired = collect_expired
+        return if expired.nil?
+
+        expired.each do |subscription|
+          subscription[:unsubscribe].call
+        rescue StandardError
+          # One failing dispatcher unsubscribe must not kill the shared worker
+          # and silently stop expiry for every other subscription.
+          nil
+        end
+      end
+    end
+
+    # Blocks until at least one subscription expires. Returns nil when the
+    # worker should exit (shutdown, or no live subscriptions remain).
+    def collect_expired
+      @mutex.synchronize do
+        expired = []
+
+        while expired.empty?
+          return nil if @closed
+
+          if @expiry_queue.empty?
+            # No live subscriptions remain (see queue invariant above):
+            # exit and let the next subscribe start a fresh worker.
+            @worker = nil
+            return nil
+          end
+
+          now = monotonic_now
+          deadline = @expiry_queue.first[0]
+          if deadline > now
+            @cond.wait(@mutex, deadline - now)
+            next
+          end
+
+          drain_due_entries_locked(now, expired)
         end
 
-        unsubscribe&.call
+        expired
       end
-      timer.abort_on_exception = false
-      subscription[:timer] = timer
-      previous_timer
     end
 
-    def cancel_timer_locked(sub_id)
-      subscription = @subscriptions[sub_id]
-      return unless subscription
+    # Caller must hold @mutex.
+    def drain_due_entries_locked(now, expired)
+      while !@expiry_queue.empty? && @expiry_queue.first[0] <= now
+        _, sub_id = @expiry_queue.shift
+        subscription = @subscriptions[sub_id]
+        next unless subscription
 
-      timer = subscription[:timer]
-      subscription[:timer] = nil
-      timer
-    end
+        if subscription[:expires_at] > now
+          push_entry_locked(subscription[:expires_at], sub_id)
+          next
+        end
 
-    def stop_thread(thread)
-      return unless thread
-      return if thread == Thread.current
-
-      thread.kill
-      thread.join
-    rescue StandardError
-      nil
+        @subscriptions.delete(sub_id)
+        expired << subscription
+      end
     end
   end
 end

--- a/sdk-ruby/lib/daytona/common/event_subscription_manager.rb
+++ b/sdk-ruby/lib/daytona/common/event_subscription_manager.rb
@@ -78,8 +78,17 @@ module Daytona
     end
 
     def unsubscribe(sub_id)
-      subscription = @mutex.synchronize { @subscriptions.delete(sub_id) }
-      # The stale queue entry is discarded when the worker pops it.
+      subscription = @mutex.synchronize do
+        removed = @subscriptions.delete(sub_id)
+        # The stale queue entry is discarded when the worker pops it — except
+        # when it was the last subscription: drop the leftovers and wake the
+        # worker so it exits now instead of idling until the old deadline.
+        if removed && @subscriptions.empty?
+          @expiry_queue.clear
+          @cond.signal
+        end
+        removed
+      end
       subscription&.dig(:unsubscribe)&.call
     end
 
@@ -109,11 +118,14 @@ module Daytona
       @expiry_queue.insert(index, [expires_at, sub_id])
     end
 
-    # Caller must hold @mutex.
+    # Caller must hold @mutex. The alive? check is a safety net: a worker that
+    # crashed for any reason leaves a dead-but-truthy reference, and a plain nil
+    # check would then block replacements forever, silently disabling expiry.
     def ensure_worker_locked
-      return if @worker
+      return if @worker&.alive?
 
       @worker = Thread.new { expiry_loop }
+      @worker.name = 'daytona-subscription-expiry'
       @worker.abort_on_exception = false
     end
 

--- a/sdk-ruby/spec/daytona/event_subscription_manager_spec.rb
+++ b/sdk-ruby/spec/daytona/event_subscription_manager_spec.rb
@@ -115,6 +115,17 @@ RSpec.describe Daytona::EventSubscriptionManager do
       expect(manager.refresh(sub_id)).to be(false)
       manager.shutdown
     end
+
+    it 'lets the worker exit promptly after the last subscription is removed' do
+      manager = described_class.new(dispatcher, ttl_seconds: 60)
+      threads_before = Thread.list.size
+      sub_id = manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
+
+      manager.unsubscribe(sub_id)
+
+      expect(wait_until(timeout: 2) { Thread.list.size == threads_before }).to be(true)
+      manager.shutdown
+    end
   end
 
   describe 'expiry worker robustness' do
@@ -126,6 +137,27 @@ RSpec.describe Daytona::EventSubscriptionManager do
       manager.subscribe(resource_id: 'sandbox-good', handler:, events:)
 
       expect(wait_until { dispatcher.unsubscribed.include?('sandbox-good') }).to be(true)
+      manager.shutdown
+    end
+
+    it 'replaces the worker when it died unexpectedly' do
+      manager = described_class.new(dispatcher, ttl_seconds: 0.1)
+
+      dead_thread = Thread.new { nil }
+      dead_thread.join
+      manager.instance_variable_set(:@worker, dead_thread)
+
+      manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
+
+      expect(wait_until { dispatcher.unsubscribed == ['sandbox-1'] }).to be(true)
+      manager.shutdown
+    end
+
+    it 'names the expiry worker thread for debugging' do
+      manager = described_class.new(dispatcher, ttl_seconds: 60)
+      manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
+
+      expect(Thread.list.map(&:name)).to include('daytona-subscription-expiry')
       manager.shutdown
     end
   end

--- a/sdk-ruby/spec/daytona/event_subscription_manager_spec.rb
+++ b/sdk-ruby/spec/daytona/event_subscription_manager_spec.rb
@@ -4,6 +4,37 @@
 # frozen_string_literal: true
 
 RSpec.describe Daytona::EventSubscriptionManager do
+  let(:fake_dispatcher_class) do
+    Class.new do
+      attr_reader :unsubscribed
+
+      def initialize(failing_resources: [])
+        @unsubscribed = []
+        @failing_resources = failing_resources
+        @mutex = Mutex.new
+      end
+
+      def subscribe(resource_id, events:, &_handler)
+        _ = events
+        proc do
+          raise "unsubscribe failed for #{resource_id}" if @failing_resources.include?(resource_id)
+
+          @mutex.synchronize { @unsubscribed << resource_id }
+        end
+      end
+    end
+  end
+
+  let(:dispatcher) { fake_dispatcher_class.new }
+  let(:handler) { proc { |_event_name, _data| } }
+  let(:events) { ['sandbox.state.updated'] }
+
+  def wait_until(timeout: 5)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    sleep(0.01) while !yield && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+    yield
+  end
+
   describe '#subscribe' do
     it 'is a no-op when no dispatcher is configured' do
       manager = described_class.new(nil)
@@ -16,6 +47,109 @@ RSpec.describe Daytona::EventSubscriptionManager do
 
       expect(sub_id).to be_nil
       expect(manager.refresh('missing')).to be(false)
+    end
+
+    it 'shares one expiry thread across many subscriptions' do
+      manager = described_class.new(dispatcher)
+      threads_before = Thread.list.size
+
+      sub_ids = Array.new(500) do |i|
+        manager.subscribe(resource_id: "sandbox-#{i}", handler:, events:)
+      end
+
+      expect(sub_ids).to all(be_a(String))
+      expect(Thread.list.size - threads_before).to be <= 1
+      manager.shutdown
+    end
+
+    it 'expires the subscription after the TTL and works again after the worker went idle' do
+      manager = described_class.new(dispatcher, ttl_seconds: 0.1)
+
+      sub_id = manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
+
+      expect(wait_until { dispatcher.unsubscribed == ['sandbox-1'] }).to be(true)
+      expect(manager.refresh(sub_id)).to be(false)
+
+      manager.subscribe(resource_id: 'sandbox-2', handler:, events:)
+      expect(wait_until { dispatcher.unsubscribed == %w[sandbox-1 sandbox-2] }).to be(true)
+      manager.shutdown
+    end
+  end
+
+  describe '#refresh' do
+    it 'does not spawn threads' do
+      manager = described_class.new(dispatcher)
+      sub_id = manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
+      threads_before = Thread.list.size
+
+      100.times { expect(manager.refresh(sub_id)).to be(true) }
+
+      expect(Thread.list.size).to eq(threads_before)
+      manager.shutdown
+    end
+
+    it 'extends the TTL past the original deadline' do
+      manager = described_class.new(dispatcher, ttl_seconds: 0.3)
+      sub_id = manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
+
+      4.times do
+        sleep(0.15)
+        expect(manager.refresh(sub_id)).to be(true)
+      end
+      expect(dispatcher.unsubscribed).to be_empty
+
+      expect(wait_until { dispatcher.unsubscribed == ['sandbox-1'] }).to be(true)
+      manager.shutdown
+    end
+  end
+
+  describe '#unsubscribe' do
+    it 'calls the dispatcher unsubscribe exactly once' do
+      manager = described_class.new(dispatcher)
+      sub_id = manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
+
+      manager.unsubscribe(sub_id)
+      manager.unsubscribe(sub_id)
+
+      expect(dispatcher.unsubscribed).to eq(['sandbox-1'])
+      expect(manager.refresh(sub_id)).to be(false)
+      manager.shutdown
+    end
+  end
+
+  describe 'expiry worker robustness' do
+    it 'keeps expiring other subscriptions when one dispatcher unsubscribe raises' do
+      dispatcher = fake_dispatcher_class.new(failing_resources: ['sandbox-faulty'])
+      manager = described_class.new(dispatcher, ttl_seconds: 0.1)
+
+      manager.subscribe(resource_id: 'sandbox-faulty', handler:, events:)
+      manager.subscribe(resource_id: 'sandbox-good', handler:, events:)
+
+      expect(wait_until { dispatcher.unsubscribed.include?('sandbox-good') }).to be(true)
+      manager.shutdown
+    end
+  end
+
+  describe '#shutdown' do
+    it 'unsubscribes everything and rejects new subscriptions' do
+      manager = described_class.new(dispatcher)
+      manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
+      manager.subscribe(resource_id: 'sandbox-2', handler:, events:)
+
+      manager.shutdown
+
+      expect(dispatcher.unsubscribed.sort).to eq(%w[sandbox-1 sandbox-2])
+      expect(manager.subscribe(resource_id: 'sandbox-3', handler:, events:)).to be_nil
+    end
+
+    it 'stops the expiry worker' do
+      manager = described_class.new(dispatcher, ttl_seconds: 60)
+      manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
+      threads_with_worker = Thread.list.size
+
+      manager.shutdown
+
+      expect(wait_until { Thread.list.size == threads_with_worker - 1 }).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #108 — `Daytona.list()` memory regression introduced in 0.198.0.

The sync subscription managers created a dedicated OS thread per subscription
(`threading.Timer` in Python, `Thread.new + sleep` in Ruby) to enforce the 300s
TTL, and every `Sandbox` subscribes at construction. Listing ~10.3k sandboxes
therefore spawned ~10.3k threads (~440 MB RSS) and OOMed 512 MiB containers.
`refresh()` — called on every public sandbox method — also destroyed and
re-created a thread per call.

Both managers now use one lazily started shared expiry worker (the same pattern
the Java SDK already uses): a deadline-ordered queue with lazy invalidation,
where `refresh()` only bumps the subscription deadline. A failing dispatcher
unsubscribe is contained per-subscription so it cannot stop expiry for others.
The worker exits when no subscriptions remain.

No public API or behavior changes: listed sandboxes still subscribe eagerly and
passively update `.state`, TTL semantics are unchanged. TypeScript (`setTimeout`
+ `unref`), Go (`time.AfterFunc`), Java (shared `ScheduledThreadPoolExecutor`),
and async Python (`loop.call_later`) were audited and are not affected.

## Verification

Issue repro against production, 2033 sandboxes, `list(client.list(ListSandboxesQuery(limit=200)))`:

| | threads after `list()` | RSS delta |
|---|---:|---:|
| 0.197.0 (baseline) | 1 | +24 MB |
| 0.200.0 | 2036 | +67 MB |
| **0.200.0 + this fix** | **4** | **+28 MB** |

(3 of the 4 threads are the main thread + socket.io read/write loops; the fix
contributes at most one, independent of list size.)

- New regression tests assert thread count stays flat across 500 subscriptions
  and cover TTL expiry, refresh extension, worker restart after idle,
  unsubscribe idempotency, faulty-unsubscribe isolation, and shutdown.
- Full suites green: sdk-python 544 passed, sdk-ruby 452 passed.
- Live QA: WS-event-driven `start()`/`exec`/`stop()` verified against prod.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share a single, lazy expiry worker across event subscriptions in `sdk-python` and `sdk-ruby` to remove per-subscription threads and fix thread/memory spikes when listing many sandboxes. The worker now recovers after crashes and exits promptly when idle; TTL behavior and public APIs are unchanged.

- **Bug Fixes**
  - Eliminated thread explosion from per-subscription timers; thread count stays flat even with thousands of subscriptions (e.g., ~2k adds ~1 thread).
  - Expiry worker restarts if it dies unexpectedly and exits immediately after the last unsubscribe, preventing stuck expiry or idle sleeps.

- **Refactors**
  - Replaced per-subscription timers with a deadline-ordered queue and shared worker; `refresh()` only bumps deadlines, and unsubscribe failures are isolated and logged.
  - Added regression tests for TTL expiry, refresh extension, worker idle/restart, unsubscribe idempotency, and shutdown.

<sup>Written for commit 5b693a2d1a78af717e67c1cb5137473fc21f24f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

