### PR TITLE
ci(publish): gate publish jobs behind the release environment

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -44,6 +44,9 @@ jobs:
   publish:
     if: github.repository == 'daytona/clients'
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    # Publish credentials live in the `release` environment: runs must start
+    # from main and be approved by a required reviewer before secrets resolve.
+    environment: release
     permissions:
       contents: read
     name: Publish ${{ matrix.name }}
@@ -113,6 +116,7 @@ jobs:
   update-homebrew-tap:
     if: ${{ github.repository == 'daytona/clients' && inputs.publish_cli && inputs.npm_tag == 'latest' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: release
     permissions: {}
     name: Update Homebrew CLI tap
     steps:

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -44,8 +44,9 @@ jobs:
   publish:
     if: github.repository == 'daytona/clients'
     runs-on: blacksmith-16vcpu-ubuntu-2404
-    # Publish credentials live in the `release` environment: runs must start
-    # from main and be approved by a required reviewer before secrets resolve.
+    # Publish credentials live in the `release` environment: every run waits
+    # for required-reviewer approval before secrets resolve. Any branch may
+    # deploy (alpha/beta prereleases publish from non-main refs).
     environment: release
     permissions:
       contents: read


### PR DESCRIPTION
Publishing jobs (`publish`, `update-homebrew-tap`) now run in the `release` environment:

- a required reviewer approves each publish run before secrets resolve; one approval covers all jobs in the run (self-approval allowed)
- deployments are allowed from any branch so alpha/beta prerelease publishes keep working — the reviewer approval is the gate

The environment already exists and is configured. Follow-up (separate step, not in this PR): publish credentials move from repository secrets to `release` environment secrets; repository-level copies are then removed.

No change to the release procedure itself: same `workflow_dispatch`, same inputs — plus one approval click per run.
