### PR TITLE
chore(codeowners): correct enforcement note and add @aprojic to security files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,19 @@
 # CODEOWNERS -- Daytona
 # These owners are automatically requested for review on PRs that modify the listed files.
 # Multiple owners = OR semantics (any one can approve).
-# Enforcement: the "Security baseline" Ruleset requires CODEOWNERS review on main,
+# Enforcement: classic branch protection on main requires code owner review,
 # so listed owners must approve before merge.
 
 # Security and compliance policies (CISO-owned)
-SECURITY.md                @MDzaja
-CODE_OF_CONDUCT.md         @MDzaja
+SECURITY.md                @MDzaja @aprojic
+CODE_OF_CONDUCT.md         @MDzaja @aprojic
 
 # Contributor License Agreement (legal)
 CLA.md                     @MDzaja @aprojic
 
 # CI/CD pipelines and composite actions
+# NOTE: job names in pr_checks.yaml and cla.yaml are required status checks on
+# main -- renaming a job without updating the branch protection list blocks all merges.
 .github/workflows/         @MDzaja
 .github/actions/           @MDzaja
 


### PR DESCRIPTION
- The header claimed a "Security baseline" ruleset enforces CODEOWNERS review — that ruleset does not exist in this org. Code owner review is enforced by classic branch protection on `main`.
- Documents that CI job names in `pr_checks.yaml` / `cla.yaml` are bound to the required status checks on `main`: renaming a job without updating the branch protection list blocks all merges.
- Adds @aprojic as co-owner (OR semantics) of `SECURITY.md` and `CODE_OF_CONDUCT.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `.github/CODEOWNERS` to correct the enforcement note (classic branch protection on `main` requires code owner review) and document that CI job names in `pr_checks.yaml` and `cla.yaml` are bound to required status checks. Add `@aprojic` as co-owner of `SECURITY.md` and `CODE_OF_CONDUCT.md`.

<sup>Written for commit 20a7ae915373bfe4ce54fbd009f59a5c23204dde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

