### PR TITLE
fix(sdk): sign S3 requests with the region provided by the API

### DIFF
--- a/api-client-go/api/openapi.yaml
+++ b/api-client-go/api/openapi.yaml
@@ -12225,6 +12225,7 @@ components:
         accessKey: temp-user-123
         sessionToken: eyJhbGciOiJIUzI1NiIs...
         secret: abchbGciOiJIUzI1NiIs...
+        region: us-east-1
         storageUrl: storage.example.com
       properties:
         accessKey:
@@ -12251,10 +12252,15 @@ components:
           description: S3 bucket name
           example: daytona
           type: string
+        region:
+          description: Region for the storage backend (e.g. "us-east-2")
+          example: us-east-1
+          type: string
       required:
       - accessKey
       - bucket
       - organizationId
+      - region
       - secret
       - sessionToken
       - storageUrl

--- a/api-client-go/model_storage_access_dto.go
+++ b/api-client-go/model_storage_access_dto.go
@@ -33,6 +33,8 @@ type StorageAccessDto struct {
 	OrganizationId string `json:"organizationId"`
 	// S3 bucket name
 	Bucket string `json:"bucket"`
+	// Region for the storage backend (e.g. \"us-east-2\")
+	Region string `json:"region"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -42,7 +44,7 @@ type _StorageAccessDto StorageAccessDto
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewStorageAccessDto(accessKey string, secret string, sessionToken string, storageUrl string, organizationId string, bucket string) *StorageAccessDto {
+func NewStorageAccessDto(accessKey string, secret string, sessionToken string, storageUrl string, organizationId string, bucket string, region string) *StorageAccessDto {
 	this := StorageAccessDto{}
 	this.AccessKey = accessKey
 	this.Secret = secret
@@ -50,6 +52,7 @@ func NewStorageAccessDto(accessKey string, secret string, sessionToken string, s
 	this.StorageUrl = storageUrl
 	this.OrganizationId = organizationId
 	this.Bucket = bucket
+	this.Region = region
 	return &this
 }
 
@@ -205,6 +208,30 @@ func (o *StorageAccessDto) SetBucket(v string) {
 	o.Bucket = v
 }
 
+// GetRegion returns the Region field value
+func (o *StorageAccessDto) GetRegion() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.Region
+}
+
+// GetRegionOk returns a tuple with the Region field value
+// and a boolean to check if the value has been set.
+func (o *StorageAccessDto) GetRegionOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Region, true
+}
+
+// SetRegion sets field value
+func (o *StorageAccessDto) SetRegion(v string) {
+	o.Region = v
+}
+
 func (o StorageAccessDto) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -221,6 +248,7 @@ func (o StorageAccessDto) ToMap() (map[string]interface{}, error) {
 	toSerialize["storageUrl"] = o.StorageUrl
 	toSerialize["organizationId"] = o.OrganizationId
 	toSerialize["bucket"] = o.Bucket
+	toSerialize["region"] = o.Region
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -240,6 +268,7 @@ func (o *StorageAccessDto) UnmarshalJSON(data []byte) (err error) {
 		"storageUrl",
 		"organizationId",
 		"bucket",
+		"region",
 	}
 
 	allProperties := make(map[string]interface{})
@@ -275,6 +304,7 @@ func (o *StorageAccessDto) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "storageUrl")
 		delete(additionalProperties, "organizationId")
 		delete(additionalProperties, "bucket")
+		delete(additionalProperties, "region")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/api-client-java/src/main/java/io/daytona/api/client/model/StorageAccessDto.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/StorageAccessDto.java
@@ -80,6 +80,11 @@ public class StorageAccessDto {
   @javax.annotation.Nonnull
   private String bucket;
 
+  public static final String SERIALIZED_NAME_REGION = "region";
+  @SerializedName(SERIALIZED_NAME_REGION)
+  @javax.annotation.Nonnull
+  private String region;
+
   public StorageAccessDto() {
   }
 
@@ -196,6 +201,25 @@ public class StorageAccessDto {
     this.bucket = bucket;
   }
 
+
+  public StorageAccessDto region(@javax.annotation.Nonnull String region) {
+    this.region = region;
+    return this;
+  }
+
+  /**
+   * Region for the storage backend (e.g. \&quot;us-east-2\&quot;)
+   * @return region
+   */
+  @javax.annotation.Nonnull
+  public String getRegion() {
+    return region;
+  }
+
+  public void setRegion(@javax.annotation.Nonnull String region) {
+    this.region = region;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -256,13 +280,14 @@ public class StorageAccessDto {
         Objects.equals(this.sessionToken, storageAccessDto.sessionToken) &&
         Objects.equals(this.storageUrl, storageAccessDto.storageUrl) &&
         Objects.equals(this.organizationId, storageAccessDto.organizationId) &&
-        Objects.equals(this.bucket, storageAccessDto.bucket)&&
+        Objects.equals(this.bucket, storageAccessDto.bucket) &&
+        Objects.equals(this.region, storageAccessDto.region)&&
         Objects.equals(this.additionalProperties, storageAccessDto.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(accessKey, secret, sessionToken, storageUrl, organizationId, bucket, additionalProperties);
+    return Objects.hash(accessKey, secret, sessionToken, storageUrl, organizationId, bucket, region, additionalProperties);
   }
 
   @Override
@@ -275,6 +300,7 @@ public class StorageAccessDto {
     sb.append("    storageUrl: ").append(toIndentedString(storageUrl)).append("\n");
     sb.append("    organizationId: ").append(toIndentedString(organizationId)).append("\n");
     sb.append("    bucket: ").append(toIndentedString(bucket)).append("\n");
+    sb.append("    region: ").append(toIndentedString(region)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -294,10 +320,10 @@ public class StorageAccessDto {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("accessKey", "secret", "sessionToken", "storageUrl", "organizationId", "bucket"));
+    openapiFields = new HashSet<String>(Arrays.asList("accessKey", "secret", "sessionToken", "storageUrl", "organizationId", "bucket", "region"));
 
     // a set of required properties/fields (JSON key names)
-    openapiRequiredFields = new HashSet<String>(Arrays.asList("accessKey", "secret", "sessionToken", "storageUrl", "organizationId", "bucket"));
+    openapiRequiredFields = new HashSet<String>(Arrays.asList("accessKey", "secret", "sessionToken", "storageUrl", "organizationId", "bucket", "region"));
   }
 
   /**
@@ -337,6 +363,9 @@ public class StorageAccessDto {
       }
       if (!jsonObj.get("bucket").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `bucket` to be a primitive type in the JSON string but got `%s`", jsonObj.get("bucket").toString()));
+      }
+      if (!jsonObj.get("region").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `region` to be a primitive type in the JSON string but got `%s`", jsonObj.get("region").toString()));
       }
   }
 

--- a/api-client-java/src/test/java/io/daytona/api/client/model/StorageAccessDtoTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/StorageAccessDtoTest.java
@@ -85,4 +85,12 @@ public class StorageAccessDtoTest {
         // TODO: test bucket
     }
 
+    /**
+     * Test the property 'region'
+     */
+    @Test
+    public void regionTest() {
+        // TODO: test region
+    }
+
 }

--- a/api-client-python-async/daytona_api_client_async/models/storage_access_dto.py
+++ b/api-client-python-async/daytona_api_client_async/models/storage_access_dto.py
@@ -36,8 +36,9 @@ class StorageAccessDto(BaseModel):
     storage_url: StrictStr = Field(description="Storage URL", serialization_alias="storageUrl")
     organization_id: StrictStr = Field(description="Organization ID", serialization_alias="organizationId")
     bucket: StrictStr = Field(description="S3 bucket name")
+    region: StrictStr = Field(description="Region for the storage backend (e.g. \"us-east-2\")")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["accessKey", "secret", "sessionToken", "storageUrl", "organizationId", "bucket"]
+    __properties: ClassVar[List[str]] = ["accessKey", "secret", "sessionToken", "storageUrl", "organizationId", "bucket", "region"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -101,7 +102,8 @@ class StorageAccessDto(BaseModel):
             "session_token": obj.get("sessionToken"),
             "storage_url": obj.get("storageUrl"),
             "organization_id": obj.get("organizationId"),
-            "bucket": obj.get("bucket")
+            "bucket": obj.get("bucket"),
+            "region": obj.get("region")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/api-client-python/daytona_api_client/models/storage_access_dto.py
+++ b/api-client-python/daytona_api_client/models/storage_access_dto.py
@@ -36,8 +36,9 @@ class StorageAccessDto(BaseModel):
     storage_url: StrictStr = Field(description="Storage URL", serialization_alias="storageUrl")
     organization_id: StrictStr = Field(description="Organization ID", serialization_alias="organizationId")
     bucket: StrictStr = Field(description="S3 bucket name")
+    region: StrictStr = Field(description="Region for the storage backend (e.g. \"us-east-2\")")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["accessKey", "secret", "sessionToken", "storageUrl", "organizationId", "bucket"]
+    __properties: ClassVar[List[str]] = ["accessKey", "secret", "sessionToken", "storageUrl", "organizationId", "bucket", "region"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -101,7 +102,8 @@ class StorageAccessDto(BaseModel):
             "session_token": obj.get("sessionToken"),
             "storage_url": obj.get("storageUrl"),
             "organization_id": obj.get("organizationId"),
-            "bucket": obj.get("bucket")
+            "bucket": obj.get("bucket"),
+            "region": obj.get("region")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/api-client-ruby/lib/daytona_api_client/models/storage_access_dto.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/storage_access_dto.rb
@@ -33,6 +33,9 @@ module DaytonaApiClient
     # S3 bucket name
     attr_accessor :bucket
 
+    # Region for the storage backend (e.g. \"us-east-2\")
+    attr_accessor :region
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -41,7 +44,8 @@ module DaytonaApiClient
         :'session_token' => :'sessionToken',
         :'storage_url' => :'storageUrl',
         :'organization_id' => :'organizationId',
-        :'bucket' => :'bucket'
+        :'bucket' => :'bucket',
+        :'region' => :'region'
       }
     end
 
@@ -63,7 +67,8 @@ module DaytonaApiClient
         :'session_token' => :'String',
         :'storage_url' => :'String',
         :'organization_id' => :'String',
-        :'bucket' => :'String'
+        :'bucket' => :'String',
+        :'region' => :'String'
       }
     end
 
@@ -124,6 +129,12 @@ module DaytonaApiClient
       else
         self.bucket = nil
       end
+
+      if attributes.key?(:'region')
+        self.region = attributes[:'region']
+      else
+        self.region = nil
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -155,6 +166,10 @@ module DaytonaApiClient
         invalid_properties.push('invalid value for "bucket", bucket cannot be nil.')
       end
 
+      if @region.nil?
+        invalid_properties.push('invalid value for "region", region cannot be nil.')
+      end
+
       invalid_properties
     end
 
@@ -168,6 +183,7 @@ module DaytonaApiClient
       return false if @storage_url.nil?
       return false if @organization_id.nil?
       return false if @bucket.nil?
+      return false if @region.nil?
       true
     end
 
@@ -231,6 +247,16 @@ module DaytonaApiClient
       @bucket = bucket
     end
 
+    # Custom attribute writer method with validation
+    # @param [Object] region Value to be assigned
+    def region=(region)
+      if region.nil?
+        fail ArgumentError, 'region cannot be nil'
+      end
+
+      @region = region
+    end
+
     # Checks equality by comparing each attribute.
     # @param [Object] Object to be compared
     def ==(o)
@@ -241,7 +267,8 @@ module DaytonaApiClient
           session_token == o.session_token &&
           storage_url == o.storage_url &&
           organization_id == o.organization_id &&
-          bucket == o.bucket
+          bucket == o.bucket &&
+          region == o.region
     end
 
     # @see the `==` method
@@ -253,7 +280,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [access_key, secret, session_token, storage_url, organization_id, bucket].hash
+      [access_key, secret, session_token, storage_url, organization_id, bucket, region].hash
     end
 
     # Builds the object from hash

--- a/api-client/src/models/storage-access-dto.ts
+++ b/api-client/src/models/storage-access-dto.ts
@@ -39,5 +39,9 @@ export interface StorageAccessDto {
      * S3 bucket name
      */
     'bucket': string;
+    /**
+     * Region for the storage backend (e.g. \"us-east-2\")
+     */
+    'region': string;
 }
 

--- a/artifacts/sdk-docs/go-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/go-sdk/daytona.mdx
@@ -4076,6 +4076,7 @@ type PushAccessCredentials struct {
     SessionToken   string `json:"sessionToken"`
     Bucket         string `json:"bucket"`
     OrganizationID string `json:"organizationId"`
+    Region         string `json:"region"`
 }
 ```
 

--- a/artifacts/sdk-docs/python-sdk/async/async-object-storage.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-object-storage.mdx
@@ -18,6 +18,7 @@ AsyncObjectStorage class for interacting with object storage services.
 - `aws_secret_access_key` _str_ - The secret access key for the object storage service.
 - `aws_session_token` _str_ - The session token for the object storage service. Used for temporary credentials.
 - `bucket_name` _str_ - The name of the bucket to use. Defaults to "daytona-volume-builds".
+- `region` _str_ - The region of the storage backend.
 
 #### AsyncObjectStorage.upload
 

--- a/artifacts/sdk-docs/python-sdk/sync/object-storage.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/object-storage.mdx
@@ -18,6 +18,7 @@ ObjectStorage class for interacting with object storage services.
 - `aws_secret_access_key` _str_ - The secret access key for the object storage service.
 - `aws_session_token` _str_ - The session token for the object storage service. Used for temporary credentials.
 - `bucket_name` _str_ - The name of the bucket to use. Defaults to "daytona-volume-builds".
+- `region` _str_ - The region of the storage backend.
 
 #### ObjectStorage.upload
 

--- a/artifacts/sdk-docs/ruby-sdk/object-storage.mdx
+++ b/artifacts/sdk-docs/ruby-sdk/object-storage.mdx
@@ -12,7 +12,7 @@ Initialize ObjectStorage with S3-compatible credentials
 #### new ObjectStorage()
 
 ```ruby
-def initialize(endpoint_url:, aws_access_key_id:, aws_secret_access_key:, aws_session_token:, bucket_name: DEFAULT_BUCKET_NAME, region: DEFAULT_REGION)
+def initialize(endpoint_url:, aws_access_key_id:, aws_secret_access_key:, aws_session_token:, region:, bucket_name: DEFAULT_BUCKET_NAME)
 
 ```
 
@@ -25,7 +25,7 @@ Initialize ObjectStorage with S3-compatible credentials
 - `aws_secret_access_key` _String_ - The secret access key for the object storage service
 - `aws_session_token` _String_ - The session token for the object storage service
 - `bucket_name` _String_ - The name of the bucket to use (defaults to "daytona-volume-builds")
-- `region` _String_ - AWS region (defaults to us-east-1)
+- `region` _String_ - Region of the storage backend
 
 **Returns**:
 

--- a/artifacts/sdk-docs/typescript-sdk/object-storage.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/object-storage.mdx
@@ -65,5 +65,6 @@ Configuration for the ObjectStorage class.
 - `accessKeyId` _string_ - The access key ID for the object storage service.
 - `bucketName?` _string_ - The name of the bucket to use.
 - `endpointUrl` _string_ - The endpoint URL for the object storage service.
+- `region` _string_ - The region of the storage backend.
 - `secretAccessKey` _string_ - The secret access key for the object storage service.
 - `sessionToken?` _string_ - The session token for the object storage service. Used for temporary credentials.

--- a/openapi-specs/api.json
+++ b/openapi-specs/api.json
@@ -15520,6 +15520,11 @@
             "type": "string",
             "description": "S3 bucket name",
             "example": "daytona"
+          },
+          "region": {
+            "type": "string",
+            "description": "Region for the storage backend (e.g. \"us-east-2\")",
+            "example": "us-east-1"
           }
         },
         "required": [
@@ -15528,7 +15533,8 @@
           "sessionToken",
           "storageUrl",
           "organizationId",
-          "bucket"
+          "bucket",
+          "region"
         ]
       },
       "LogEntry": {

--- a/sdk-go/pkg/daytona/client.go
+++ b/sdk-go/pkg/daytona/client.go
@@ -1016,6 +1016,7 @@ func (c *Client) getPushAccessCredentials(ctx context.Context) (*PushAccessCrede
 		SessionToken:   creds.GetSessionToken(),
 		Bucket:         creds.GetBucket(),
 		OrganizationID: creds.GetOrganizationId(),
+		Region:         creds.GetRegion(),
 	}
 
 	return result, nil
@@ -1041,6 +1042,7 @@ func (c *Client) processImageContext(ctx context.Context, image *DockerImage) ([
 		SecretAccessKey: creds.Secret,
 		SessionToken:    &creds.SessionToken,
 		BucketName:      creds.Bucket,
+		Region:          creds.Region,
 	})
 
 	// Upload each context

--- a/sdk-go/pkg/daytona/object_storage.go
+++ b/sdk-go/pkg/daytona/object_storage.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -28,6 +27,7 @@ type objectStorageConfig struct {
 	SecretAccessKey string
 	SessionToken    *string
 	BucketName      string
+	Region          string
 }
 
 // objectStorage handles S3-compatible object storage operations for uploading
@@ -41,18 +41,6 @@ type objectStorage struct {
 //
 // This is used internally by the SDK for uploading build contexts.
 func NewObjectStorage(config objectStorageConfig) *objectStorage {
-	// Extract region from endpoint URL
-	region := "us-east-1" // default
-	if strings.Contains(config.EndpointURL, "amazonaws.com") {
-		parts := strings.Split(config.EndpointURL, ".")
-		for i, part := range parts {
-			if part == "s3" && i+1 < len(parts) {
-				region = parts[i+1]
-				break
-			}
-		}
-	}
-
 	bucketName := config.BucketName
 	if bucketName == "" {
 		bucketName = "daytona-volume-builds"
@@ -72,7 +60,7 @@ func NewObjectStorage(config objectStorageConfig) *objectStorage {
 
 	// Create S3 client
 	client := s3.New(s3.Options{
-		Region:       region,
+		Region:       config.Region,
 		Credentials:  creds,
 		BaseEndpoint: aws.String(config.EndpointURL),
 		UsePathStyle: true,
@@ -335,4 +323,5 @@ type PushAccessCredentials struct {
 	SessionToken   string `json:"sessionToken"`
 	Bucket         string `json:"bucket"`
 	OrganizationID string `json:"organizationId"`
+	Region         string `json:"region"`
 }

--- a/sdk-go/pkg/daytona/object_storage_test.go
+++ b/sdk-go/pkg/daytona/object_storage_test.go
@@ -18,6 +18,7 @@ func TestNewObjectStorage(t *testing.T) {
 		name           string
 		config         objectStorageConfig
 		expectedBucket string
+		expectedRegion string
 	}{
 		{
 			name: "basic config",
@@ -26,8 +27,10 @@ func TestNewObjectStorage(t *testing.T) {
 				AccessKeyID:     "AKID",
 				SecretAccessKey: "SECRET",
 				BucketName:      "my-bucket",
+				Region:          "us-east-1",
 			},
 			expectedBucket: "my-bucket",
+			expectedRegion: "us-east-1",
 		},
 		{
 			name: "default bucket name",
@@ -36,8 +39,10 @@ func TestNewObjectStorage(t *testing.T) {
 				AccessKeyID:     "AKID",
 				SecretAccessKey: "SECRET",
 				BucketName:      "",
+				Region:          "us-west-2",
 			},
 			expectedBucket: "daytona-volume-builds",
+			expectedRegion: "us-west-2",
 		},
 		{
 			name: "with session token",
@@ -47,8 +52,10 @@ func TestNewObjectStorage(t *testing.T) {
 				SecretAccessKey: "SECRET",
 				SessionToken:    strPtr("session-token"),
 				BucketName:      "test-bucket",
+				Region:          "eu-west-1",
 			},
 			expectedBucket: "test-bucket",
+			expectedRegion: "eu-west-1",
 		},
 		{
 			name: "non-aws endpoint",
@@ -57,8 +64,22 @@ func TestNewObjectStorage(t *testing.T) {
 				AccessKeyID:     "minioadmin",
 				SecretAccessKey: "minioadmin",
 				BucketName:      "builds",
+				Region:          "auto",
 			},
 			expectedBucket: "builds",
+			expectedRegion: "auto",
+		},
+		{
+			name: "region is passed through regardless of endpoint host",
+			config: objectStorageConfig{
+				EndpointURL:     "https://s3.us-west-2.amazonaws.com",
+				AccessKeyID:     "AKID",
+				SecretAccessKey: "SECRET",
+				BucketName:      "builds",
+				Region:          "us-east-2",
+			},
+			expectedBucket: "builds",
+			expectedRegion: "us-east-2",
 		},
 	}
 
@@ -67,7 +88,8 @@ func TestNewObjectStorage(t *testing.T) {
 			objStorage := NewObjectStorage(tt.config)
 			require.NotNil(t, objStorage)
 			assert.Equal(t, tt.expectedBucket, objStorage.bucketName)
-			assert.NotNil(t, objStorage.client)
+			require.NotNil(t, objStorage.client)
+			assert.Equal(t, tt.expectedRegion, objStorage.client.Options().Region)
 		})
 	}
 }
@@ -199,6 +221,7 @@ func TestPushAccessCredentialsStruct(t *testing.T) {
 		SessionToken:   "TOKEN",
 		Bucket:         "my-bucket",
 		OrganizationID: "org-1",
+		Region:         "us-east-2",
 	}
 
 	assert.Equal(t, "https://s3.us-east-1.amazonaws.com", creds.StorageURL)
@@ -207,6 +230,7 @@ func TestPushAccessCredentialsStruct(t *testing.T) {
 	assert.Equal(t, "TOKEN", creds.SessionToken)
 	assert.Equal(t, "my-bucket", creds.Bucket)
 	assert.Equal(t, "org-1", creds.OrganizationID)
+	assert.Equal(t, "us-east-2", creds.Region)
 }
 
 func TestObjectStorageUploadValidations(t *testing.T) {

--- a/sdk-go/pkg/daytona/snapshot.go
+++ b/sdk-go/pkg/daytona/snapshot.go
@@ -315,6 +315,7 @@ func (s *SnapshotService) processImageContext(ctx context.Context, image *Docker
 		SecretAccessKey: creds.Secret,
 		SessionToken:    &creds.SessionToken,
 		BucketName:      creds.Bucket,
+		Region:          creds.Region,
 	})
 
 	// Upload each context

--- a/sdk-python/src/daytona/_async/object_storage.py
+++ b/sdk-python/src/daytona/_async/object_storage.py
@@ -26,6 +26,7 @@ class AsyncObjectStorage:
         aws_secret_access_key (str): The secret access key for the object storage service.
         aws_session_token (str): The session token for the object storage service. Used for temporary credentials.
         bucket_name (str): The name of the bucket to use. Defaults to "daytona-volume-builds".
+        region (str): The region of the storage backend.
     """
 
     def __init__(
@@ -35,12 +36,16 @@ class AsyncObjectStorage:
         aws_secret_access_key: str,
         aws_session_token: str,
         bucket_name: str = "daytona-volume-builds",
+        *,
+        region: str,
     ):
         self.bucket_name: str = bucket_name
+        self.region: str = region
         with isolated_env():
             self.store: S3Store = S3Store(
                 bucket=bucket_name,
                 endpoint=endpoint_url,
+                region=self.region,
                 access_key_id=aws_access_key_id,
                 secret_access_key=aws_secret_access_key,
                 session_token=aws_session_token,

--- a/sdk-python/src/daytona/_async/snapshot.py
+++ b/sdk-python/src/daytona/_async/snapshot.py
@@ -251,6 +251,7 @@ class AsyncSnapshotService:
             push_access_creds.secret,
             push_access_creds.session_token,
             push_access_creds.bucket,
+            region=push_access_creds.region,
         )
         context_hashes: list[str] = []
         for context in image._context_list:

--- a/sdk-python/src/daytona/_sync/object_storage.py
+++ b/sdk-python/src/daytona/_sync/object_storage.py
@@ -24,6 +24,7 @@ class ObjectStorage:
         aws_secret_access_key (str): The secret access key for the object storage service.
         aws_session_token (str): The session token for the object storage service. Used for temporary credentials.
         bucket_name (str): The name of the bucket to use. Defaults to "daytona-volume-builds".
+        region (str): The region of the storage backend.
     """
 
     def __init__(
@@ -33,12 +34,16 @@ class ObjectStorage:
         aws_secret_access_key: str,
         aws_session_token: str,
         bucket_name: str = "daytona-volume-builds",
+        *,
+        region: str,
     ):
         self.bucket_name: str = bucket_name
+        self.region: str = region
         with isolated_env():
             self.store: S3Store = S3Store(
                 bucket=bucket_name,
                 endpoint=endpoint_url,
+                region=self.region,
                 access_key_id=aws_access_key_id,
                 secret_access_key=aws_secret_access_key,
                 session_token=aws_session_token,

--- a/sdk-python/src/daytona/_sync/snapshot.py
+++ b/sdk-python/src/daytona/_sync/snapshot.py
@@ -251,6 +251,7 @@ class SnapshotService:
             push_access_creds.secret,
             push_access_creds.session_token,
             push_access_creds.bucket,
+            region=push_access_creds.region,
         )
         context_hashes: list[str] = []
         for context in image._context_list:

--- a/sdk-python/tests/test_async_object_storage.py
+++ b/sdk-python/tests/test_async_object_storage.py
@@ -17,11 +17,20 @@ def _make_async_storage():
         mock_store.head_async = AsyncMock()
         mock_store.put_async = AsyncMock()
         mock_store_cls.return_value = mock_store
-        storage = AsyncObjectStorage("https://s3.example", "key", "secret", "token", bucket_name="bucket")
+        storage = AsyncObjectStorage(
+            "https://s3.example", "key", "secret", "token", bucket_name="bucket", region="us-east-2"
+        )
     return storage, mock_store
 
 
 class TestAsyncObjectStorage:
+    def test_constructor_passes_region_to_store(self):
+        from daytona._async.object_storage import AsyncObjectStorage
+
+        with patch("daytona._async.object_storage.S3Store") as mock_store_cls:
+            AsyncObjectStorage("https://s3.us-west-2.amazonaws.com", "key", "secret", "token", region="ap-south-1")
+            assert mock_store_cls.call_args.kwargs["region"] == "ap-south-1"
+
     @pytest.mark.asyncio
     async def test_upload_missing_path_raises(self):
         storage, _store = _make_async_storage()

--- a/sdk-python/tests/test_object_storage.py
+++ b/sdk-python/tests/test_object_storage.py
@@ -15,11 +15,28 @@ def _make_storage():
     with patch("daytona._sync.object_storage.S3Store") as mock_store_cls:
         mock_store = MagicMock()
         mock_store_cls.return_value = mock_store
-        storage = ObjectStorage("https://s3.example", "key", "secret", "token", bucket_name="bucket")
+        storage = ObjectStorage(
+            "https://s3.example", "key", "secret", "token", bucket_name="bucket", region="us-east-2"
+        )
     return storage, mock_store
 
 
 class TestObjectStorage:
+    def test_constructor_passes_region_to_store(self):
+        from daytona._sync.object_storage import ObjectStorage
+
+        with patch("daytona._sync.object_storage.S3Store") as mock_store_cls:
+            ObjectStorage("https://s3.us-west-2.amazonaws.com", "key", "secret", "token", region="ap-south-1")
+            assert mock_store_cls.call_args.kwargs["region"] == "ap-south-1"
+
+    def test_constructor_requires_region(self):
+        from daytona._sync.object_storage import ObjectStorage
+
+        with pytest.raises(TypeError):
+            ObjectStorage(
+                "https://s3.us-west-2.amazonaws.com", "key", "secret", "token"
+            )  # pylint: disable=missing-kwoa
+
     def test_upload_missing_path_raises(self):
         storage, _store = _make_storage()
 

--- a/sdk-python/tests/test_snapshot.py
+++ b/sdk-python/tests/test_snapshot.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -114,6 +114,26 @@ class TestSyncSnapshotService:
             == []
         )
 
+    def test_process_image_context_passes_region_to_object_storage(self):
+        service, _ = self._make_service()
+        object_storage_api = MagicMock()
+        creds = object_storage_api.get_push_access.return_value
+        creds.storage_url = "https://s3.example"
+        creds.access_key = "key"
+        creds.secret = "secret"
+        creds.session_token = "token"
+        creds.bucket = "bucket"
+        creds.organization_id = "org-1"
+        creds.region = "us-east-2"
+        image = Image.base("python:3.12")
+        image._context_list = [MagicMock(source_path="/tmp/ctx", archive_path=".")]
+
+        with patch("daytona._sync.snapshot.ObjectStorage") as mock_storage_cls:
+            mock_storage_cls.return_value.upload.return_value = "ctx-hash"
+
+            assert service.process_image_context(object_storage_api, image) == ["ctx-hash"]
+            assert mock_storage_cls.call_args.kwargs["region"] == "us-east-2"
+
 
 class TestAsyncSnapshotService:
     def _make_service(self):
@@ -217,3 +237,25 @@ class TestAsyncSnapshotService:
             )
             == []
         )
+
+    @pytest.mark.asyncio
+    async def test_process_image_context_passes_region_to_object_storage(self):
+        service, _ = self._make_service()
+        object_storage_api = AsyncMock()
+        creds = MagicMock()
+        creds.storage_url = "https://s3.example"
+        creds.access_key = "key"
+        creds.secret = "secret"
+        creds.session_token = "token"
+        creds.bucket = "bucket"
+        creds.organization_id = "org-1"
+        creds.region = "us-east-2"
+        object_storage_api.get_push_access.return_value = creds
+        image = Image.base("python:3.12")
+        image._context_list = [MagicMock(source_path="/tmp/ctx", archive_path=".")]
+
+        with patch("daytona._async.snapshot.AsyncObjectStorage") as mock_storage_cls:
+            mock_storage_cls.return_value.upload = AsyncMock(return_value="ctx-hash")
+
+            assert await service.process_image_context(object_storage_api, image) == ["ctx-hash"]
+            assert mock_storage_cls.call_args.kwargs["region"] == "us-east-2"

--- a/sdk-ruby/lib/daytona/object_storage.rb
+++ b/sdk-ruby/lib/daytona/object_storage.rb
@@ -25,9 +25,9 @@ module Daytona
     # @param aws_secret_access_key [String] The secret access key for the object storage service
     # @param aws_session_token [String] The session token for the object storage service
     # @param bucket_name [String] The name of the bucket to use (defaults to "daytona-volume-builds")
-    # @param region [String] AWS region (defaults to us-east-1)
+    # @param region [String] Region of the storage backend
     def initialize(endpoint_url:, aws_access_key_id:, aws_secret_access_key:, aws_session_token:, # rubocop:disable Metrics/ParameterLists
-                   bucket_name: DEFAULT_BUCKET_NAME, region: DEFAULT_REGION)
+                   region:, bucket_name: DEFAULT_BUCKET_NAME)
       @bucket_name = bucket_name
       @s3_client = Aws::S3::Client.new(
         region:,
@@ -165,8 +165,5 @@ module Daytona
 
     DEFAULT_BUCKET_NAME = 'daytona-volume-builds'
     private_constant :DEFAULT_BUCKET_NAME
-
-    DEFAULT_REGION = 'us-east-1'
-    private_constant :DEFAULT_REGION
   end
 end

--- a/sdk-ruby/lib/daytona/snapshot_service.rb
+++ b/sdk-ruby/lib/daytona/snapshot_service.rb
@@ -147,7 +147,8 @@ module Daytona
         aws_access_key_id: push_access_creds.access_key,
         aws_secret_access_key: push_access_creds.secret,
         aws_session_token: push_access_creds.session_token,
-        bucket_name: push_access_creds.bucket
+        bucket_name: push_access_creds.bucket,
+        region: push_access_creds.region
       )
 
       image.context_list.map do |context|

