### PR TITLE
fix(toolbox-api-client-python): optional FileInfo.modifiedAt for old-runner compatibility

### DIFF
--- a/hack/python-client/patch-toolbox-spec.mjs
+++ b/hack/python-client/patch-toolbox-spec.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Python-only overlay for the vendored toolbox spec.
+//
+// NOTE: This is a temporary solution.
+//
+// Older runner daemons return `modifiedAt: null` (or omit it) in FileInfo
+// responses, which the strict pydantic models reject. Until all runners
+// are upgraded, the Python toolbox clients are generated from a patched copy
+// of the spec where `modifiedAt` is not required (=> Optional[StrictStr]).
+//
+// The vendored openapi-specs/toolbox.json stays pristine; only the Python
+// client generation consumes the patched copy. Other languages are untouched.
+//
+// Usage: node hack/python-client/patch-toolbox-spec.mjs <input-spec> <output-spec>
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const [input, output] = process.argv.slice(2);
+if (!input || !output) {
+  console.error('Usage: patch-toolbox-spec.mjs <input-spec> <output-spec>');
+  process.exit(1);
+}
+
+// schema -> properties to drop from its `required` list
+const OPTIONAL_OVERRIDES = {
+  FileInfo: ['modifiedAt'],
+};
+
+const spec = JSON.parse(readFileSync(input, 'utf8'));
+const schemas = spec.definitions ?? spec.components?.schemas ?? {};
+
+for (const [schemaName, props] of Object.entries(OPTIONAL_OVERRIDES)) {
+  const schema = schemas[schemaName];
+  if (!schema?.required) continue;
+  const before = schema.required.length;
+  schema.required = schema.required.filter((p) => !props.includes(p));
+  if (schema.required.length !== before) {
+    console.log(
+      `patch-toolbox-spec: ${schemaName}: made optional -> ${props.join(', ')}`,
+    );
+  }
+  if (schema.required.length === 0) delete schema.required;
+}
+
+mkdirSync(dirname(output), { recursive: true });
+writeFileSync(output, JSON.stringify(spec, null, 2) + '\n');

