### PR TITLE
fix(sdk-typescript): declare tslib and ws as runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "pathe": "^2.0.3",
     "shell-quote": "^1.8.2",
     "socket.io-client": "^4.8.1",
-    "tar": "^7.5.11"
+    "tar": "^7.5.11",
+    "tslib": "^2.8.1",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.3",
@@ -80,7 +82,6 @@
     "prettier": "^3.5.0",
     "ts-jest": "29.4.1",
     "ts-node": "10.9.1",
-    "tslib": "^2.8.1",
     "tsx": "^4.20.5",
     "typedoc": "~0.27.7",
     "typedoc-plugin-markdown": "~4.4.2",

--- a/sdk-python/tests/test_event_subscription_manager.py
+++ b/sdk-python/tests/test_event_subscription_manager.py
@@ -77,7 +77,9 @@ class TestSyncEventSubscriptionManagerThreadUsage:
         for _ in range(100):
             assert manager.refresh(sub_id)
 
-        assert threading.active_count() == threads_before
+        # <= not ==: a dying worker from an earlier test may exit mid-test and
+        # lower the global count; only an increase would indicate spawned threads.
+        assert threading.active_count() <= threads_before
         manager.shutdown()
 
 
@@ -147,12 +149,13 @@ class TestSyncEventSubscriptionManagerLifecycle:
         dispatcher = FakeSyncDispatcher()
         manager = SyncEventSubscriptionManager(dispatcher, ttl_seconds=60.0)
         manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"])
-        assert threading.active_count() >= 2
+        worker = manager._worker  # pylint: disable=protected-access
+        assert worker is not None and worker.is_alive()
 
-        threads_expected = threading.active_count() - 1
         manager.shutdown()
 
-        assert _wait_until(lambda: threading.active_count() == threads_expected)
+        worker.join(timeout=5.0)
+        assert not worker.is_alive()
 
     def test_subscribe_without_dispatcher_is_noop(self):
         manager = SyncEventSubscriptionManager(None)
@@ -196,10 +199,12 @@ class TestSyncEventSubscriptionManagerRobustness:
     def test_worker_exits_promptly_after_last_unsubscribe(self):
         dispatcher = FakeSyncDispatcher()
         manager = SyncEventSubscriptionManager(dispatcher, ttl_seconds=60.0)
-        threads_before = threading.active_count()
         sub_id = manager.subscribe("sandbox-1", _noop_handler, ["sandbox.state.updated"])
+        worker = manager._worker  # pylint: disable=protected-access
+        assert worker is not None and worker.is_alive()
 
         manager.unsubscribe(sub_id)
 
-        assert _wait_until(lambda: threading.active_count() == threads_before, timeout=2.0)
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
         manager.shutdown()

--- a/sdk-ruby/spec/daytona/event_subscription_manager_spec.rb
+++ b/sdk-ruby/spec/daytona/event_subscription_manager_spec.rb
@@ -84,7 +84,9 @@ RSpec.describe Daytona::EventSubscriptionManager do
 
       100.times { expect(manager.refresh(sub_id)).to be(true) }
 
-      expect(Thread.list.size).to eq(threads_before)
+      # <= not ==: a dying worker from an earlier example may exit mid-test and
+      # lower the global count; only an increase would indicate spawned threads.
+      expect(Thread.list.size).to be <= threads_before
       manager.shutdown
     end
 
@@ -118,12 +120,14 @@ RSpec.describe Daytona::EventSubscriptionManager do
 
     it 'lets the worker exit promptly after the last subscription is removed' do
       manager = described_class.new(dispatcher, ttl_seconds: 60)
-      threads_before = Thread.list.size
       sub_id = manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
+      worker = manager.instance_variable_get(:@worker)
+      expect(worker).to be_alive
 
       manager.unsubscribe(sub_id)
 
-      expect(wait_until(timeout: 2) { Thread.list.size == threads_before }).to be(true)
+      worker.join(2)
+      expect(worker).not_to be_alive
       manager.shutdown
     end
   end
@@ -157,7 +161,7 @@ RSpec.describe Daytona::EventSubscriptionManager do
       manager = described_class.new(dispatcher, ttl_seconds: 60)
       manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
 
-      expect(Thread.list.map(&:name)).to include('daytona-subscription-expiry')
+      expect(manager.instance_variable_get(:@worker).name).to eq('daytona-subscription-expiry')
       manager.shutdown
     end
   end
@@ -177,11 +181,13 @@ RSpec.describe Daytona::EventSubscriptionManager do
     it 'stops the expiry worker' do
       manager = described_class.new(dispatcher, ttl_seconds: 60)
       manager.subscribe(resource_id: 'sandbox-1', handler:, events:)
-      threads_with_worker = Thread.list.size
+      worker = manager.instance_variable_get(:@worker)
+      expect(worker).to be_alive
 
       manager.shutdown
 
-      expect(wait_until { Thread.list.size == threads_with_worker - 1 }).to be(true)
+      worker.join(5)
+      expect(worker).not_to be_alive
     end
   end
 end

