### PR TITLE
Relax dotenv dependency to allow 3.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       daytona_analytics_api_client (= 0.0.0.pre.dev)
       daytona_api_client (= 0.0.0.pre.dev)
       daytona_toolbox_api_client (= 0.0.0.pre.dev)
-      dotenv (~> 2.0)
+      dotenv (>= 2.0, < 4)
       observer (~> 0.1)
       opentelemetry-exporter-otlp (~> 0.29)
       opentelemetry-exporter-otlp-metrics (~> 0.1)

--- a/sdk-ruby/daytona.gemspec
+++ b/sdk-ruby/daytona.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'daytona_analytics_api_client', Daytona::Sdk::VERSION
   spec.add_dependency 'daytona_api_client', Daytona::Sdk::VERSION
   spec.add_dependency 'daytona_toolbox_api_client', Daytona::Sdk::VERSION
-  spec.add_dependency 'dotenv', '~> 2.0'
+  spec.add_dependency 'dotenv', '>= 2.0', '< 4'
   spec.add_dependency 'observer', '~> 0.1'
   spec.add_dependency 'toml', '~> 0.3'
   spec.add_dependency 'websocket-client-simple', '~> 0.6'


### PR DESCRIPTION
The Ruby SDK pins `dotenv ~> 2.0`, which makes `gem 'daytona'` unresolvable in any bundle that already depends on dotenv 3.

The SDK's only dotenv usage is `Dotenv.parse`, whose API is unchanged between 2.x and 3.x, so this relaxes the constraint to `'>= 2.0', '< 4'`. Users on dotenv 2.x are unaffected.

Verified in a Rails 8 app against dotenv 3.2.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed the `dotenv` dependency to support 3.x. This resolves Bundler conflicts for apps on `dotenv` 3.x and keeps 2.x users unaffected (we only call Dotenv.parse).

- **Dependencies**
  - Updated `dotenv` constraint from `~> 2.0` to `>= 2.0, < 4` and synced Gemfile.lock to match.

<sup>Written for commit 10c6b50b8a6f6b9a877fc26aa327b1b533d8a61a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