--- a/sdk-ruby/spec/daytona/object_storage_spec.rb
+++ b/sdk-ruby/spec/daytona/object_storage_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Daytona::ObjectStorage do
       aws_access_key_id: 'key-id',
       aws_secret_access_key: 'secret',
       aws_session_token: 'token',
-      bucket_name: 'test-bucket'
+      bucket_name: 'test-bucket',
+      region: 'us-east-2'
     )
   end
 
@@ -21,6 +22,31 @@ RSpec.describe Daytona::ObjectStorage do
     it 'stores bucket_name and creates the S3 client' do
       expect(storage.bucket_name).to eq('test-bucket')
       expect(storage.s3_client).to eq(s3_client)
+    end
+
+    it 'passes the provided region to the S3 client' do
+      allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
+
+      described_class.new(
+        endpoint_url: 'https://s3.us-west-2.amazonaws.com',
+        aws_access_key_id: 'key-id',
+        aws_secret_access_key: 'secret',
+        aws_session_token: 'token',
+        region: 'ap-south-1'
+      )
+
+      expect(Aws::S3::Client).to have_received(:new).with(hash_including(region: 'ap-south-1'))
+    end
+
+    it 'requires a region' do
+      expect do
+        described_class.new(
+          endpoint_url: 'https://s3.us-west-2.amazonaws.com',
+          aws_access_key_id: 'key-id',
+          aws_secret_access_key: 'secret',
+          aws_session_token: 'token'
+        )
+      end.to raise_error(ArgumentError, /region/)
     end
   end
 