--- a/nx.json
+++ b/nx.json
@@ -41,7 +41,8 @@
     "pythonApiClient": [
       "apiClient",
       "{workspaceRoot}/hack/python-client/openapi-templates/**/*",
-      "{workspaceRoot}/hack/python-client/postprocess.sh"
+      "{workspaceRoot}/hack/python-client/postprocess.sh",
+      "{workspaceRoot}/hack/python-client/patch-toolbox-spec.mjs"
     ],
     "goApiClient": [
       "apiClient",

--- a/toolbox-api-client-python-async/daytona_toolbox_api_client_async/models/file_info.py
+++ b/toolbox-api-client-python-async/daytona_toolbox_api_client_async/models/file_info.py
@@ -33,7 +33,7 @@ class FileInfo(BaseModel):
     is_dir: StrictBool = Field(serialization_alias="isDir")
     mod_time: StrictStr = Field(description="Deprecated: ModTime uses Go's time.String() layout which is not a standard format. Use ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.", serialization_alias="modTime")
     mode: StrictStr
-    modified_at: StrictStr = Field(serialization_alias="modifiedAt")
+    modified_at: Optional[StrictStr] = Field(default=None, serialization_alias="modifiedAt")
     name: StrictStr
     owner: StrictStr
     path: Optional[StrictStr] = Field(default=None, description="Full path of the entry")

--- a/toolbox-api-client-python-async/project.json
+++ b/toolbox-api-client-python-async/project.json
@@ -12,7 +12,8 @@
       "options": {
         "commands": [
           "rm -rf {projectRoot}/daytona_toolbox_api_client_async",
-          "yarn run openapi-generator-cli generate --git-repo-id=clients --git-user-id=daytona -i openapi-specs/toolbox.json -g python --model-name-mappings computeruse.AccessibilityNode=ComputerUseAccessibilityNode -t hack/python-client/openapi-templates --additional-properties=packageName=daytona_toolbox_api_client_async,projectName=daytona_toolbox_api_client_async,packageVersion=$DEFAULT_PACKAGE_VERSION,pythonPackageName=daytona_toolbox_api_client_async,disallowAdditionalPropertiesIfNotPresent=false,library=asyncio,enumUnknownDefaultCase=true -o {projectRoot}",
+          "node hack/python-client/patch-toolbox-spec.mjs openapi-specs/toolbox.json tmp/toolbox-python-async.json",
+          "yarn run openapi-generator-cli generate --git-repo-id=clients --git-user-id=daytona -i tmp/toolbox-python-async.json -g python --model-name-mappings computeruse.AccessibilityNode=ComputerUseAccessibilityNode -t hack/python-client/openapi-templates --additional-properties=packageName=daytona_toolbox_api_client_async,projectName=daytona_toolbox_api_client_async,packageVersion=$DEFAULT_PACKAGE_VERSION,pythonPackageName=daytona_toolbox_api_client_async,disallowAdditionalPropertiesIfNotPresent=false,library=asyncio,enumUnknownDefaultCase=true -o {projectRoot}",
           "bash hack/python-client/postprocess.sh {projectRoot}"
         ],
         "parallel": false

--- a/toolbox-api-client-python/daytona_toolbox_api_client/models/file_info.py
+++ b/toolbox-api-client-python/daytona_toolbox_api_client/models/file_info.py
@@ -33,7 +33,7 @@ class FileInfo(BaseModel):
     is_dir: StrictBool = Field(serialization_alias="isDir")
     mod_time: StrictStr = Field(description="Deprecated: ModTime uses Go's time.String() layout which is not a standard format. Use ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.", serialization_alias="modTime")
     mode: StrictStr
-    modified_at: StrictStr = Field(serialization_alias="modifiedAt")
+    modified_at: Optional[StrictStr] = Field(default=None, serialization_alias="modifiedAt")
     name: StrictStr
     owner: StrictStr
     path: Optional[StrictStr] = Field(default=None, description="Full path of the entry")

--- a/toolbox-api-client-python/project.json
+++ b/toolbox-api-client-python/project.json
@@ -12,7 +12,8 @@
       "options": {
         "commands": [
           "rm -rf {projectRoot}/daytona_toolbox_api_client",
-          "yarn run openapi-generator-cli generate --git-repo-id=clients --git-user-id=daytona -i openapi-specs/toolbox.json -g python --model-name-mappings computeruse.AccessibilityNode=ComputerUseAccessibilityNode -t hack/python-client/openapi-templates --additional-properties=packageName=daytona_toolbox_api_client,projectName=daytona_toolbox_api_client,packageVersion=$DEFAULT_PACKAGE_VERSION,pythonPackageName=daytona_toolbox_api_client,disallowAdditionalPropertiesIfNotPresent=false,enumUnknownDefaultCase=true -o {projectRoot}",
+          "node hack/python-client/patch-toolbox-spec.mjs openapi-specs/toolbox.json tmp/toolbox-python-sync.json",
+          "yarn run openapi-generator-cli generate --git-repo-id=clients --git-user-id=daytona -i tmp/toolbox-python-sync.json -g python --model-name-mappings computeruse.AccessibilityNode=ComputerUseAccessibilityNode -t hack/python-client/openapi-templates --additional-properties=packageName=daytona_toolbox_api_client,projectName=daytona_toolbox_api_client,packageVersion=$DEFAULT_PACKAGE_VERSION,pythonPackageName=daytona_toolbox_api_client,disallowAdditionalPropertiesIfNotPresent=false,enumUnknownDefaultCase=true -o {projectRoot}",
           "bash hack/python-client/postprocess.sh {projectRoot}"
         ],
         "parallel": false


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make `FileInfo.modifiedAt` optional in the Python toolbox clients to stay compatible with older runners that return null or omit the field. Adds a Python-only spec patch step so generation accepts missing values without changing the upstream spec or other languages.

- **Bug Fixes**
  - `FileInfo.modified_at` is now Optional[str] (default None) in `daytona_toolbox_api_client` and `daytona_toolbox_api_client_async`.

- **Refactors**
  - Added `hack/python-client/patch-toolbox-spec.mjs` to drop `modifiedAt` from `FileInfo` required list when generating Python clients.
  - Updated Python client generation to use the patched spec and added the script to `nx.json` inputs.

<sup>Written for commit 2e002ebac2465fcfa80cbb0db7d0b13fd23e80ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

