### PR TITLE
ci(release): gate release workflows behind the release environment

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -17,6 +17,9 @@ jobs:
   prepare:
     if: github.repository == 'daytona/clients'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # GITHUBBOT_TOKEN lives only in the `release` environment; the run waits
+    # for required-reviewer approval before secrets resolve.
+    environment: release
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,6 +111,9 @@ jobs:
     needs: release
     if: github.repository == 'daytona/clients'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # GITHUBBOT_TOKEN lives only in the `release` environment; the run waits
+    # for required-reviewer approval before secrets resolve.
+    environment: release
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,9 @@ jobs:
   release:
     if: github.repository == 'daytona/clients'
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    # GITHUBBOT_TOKEN lives only in the `release` environment; the run waits
+    # for required-reviewer approval before secrets resolve.
+    environment: release
     permissions:
       contents: write
     env:


### PR DESCRIPTION
Follow-up to #127: publish credentials moved to the `release` environment and the repository-level copies were removed. `prepare-release` and `release` still read `GITHUBBOT_TOKEN` from repository secrets, so their next run would get an empty `GH_TOKEN` and stop at the fail-fast guard when creating the release/sync PR.

Declaring `environment: release` on both jobs restores token access and puts the whole release chain behind the same approval gate: one reviewer click per run (self-approval allowed), any branch may deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the release chain behind the `release` environment so `prepare-release`, `release`, and `sync_gosum` wait for approval and can read `GITHUBBOT_TOKEN`. Fixes fail-fast runs from empty `GH_TOKEN` after moving publish credentials to the environment, and keeps tag pushes, asset uploads, and the sync PR to one reviewer click per run from any branch.

<sup>Written for commit 97ca8630fff886aa356cd571353d2c7f99c6b7ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