--- a/sdk-ruby/spec/daytona/snapshot_service_spec.rb
+++ b/sdk-ruby/spec/daytona/snapshot_service_spec.rb
@@ -184,7 +184,8 @@ RSpec.describe Daytona::SnapshotService do
       image.context_list << Daytona::Context.new(source_path: '/tmp/a', archive_path: 'a')
       image.context_list << Daytona::Context.new(source_path: '/tmp/b', archive_path: 'b')
       creds = double('PushAccess', storage_url: 'https://s3.example.com', access_key: 'key', secret: 'secret',
-                                   session_token: 'token', bucket: 'bucket', organization_id: 'org-1')
+                                   session_token: 'token', bucket: 'bucket', organization_id: 'org-1',
+                                   region: 'us-east-2')
       storage = instance_double(Daytona::ObjectStorage)
 
       allow(object_storage_api).to receive(:get_push_access).and_return(creds)
@@ -194,6 +195,7 @@ RSpec.describe Daytona::SnapshotService do
       result = described_class.process_image_context(object_storage_api, image)
 
       expect(result).to eq(%w[hash-a hash-b])
+      expect(Daytona::ObjectStorage).to have_received(:new).with(hash_including(region: 'us-east-2'))
       expect(storage).to have_received(:upload).with('/tmp/a', 'org-1', 'a')
       expect(storage).to have_received(:upload).with('/tmp/b', 'org-1', 'b')
     end