--- a/sdk-typescript/scripts/post-build.js
+++ b/sdk-typescript/scripts/post-build.js
@@ -15,7 +15,18 @@ const writeJson = (p, data) => fs.writeFileSync(p, JSON.stringify(data, null, 2)
 const generatedDeps = readJson(path.join(cjsDir, 'package.json')).dependencies ?? {}
 
 const pkg = readJson(path.join(sourceDir, 'package.json'))
-pkg.dependencies = { ...generatedDeps }
+const rootDeps = readJson(path.join(workspaceRoot, 'package.json')).dependencies
+// The generated deps only contain packages imported directly from source, so
+// they miss runtime deps that strict resolvers (Yarn PnP, pnpm) require to be
+// declared:
+//   - tslib: tsconfig.base.json sets "importHelpers": true, so emitted JS
+//     imports helpers from tslib at runtime
+//   - ws: isomorphic-ws declares ws as a peer dependency and require()s it in
+//     Node; an ancestor (this package) must provide it
+for (const name of ['tslib', 'ws']) {
+  if (!rootDeps[name]) throw new Error(`${name} must be declared in the workspace root dependencies`)
+}
+pkg.dependencies = { tslib: rootDeps.tslib, ws: rootDeps.ws, ...generatedDeps }
 for (const name of ['api-client', 'toolbox-api-client', 'analytics-api-client']) {
   const distPkg = readJson(path.join(workspaceRoot, 'dist', name, 'package.json'))
   pkg.dependencies[`@daytona/${name}`] = distPkg.version

--- a/yarn.lock
+++ b/yarn.lock
@@ -11101,6 +11101,7 @@ __metadata:
     typescript: "npm:5.8.3"
     typescript-eslint: "npm:^8.19.0"
     verdaccio: "npm:6.0.5"
+    ws: "npm:^8.18.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Problem

`@daytona/sdk@0.200.1` throws at require-time for every Yarn PnP project (and pnpm-strict): 

1. `@daytona/sdk tried to access tslib, but it isn't declared in its dependencies`
2. After working around (1): `isomorphic-ws tried to access ws (a peer dependency) but it isn't provided by its ancestors`

Plain npm users were unaffected because npm hoists and auto-installs peers, which is why this shipped unnoticed.

### Root cause

The published manifest is assembled by `sdk-typescript/scripts/post-build.js` from the dependency list generated by the Nx tsc build. That list only contains packages **imported directly in source**, so it misses two runtime deps that never appear in an import statement:

- **`tslib`** — `tsconfig.base.json` sets `"importHelpers": true`, so every emitted JS file imports helpers from `tslib` at runtime
- **`ws`** — `isomorphic-ws@5` declares `ws` as a peer dependency and `require()`s it in Node; strict resolvers require an ancestor (`@daytona/sdk`) to provide it

## Fix

- `post-build.js` now injects `tslib` and `ws` into the published `dependencies`, sourcing the version ranges from the root `package.json` (single source of truth — same place the build detects everything else from)
- Root `package.json`: moved `tslib` from devDependencies to dependencies, added `ws: ^8.18.0`

Intentionally **not** done (per analysis): disabling `importHelpers` (bundle-size regression) or replacing `isomorphic-ws` (browser builds rely on its conditional resolution).

## Verification

All checks ran against a locally packed tarball of the built artifact (`npm pack dist/sdk-typescript`), with the workspace-internal `@daytona/*` API clients overridden to local tarballs:

| Check | Result |
|---|---|
| Tarball `package.json` contains `tslib ^2.8.1` + `ws ^8.18.0` | ✅ |
| Yarn 4.17 PnP: `import('@daytona/sdk')` | ✅ |
| pnpm: import + `pnpm why` (tslib/ws resolve via `@daytona/sdk`) | ✅ |
| npm fresh consumer: import + `npm ls tslib ws` | ✅ |
| `attw --pack` | ✅ |
| `nx test sdk-typescript` | ✅ |

## Notes for consumers

Once released, the `.yarnrc.yml` `packageExtensions` workaround can be removed:

```yaml
packageExtensions:
  "@daytona/sdk@*":
    dependencies:
      tslib: "^2"
      ws: "^8"
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare `tslib` and `ws` as runtime dependencies for the published `@daytona/sdk` to fix require-time errors in Yarn PnP and pnpm strict. The build now injects these deps from root versions; root `package.json` was updated.

- **Bug Fixes**
  - `sdk-typescript/scripts/post-build.js` now adds `tslib` and `ws` to published `dependencies` using versions from the root and throws if they’re missing; root `package.json` moves `tslib` to `dependencies` and adds `ws`.
  - Fixes strict resolver failures (Yarn PnP, pnpm) caused by missing `tslib` and peer `ws` from `isomorphic-ws`.
  - Deflaked Python and Ruby SDK tests by asserting worker liveness directly instead of comparing global thread counts.

- **Migration**
  - Yarn PnP: remove any `packageExtensions` that add `tslib` or `ws` to `@daytona/sdk`.
  - No action needed for npm users.

<sup>Written for commit 5e7aa2c3c86577da43b21349629ec2f976dd3ba5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