--- a/sdk-typescript/src/ObjectStorage.ts
+++ b/sdk-typescript/src/ObjectStorage.ts
@@ -20,6 +20,7 @@ import { WithInstrumentation } from './utils/otel.decorator'
  * @property {string} secretAccessKey - The secret access key for the object storage service.
  * @property {string} [sessionToken] - The session token for the object storage service. Used for temporary credentials.
  * @property {string} [bucketName] - The name of the bucket to use.
+ * @property {string} region - The region of the storage backend.
  */
 export interface ObjectStorageConfig {
   endpointUrl: string
@@ -27,6 +28,7 @@ export interface ObjectStorageConfig {
   secretAccessKey: string
   sessionToken?: string
   bucketName?: string
+  region: string
 }
 
 /**
@@ -42,7 +44,7 @@ export class ObjectStorage {
   constructor(config: ObjectStorageConfig) {
     this.bucketName = config.bucketName || 'daytona-volume-builds'
     this.s3Client = new S3Client({
-      region: this.extractAwsRegion(config.endpointUrl) || 'us-east-1',
+      region: config.region,
       endpoint: config.endpointUrl,
       credentials: {
         accessKeyId: config.accessKeyId,
@@ -233,10 +235,5 @@ export class ObjectStorage {
     })
 
     await uploader.done()
-  }
-
-  private extractAwsRegion(endpoint: string): string | undefined {
-    const match = endpoint.match(/s3[.-]([a-z0-9-]+)\.amazonaws\.com/)
-    return match?.[1]
   }
 }

--- a/sdk-typescript/src/Snapshot.ts
+++ b/sdk-typescript/src/Snapshot.ts
@@ -292,6 +292,7 @@ export class SnapshotService {
       secretAccessKey: pushAccessCreds.secret,
       sessionToken: pushAccessCreds.sessionToken,
       bucketName: pushAccessCreds.bucket,
+      region: pushAccessCreds.region,
     })
 
     const contextHashes = []

--- a/sdk-typescript/src/__tests__/ObjectStorage.test.ts
+++ b/sdk-typescript/src/__tests__/ObjectStorage.test.ts
@@ -59,7 +59,7 @@ describe('ObjectStorage', () => {
   const originalStream = require('stream') as typeof import('stream')
   let tempDir = ''
 
-  const makeStorage = async (endpointUrl = 'https://s3.eu-central-1.amazonaws.com') => {
+  const makeStorage = async (endpointUrl = 'https://s3.eu-central-1.amazonaws.com', region = 'eu-central-1') => {
     const { ObjectStorage } = await import('../ObjectStorage')
     return new ObjectStorage({
       endpointUrl,
@@ -67,6 +67,7 @@ describe('ObjectStorage', () => {
       secretAccessKey: 'secret',
       sessionToken: 'session',
       bucketName: 'custom-bucket',
+      region,
     })
   }
 
@@ -94,8 +95,8 @@ describe('ObjectStorage', () => {
     }
   })
 
-  it('configures the s3 client with extracted region and credentials', async () => {
-    const storage = await makeStorage('https://s3.us-west-2.amazonaws.com')
+  it('configures the s3 client with the provided region and credentials', async () => {
+    const storage = await makeStorage('https://s3.us-west-2.amazonaws.com', 'us-west-2')
 
     const client = storage as unknown as { s3Client: MockS3Client }
     expect(client.s3Client.config).toMatchObject({
@@ -110,11 +111,11 @@ describe('ObjectStorage', () => {
     })
   })
 
-  it('falls back to the default region when the endpoint does not encode one', async () => {
-    const storage = await makeStorage('https://storage.example.com')
+  it('uses the provided region regardless of the endpoint host', async () => {
+    const storage = await makeStorage('https://storage.example.com', 'us-east-2')
 
     const client = storage as unknown as { s3Client: MockS3Client }
-    expect(client.s3Client.config.region).toBe('us-east-1')
+    expect(client.s3Client.config.region).toBe('us-east-2')
   })
 
   it('throws when uploading a missing path', async () => {
@@ -266,16 +267,5 @@ describe('ObjectStorage', () => {
       ['.'],
     )
     expect(mockUploadDone).toHaveBeenCalledTimes(1)
-  })
-
-  it('extracts aws regions from supported s3 endpoints', async () => {
-    const storage = await makeStorage()
-    const runtime = storage as unknown as {
-      extractAwsRegion: (endpoint: string) => string | undefined
-    }
-
-    expect(runtime.extractAwsRegion('https://s3.us-east-1.amazonaws.com')).toBe('us-east-1')
-    expect(runtime.extractAwsRegion('https://s3-eu-west-1.amazonaws.com')).toBe('eu-west-1')
-    expect(runtime.extractAwsRegion('https://files.example.com')).toBeUndefined()
   })
 })

--- a/sdk-typescript/src/__tests__/Snapshot.test.ts
+++ b/sdk-typescript/src/__tests__/Snapshot.test.ts
@@ -141,6 +141,7 @@ describe('SnapshotService', () => {
         sessionToken: 'session',
         bucket: 'bucket',
         organizationId: 'org-1',
+        region: 'us-east-2',
       }),
     )
     mockDynamicImport.mockResolvedValue({ ObjectStorage })
@@ -152,6 +153,7 @@ describe('SnapshotService', () => {
 
     await expect(SnapshotService.processImageContext(objectStorageApi as never, image)).resolves.toEqual(['ctx-hash'])
     expect(objectStorageApi.getPushAccess).toHaveBeenCalledTimes(1)
+    expect(ObjectStorage).toHaveBeenCalledWith(expect.objectContaining({ region: 'us-east-2' }))
     expect(upload).toHaveBeenCalledWith('/tmp/context', 'org-1', '.')
   })
 


### PR DESCRIPTION
## Summary

Fixes #44 — SDK object-storage operations failed with `HTTP 400` against S3 buckets
outside `us-east-1` (e.g. Dockerfile-based snapshot builds and volume uploads on
self-hosted deployments).

The SDKs previously guessed the SigV4 signing region by parsing the storage endpoint
host, defaulting to `us-east-1`. This broke for any non-`us-east-1` AWS bucket,
un-parseable custom endpoints (CNAMEs), and S3-compatible stores that require a
specific region string (e.g. Cloudflare R2's `auto`). The API now returns the
authoritative `region` in `StorageAccessDto` (`GET /object-storage/push-access`),
and all SDKs pass it through verbatim — no derivation, no defaults, no fallbacks.

## Changes

- **api-clients (regenerated):** `StorageAccessDto` gains the required `region` property.
- **sdk-python:** `ObjectStorage` / `AsyncObjectStorage` take a required keyword-only
  `region` and pass it to obstore's `S3Store` (previously no region was set at all —
  obstore always signed `us-east-1`). Snapshot services forward `push_access_creds.region`.
- **sdk-typescript:** `ObjectStorageConfig.region` is required; removed `extractAwsRegion()`.
- **sdk-go:** `Region` added to `objectStorageConfig` / `PushAccessCredentials` and passed
  through. Removed the endpoint-parsing logic — it was also silently broken (split on `.`
  never matched scheme-prefixed URLs, so Go always signed `us-east-1`).
- **sdk-ruby:** `region:` is a required kwarg; removed the `us-east-1` default that the
  snapshot service was unconditionally relying on.

## Behavior when `region` is absent

Intentionally fail-fast: response validation of `get_push_access` rejects a missing
`region` (required DTO field), and constructing object storage without one raises
(`TypeError` / compile error / `ArgumentError`). No silent guessing anywhere.

> ⚠️ Requires the API change that adds `region` to `StorageAccessDto` to be deployed
> before these SDK versions are released.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sign S3 requests with the region provided by the API to fix object-storage operations on non-`us-east-1` and custom S3-compatible endpoints. The API returns `region` in `StorageAccessDto`, and SDKs use it directly with no guessing or defaults.

- **Bug Fixes**
  - API clients: `StorageAccessDto` adds required `region`.
  - `sdk-python`: `ObjectStorage` / `AsyncObjectStorage` require `region` and pass it to `obstore` `S3Store`.
  - `sdk-typescript`: `ObjectStorageConfig.region` is required; removed region extraction helper.
  - `sdk-go`: added `Region` to config/credentials; removed endpoint parsing; sign with provided region.
  - `sdk-ruby`: `region` is required; removed `us-east-1` default.
  - `sdk-java`/`api-client-java`: expose `region` on `StorageAccessDto`; pass `includeWarm` to `listSandboxes` after client regen.

- **Migration**
  - Deploy API that returns `region` in `GET /object-storage/push-access` before upgrading SDKs.
  - Pass `push_access_creds.region` to object storage constructors in all SDKs.
  - Missing `region` will fail validation or compilation.

<sup>Written for commit 101aecc0ba0b0e83f73ef66ba5d8b6305953144f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

