### PR TITLE
feat(sdk): promote fork and create-snapshot to stable API, deprecate experimental aliases

### DIFF
--- a/artifacts/sdk-docs/go-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/go-sdk/daytona.mdx
@@ -250,6 +250,8 @@ result, err := sandbox.Process.ExecuteCommand(ctx, "ls -la")
   - [func NewSandbox\(client \*Client, toolboxClient \*toolbox.APIClient, dto sandboxDTO, language types.CodeLanguage, subscriptionManager \*common.EventSubscriptionManager\) \*Sandbox](<#NewSandbox>)
   - [func \(s \*Sandbox\) Archive\(ctx context.Context\) error](<#Sandbox.Archive>)
   - [func \(s \*Sandbox\) CreateLspServer\(languageID types.LspLanguageID, pathToProject string\) \*LspServerService](<#Sandbox.CreateLspServer>)
+  - [func \(s \*Sandbox\) CreateSnapshot\(ctx context.Context, name string\) error](<#Sandbox.CreateSnapshot>)
+  - [func \(s \*Sandbox\) CreateSnapshotWithTimeout\(ctx context.Context, name string, timeout time.Duration\) error](<#Sandbox.CreateSnapshotWithTimeout>)
   - [func \(s \*Sandbox\) Delete\(ctx context.Context\) error](<#Sandbox.Delete>)
   - [func \(s \*Sandbox\) DeleteAndWait\(ctx context.Context, timeout time.Duration\) error](<#Sandbox.DeleteAndWait>)
   - [func \(s \*Sandbox\) DeleteWithTimeout\(ctx context.Context, timeout time.Duration\) error](<#Sandbox.DeleteWithTimeout>)
@@ -259,6 +261,8 @@ result, err := sandbox.Process.ExecuteCommand(ctx, "ls -la")
   - [func \(s \*Sandbox\) ExperimentalFork\(ctx context.Context, name \*string\) \(\*Sandbox, error\)](<#Sandbox.ExperimentalFork>)
   - [func \(s \*Sandbox\) ExperimentalForkWithTimeout\(ctx context.Context, name \*string, timeout time.Duration\) \(\*Sandbox, error\)](<#Sandbox.ExperimentalForkWithTimeout>)
   - [func \(s \*Sandbox\) ExpireSignedPreviewLink\(ctx context.Context, port int, token string\) error](<#Sandbox.ExpireSignedPreviewLink>)
+  - [func \(s \*Sandbox\) Fork\(ctx context.Context, name \*string\) \(\*Sandbox, error\)](<#Sandbox.Fork>)
+  - [func \(s \*Sandbox\) ForkWithTimeout\(ctx context.Context, name \*string, timeout time.Duration\) \(\*Sandbox, error\)](<#Sandbox.ForkWithTimeout>)
   - [func \(s \*Sandbox\) GetMetrics\(ctx context.Context, start, end \*time.Time\) \(\[\]SandboxMetrics, error\)](<#Sandbox.GetMetrics>)
   - [func \(s \*Sandbox\) GetMetricsLatest\(ctx context.Context\) \(SandboxMetrics, error\)](<#Sandbox.GetMetricsLatest>)
   - [func \(s \*Sandbox\) GetPreviewLink\(ctx context.Context, port int\) \(\*types.PreviewLink, error\)](<#Sandbox.GetPreviewLink>)
@@ -4432,6 +4436,41 @@ if err := lsp.Start(ctx); err != nil {
 defer lsp.Stop(ctx)
 ```
 
+<a name="Sandbox.CreateSnapshot"></a>
+### func \(\*Sandbox\) CreateSnapshot
+
+```go
+func (s *Sandbox) CreateSnapshot(ctx context.Context, name string) error
+```
+
+CreateSnapshot creates a snapshot from the current state of the sandbox with a default timeout of 60 seconds.
+
+This captures the sandbox's filesystem into a reusable snapshot that can be used to create new sandboxes. The sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
+
+Example:
+
+```
+err := sandbox.CreateSnapshot(ctx, "my-snapshot")
+if err != nil {
+    return err
+}
+```
+
+<a name="Sandbox.CreateSnapshotWithTimeout"></a>
+### func \(\*Sandbox\) CreateSnapshotWithTimeout
+
+```go
+func (s *Sandbox) CreateSnapshotWithTimeout(ctx context.Context, name string, timeout time.Duration) error
+```
+
+CreateSnapshotWithTimeout creates a snapshot from the current state of the sandbox with a custom timeout. 0 means no timeout.
+
+Example:
+
+```
+err := sandbox.CreateSnapshotWithTimeout(ctx, "my-snapshot", 2*time.Minute)
+```
+
 <a name="Sandbox.Delete"></a>
 ### func \(\*Sandbox\) Delete
 
@@ -4502,18 +4541,9 @@ url, err := sandbox.DownloadURL(ctx, "/home/user/report.pdf", nil)
 func (s *Sandbox) ExperimentalCreateSnapshot(ctx context.Context, name string) error
 ```
 
-ExperimentalCreateSnapshot creates a snapshot from the current state of the sandbox with a default timeout of 60 seconds.
+ExperimentalCreateSnapshot creates a snapshot from the current state of the sandbox.
 
-This captures the sandbox's filesystem into a reusable snapshot that can be used to create new sandboxes. The sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
-
-Example:
-
-```
-err := sandbox.ExperimentalCreateSnapshot(ctx, "my-snapshot")
-if err != nil {
-    return err
-}
-```
+Deprecated: Use CreateSnapshot instead. This method will be removed in a future release.
 
 <a name="Sandbox.ExperimentalCreateSnapshotWithTimeout"></a>
 ### func \(\*Sandbox\) ExperimentalCreateSnapshotWithTimeout
@@ -4522,13 +4552,9 @@ if err != nil {
 func (s *Sandbox) ExperimentalCreateSnapshotWithTimeout(ctx context.Context, name string, timeout time.Duration) error
 ```
 
-ExperimentalCreateSnapshotWithTimeout creates a snapshot from the current state of the sandbox with a custom timeout. 0 means no timeout.
+ExperimentalCreateSnapshotWithTimeout creates a snapshot with a custom timeout.
 
-Example:
-
-```
-err := sandbox.ExperimentalCreateSnapshotWithTimeout(ctx, "my-snapshot", 2*time.Minute)
-```
+Deprecated: Use CreateSnapshotWithTimeout instead. This method will be removed in a future release.
 
 <a name="Sandbox.ExperimentalFork"></a>
 ### func \(\*Sandbox\) ExperimentalFork
@@ -4537,19 +4563,9 @@ err := sandbox.ExperimentalCreateSnapshotWithTimeout(ctx, "my-snapshot", 2*time.
 func (s *Sandbox) ExperimentalFork(ctx context.Context, name *string) (*Sandbox, error)
 ```
 
-ExperimentalFork forks the sandbox with a default timeout of 60 seconds, creating a new sandbox with an identical filesystem.
+ExperimentalFork forks the sandbox with a default timeout of 60 seconds.
 
-The forked sandbox is a copy\-on\-write clone of the original. It starts with the same disk contents but operates independently from that point on. ExperimentalFork waits for the new sandbox to reach the "started" state before returning.
-
-Example:
-
-```
-forked, err := sandbox.ExperimentalFork(ctx, nil)
-if err != nil {
-    return err
-}
-fmt.Printf("Forked sandbox: %s\n", forked.ID)
-```
+Deprecated: Use Fork instead. This method will be removed in a future release.
 
 <a name="Sandbox.ExperimentalForkWithTimeout"></a>
 ### func \(\*Sandbox\) ExperimentalForkWithTimeout
@@ -4558,19 +4574,9 @@ fmt.Printf("Forked sandbox: %s\n", forked.ID)
 func (s *Sandbox) ExperimentalForkWithTimeout(ctx context.Context, name *string, timeout time.Duration) (*Sandbox, error)
 ```
 
-ExperimentalForkWithTimeout forks the sandbox with a custom timeout, creating a new sandbox with an identical filesystem.
+ExperimentalForkWithTimeout forks the sandbox with a custom timeout.
 
-The forked sandbox is a copy\-on\-write clone of the original. It starts with the same disk contents but operates independently from that point on. ExperimentalForkWithTimeout waits for the new sandbox to reach the "started" state before returning. 0 means no timeout.
-
-Example:
-
-```
-forked, err := sandbox.ExperimentalForkWithTimeout(ctx, nil, 2*time.Minute)
-if err != nil {
-    return err
-}
-fmt.Printf("Forked sandbox: %s\n", forked.ID)
-```
+Deprecated: Use ForkWithTimeout instead. This method will be removed in a future release.
 
 <a name="Sandbox.ExpireSignedPreviewLink"></a>
 ### func \(\*Sandbox\) ExpireSignedPreviewLink
@@ -4590,6 +4596,48 @@ err := sandbox.ExpireSignedPreviewLink(ctx, 3000, "preview-token-to-expire")
 if err != nil {
     return err
 }
+```
+
+<a name="Sandbox.Fork"></a>
+### func \(\*Sandbox\) Fork
+
+```go
+func (s *Sandbox) Fork(ctx context.Context, name *string) (*Sandbox, error)
+```
+
+Fork forks the sandbox with a default timeout of 60 seconds, creating a new sandbox with an identical filesystem.
+
+The forked sandbox is a copy\-on\-write clone of the original. It starts with the same disk contents but operates independently from that point on. Fork waits for the new sandbox to reach the "started" state before returning.
+
+Example:
+
+```
+forked, err := sandbox.Fork(ctx, nil)
+if err != nil {
+    return err
+}
+fmt.Printf("Forked sandbox: %s\n", forked.ID)
+```
+
+<a name="Sandbox.ForkWithTimeout"></a>
+### func \(\*Sandbox\) ForkWithTimeout
+
+```go
+func (s *Sandbox) ForkWithTimeout(ctx context.Context, name *string, timeout time.Duration) (*Sandbox, error)
+```
+
+ForkWithTimeout forks the sandbox with a custom timeout, creating a new sandbox with an identical filesystem.
+
+The forked sandbox is a copy\-on\-write clone of the original. It starts with the same disk contents but operates independently from that point on. ForkWithTimeout waits for the new sandbox to reach the "started" state before returning. 0 means no timeout.
+
+Example:
+
+```
+forked, err := sandbox.ForkWithTimeout(ctx, nil, 2*time.Minute)
+if err != nil {
+    return err
+}
+fmt.Printf("Forked sandbox: %s\n", forked.ID)
 ```
 
 <a name="Sandbox.GetMetrics"></a>

--- a/artifacts/sdk-docs/java-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/java-sdk/sandbox.mdx
@@ -672,7 +672,7 @@ sandbox.createSnapshot("my-snapshot", 120);
 **Parameters**:
 
 - `name` _String_ - name for the new snapshot
-- `timeoutSeconds` _long_ - reserved timeout parameter for parity with other SDKs
+- `timeoutSeconds` _long_ - maximum seconds to wait for the snapshot operation to complete; `0` disables timeout
 
 **Throws**:
 
@@ -709,7 +709,7 @@ The Sandbox will temporarily enter a 'snapshotting' state and return to its prev
 **Parameters**:
 
 - `name` _String_ - name for the new snapshot
-- `timeoutSeconds` _long_ - reserved timeout parameter for parity with other SDKs
+- `timeoutSeconds` _long_ - maximum seconds to wait for the snapshot operation to complete; `0` disables timeout
 
 **Throws**:
 

--- a/artifacts/sdk-docs/java-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/java-sdk/sandbox.mdx
@@ -545,6 +545,55 @@ Refreshes local Sandbox fields from latest API state. After refresh, all fields
 
 - `DaytonaException` - if refresh fails
 
+#### fork()
+```java
+public Sandbox fork()
+```
+
+Forks this Sandbox, creating a new Sandbox with an identical filesystem.
+Uses default timeout of 60 seconds.
+
+Example usage:
+```java
+Sandbox forked = sandbox.fork();
+System.out.println(forked.getId());
+```
+
+**Returns**:
+
+- `Sandbox` - the forked `Sandbox` in started state
+
+**Throws**:
+
+- `DaytonaException` - if the fork operation fails or times out
+
+#### fork()
+```java
+public Sandbox fork(String name, long timeoutSeconds)
+```
+
+Forks this Sandbox, creating a new Sandbox with an identical filesystem.
+The forked Sandbox is a copy-on-write clone of the original.
+
+Example usage:
+```java
+Sandbox forked = sandbox.fork("my-fork", 120);
+System.out.println(forked.getId());
+```
+
+**Parameters**:
+
+- `name` _String_ - optional name for the forked Sandbox; `null` for auto-generated
+- `timeoutSeconds` _long_ - maximum seconds to wait for the forked Sandbox to start; `0` disables timeout
+
+**Returns**:
+
+- `Sandbox` - the forked `Sandbox` in started state
+
+**Throws**:
+
+- `DaytonaException` - if the fork operation fails or times out
+
 #### experimentalFork()
 ```java
 public Sandbox experimentalFork()
@@ -552,6 +601,8 @@ public Sandbox experimentalFork()
 
 Forks this Sandbox, creating a new Sandbox with an identical filesystem.
 Uses default timeout of 60 seconds.
+
+**Deprecated**: Use `#fork()` instead. This method will be removed in a future version.
 
 **Returns**:
 
@@ -569,6 +620,8 @@ public Sandbox experimentalFork(String name, long timeoutSeconds)
 Forks this Sandbox, creating a new Sandbox with an identical filesystem.
 The forked Sandbox is a copy-on-write clone of the original.
 
+**Deprecated**: Use `#fork(String, long)` instead. This method will be removed in a future version.
+
 **Parameters**:
 
 - `name` _String_ - optional name for the forked Sandbox; `null` for auto-generated
@@ -582,6 +635,49 @@ The forked Sandbox is a copy-on-write clone of the original.
 
 - `DaytonaException` - if the fork operation fails or times out
 
+#### createSnapshot()
+```java
+public void createSnapshot(String name)
+```
+
+Creates a snapshot from the current state of this Sandbox.
+Uses default timeout of 60 seconds.
+
+Example usage:
+```java
+sandbox.createSnapshot("my-snapshot");
+```
+
+**Parameters**:
+
+- `name` _String_ - name for the new snapshot
+
+**Throws**:
+
+- `DaytonaException` - if the snapshot operation fails
+
+#### createSnapshot()
+```java
+public void createSnapshot(String name, long timeoutSeconds)
+```
+
+Creates a snapshot from the current state of this Sandbox.
+The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
+
+Example usage:
+```java
+sandbox.createSnapshot("my-snapshot", 120);
+```
+
+**Parameters**:
+
+- `name` _String_ - name for the new snapshot
+- `timeoutSeconds` _long_ - reserved timeout parameter for parity with other SDKs
+
+**Throws**:
+
+- `DaytonaException` - if the snapshot operation fails
+
 #### experimentalCreateSnapshot()
 ```java
 public void experimentalCreateSnapshot(String name)
@@ -589,6 +685,8 @@ public void experimentalCreateSnapshot(String name)
 
 Creates a snapshot from the current state of this Sandbox.
 Uses default timeout of 60 seconds.
+
+**Deprecated**: Use `#createSnapshot(String)` instead. This method will be removed in a future version.
 
 **Parameters**:
 
@@ -605,6 +703,8 @@ public void experimentalCreateSnapshot(String name, long timeoutSeconds)
 
 Creates a snapshot from the current state of this Sandbox.
 The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
+
+**Deprecated**: Use `#createSnapshot(String, long)` instead. This method will be removed in a future version.
 
 **Parameters**:
 

--- a/artifacts/sdk-docs/python-sdk/async/async-sandbox.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-sandbox.mdx
@@ -1054,6 +1054,79 @@ It is useful for keeping long-running sessions alive while there is still user a
 await sandbox.refresh_activity()
 ```
 
+#### AsyncSandbox.fork
+
+```python
+@intercept_errors(message_prefix="Failed to fork sandbox: ")
+@with_timeout()
+@with_instrumentation()
+async def fork(name: str | None = None,
+               timeout: float | None = 60) -> "AsyncSandbox"
+```
+
+Forks the Sandbox, creating a new Sandbox with an identical filesystem.
+
+The forked Sandbox is a copy-on-write clone of the original. It starts
+with the same disk contents but operates independently from that point on.
+
+**Arguments**:
+
+- `name` _str | None_ - Optional name for the forked Sandbox. If not provided, a unique name will be generated.
+- `timeout` _float | None_ - Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
+  
+
+**Returns**:
+
+- `AsyncSandbox` - The forked Sandbox.
+  
+
+**Raises**:
+
+- `DaytonaError` - If the fork operation fails or times out.
+  
+
+**Example**:
+
+```python
+sandbox = await daytona.get("my-sandbox")
+forked = await sandbox.fork(name="my-fork")
+print(f"Forked sandbox: {forked.id}")
+```
+
+#### AsyncSandbox.create\_snapshot
+
+```python
+@intercept_errors(message_prefix="Failed to create snapshot: ")
+@with_timeout()
+@with_instrumentation()
+async def create_snapshot(name: str, timeout: float | None = 60) -> None
+```
+
+Creates a snapshot from the current state of the Sandbox.
+
+This captures the Sandbox's filesystem into a reusable snapshot that can be
+used to create new Sandboxes. The Sandbox will temporarily enter a
+'snapshotting' state and return to its previous state when complete.
+
+**Arguments**:
+
+- `name` _str_ - Name for the new snapshot.
+- `timeout` _float | None_ - Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
+  
+
+**Raises**:
+
+- `DaytonaError` - If the snapshot operation fails or times out.
+  
+
+**Example**:
+
+```python
+sandbox = await daytona.get("my-sandbox")
+await sandbox.create_snapshot("my-snapshot")
+print("Snapshot created successfully")
+```
+
 #### AsyncSandbox.pause
 
 ```python

--- a/artifacts/sdk-docs/python-sdk/sync/sandbox.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/sandbox.mdx
@@ -1044,6 +1044,78 @@ It is useful for keeping long-running sessions alive while there is still user a
 sandbox.refresh_activity()
 ```
 
+#### Sandbox.fork
+
+```python
+@intercept_errors(message_prefix="Failed to fork sandbox: ")
+@with_timeout()
+@with_instrumentation()
+def fork(name: str | None = None, timeout: float | None = 60) -> "Sandbox"
+```
+
+Forks the Sandbox, creating a new Sandbox with an identical filesystem.
+
+The forked Sandbox is a copy-on-write clone of the original. It starts
+with the same disk contents but operates independently from that point on.
+
+**Arguments**:
+
+- `name` _str | None_ - Optional name for the forked Sandbox. If not provided, a unique name will be generated.
+- `timeout` _float | None_ - Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
+  
+
+**Returns**:
+
+- `Sandbox` - The forked Sandbox.
+  
+
+**Raises**:
+
+- `DaytonaError` - If the fork operation fails or times out.
+  
+
+**Example**:
+
+```python
+sandbox = daytona.get("my-sandbox")
+forked = sandbox.fork(name="my-fork")
+print(f"Forked sandbox: {forked.id}")
+```
+
+#### Sandbox.create\_snapshot
+
+```python
+@intercept_errors(message_prefix="Failed to create snapshot: ")
+@with_timeout()
+@with_instrumentation()
+def create_snapshot(name: str, timeout: float | None = 60) -> None
+```
+
+Creates a snapshot from the current state of the Sandbox.
+
+This captures the Sandbox's filesystem into a reusable snapshot that can be
+used to create new Sandboxes. The Sandbox will temporarily enter a
+'snapshotting' state and return to its previous state when complete.
+
+**Arguments**:
+
+- `name` _str_ - Name for the new snapshot.
+- `timeout` _float | None_ - Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
+  
+
+**Raises**:
+
+- `DaytonaError` - If the snapshot operation fails or times out.
+  
+
+**Example**:
+
+```python
+sandbox = daytona.get("my-sandbox")
+sandbox.create_snapshot("my-snapshot")
+print("Snapshot created successfully")
+```
+
 #### Sandbox.pause
 
 ```python

--- a/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
@@ -1293,12 +1293,16 @@ def experimental_fork(name: nil, timeout: DEFAULT_TIMEOUT)
 
 ```
 
+Deprecated: Use +fork+ instead. This method will be removed in a future version.
+
 #### experimental_create_snapshot()
 
 ```ruby
 def experimental_create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
 
 ```
+
+Deprecated: Use +create_snapshot+ instead. This method will be removed in a future version.
 
 #### pause()
 

--- a/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
@@ -1247,10 +1247,10 @@ Treats destroyed as stopped to cover ephemeral sandboxes that are automatically 
 
 - `void`
 
-#### experimental_fork()
+#### fork()
 
 ```ruby
-def experimental_fork(name: nil, timeout: DEFAULT_TIMEOUT)
+def fork(name: nil, timeout: DEFAULT_TIMEOUT)
 
 ```
 
@@ -1267,10 +1267,10 @@ with the same disk contents but operates independently from that point on.
 
 - `Daytona:Sandbox` - The forked Sandbox
 
-#### experimental_create_snapshot()
+#### create_snapshot()
 
 ```ruby
-def experimental_create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
+def create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
 
 ```
 
@@ -1285,6 +1285,20 @@ The Sandbox will temporarily enter a 'snapshotting' state and return to its prev
 **Returns**:
 
 - `void`
+
+#### experimental_fork()
+
+```ruby
+def experimental_fork(name: nil, timeout: DEFAULT_TIMEOUT)
+
+```
+
+#### experimental_create_snapshot()
+
+```ruby
+def experimental_create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
+
+```
 
 #### pause()
 

--- a/artifacts/sdk-docs/typescript-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/daytona.mdx
@@ -78,7 +78,7 @@ When JWT token is provided without an organization ID
 
 ### Methods
 
-#### \_experimental\_fork()
+#### ~~\_experimental\_fork()~~
 
 ```ts
 _experimental_fork(
@@ -89,27 +89,24 @@ _experimental_fork(
 timeout?: number): Promise<Sandbox>
 ```
 
-Forks a Sandbox, creating a new Sandbox with an identical filesystem.
-
 **Parameters**:
 
-- `sandbox` _Sandbox_ - The Sandbox to fork
-- `params?` _Fork parameters_
-- `name?` _string_ - Optional name for the forked Sandbox
-- `timeout?` _number = 60_ - Timeout in seconds (0 means no timeout, default is 60)
+- `sandbox` _Sandbox_
+- `params?` _###### name?_ - `string`
+- `timeout?` _number = 60_
 
 
 **Returns**:
 
-- `Promise<Sandbox>` - The forked Sandbox
+- `Promise<Sandbox>`
 
-**Example:**
+##### Deprecated
 
-```ts
-const sandbox = await daytona.get('my-sandbox-id');
-const forked = await daytona._experimental_fork(sandbox, { name: 'my-fork' });
-console.log(`Forked sandbox: ${forked.id}`);
-```
+Use `fork` instead. This method will be removed in a future version.
+
+##### See
+
+Daytona.fork
 
 ***
 
@@ -256,6 +253,41 @@ Deletes a Sandbox.
 ```ts
 const sandbox = await daytona.get('my-sandbox-id');
 await daytona.delete(sandbox);
+```
+
+***
+
+#### fork()
+
+```ts
+fork(
+   sandbox: Sandbox, 
+   params?: {
+  name: string;
+ }, 
+timeout?: number): Promise<Sandbox>
+```
+
+Forks a Sandbox, creating a new Sandbox with an identical filesystem.
+
+**Parameters**:
+
+- `sandbox` _Sandbox_ - The Sandbox to fork
+- `params?` _Fork parameters_
+- `name?` _string_ - Optional name for the forked Sandbox
+- `timeout?` _number = 60_ - Timeout in seconds (0 means no timeout, default is 60)
+
+
+**Returns**:
+
+- `Promise<Sandbox>` - The forked Sandbox
+
+**Example:**
+
+```ts
+const sandbox = await daytona.get('my-sandbox-id');
+const forked = await daytona.fork(sandbox, { name: 'my-fork' });
+console.log(`Forked sandbox: ${forked.id}`);
 ```
 
 ***

--- a/artifacts/sdk-docs/typescript-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/daytona.mdx
@@ -83,16 +83,14 @@ When JWT token is provided without an organization ID
 ```ts
 _experimental_fork(
    sandbox: Sandbox, 
-   params?: {
-  name: string;
- }, 
+   params?: ForkSandboxParams, 
 timeout?: number): Promise<Sandbox>
 ```
 
 **Parameters**:
 
 - `sandbox` _Sandbox_
-- `params?` _###### name?_ - `string`
+- `params?` _ForkSandboxParams_
 - `timeout?` _number = 60_
 
 
@@ -262,9 +260,7 @@ await daytona.delete(sandbox);
 ```ts
 fork(
    sandbox: Sandbox, 
-   params?: {
-  name: string;
- }, 
+   params?: ForkSandboxParams, 
 timeout?: number): Promise<Sandbox>
 ```
 
@@ -273,8 +269,7 @@ Forks a Sandbox, creating a new Sandbox with an identical filesystem.
 **Parameters**:
 
 - `sandbox` _Sandbox_ - The Sandbox to fork
-- `params?` _Fork parameters_
-- `name?` _string_ - Optional name for the forked Sandbox
+- `params?` _ForkSandboxParams_ - Fork parameters
 - `timeout?` _number = 60_ - Timeout in seconds (0 means no timeout, default is 60)
 
 
@@ -569,6 +564,22 @@ Represents a volume mount for a Sandbox.
 **Extends:**
 
 - `SandboxVolume`
+## ForkSandboxParams
+
+```ts
+type ForkSandboxParams = {
+  name: string;
+};
+```
+
+Parameters for forking a Sandbox.
+
+**Type declaration**:
+
+- `name?` _string_ - Optional name for the forked Sandbox. If not provided, a unique name will be generated.
+    
+
+
 ## CODE\_TOOLBOX\_LANGUAGE\_LABEL
 
 ```ts

--- a/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
@@ -97,46 +97,33 @@ Daytona.list rather than constructing directly.
 
 ### Methods
 
-#### \_experimental\_createSnapshot()
+#### ~~\_experimental\_createSnapshot()~~
 
 ```ts
-_experimental_createSnapshot(name: string, timeout?: number): Promise<void>
+_experimental_createSnapshot(name: string, timeout: number): Promise<void>
 ```
-
-Creates a snapshot from the current state of the Sandbox.
-
-This captures the Sandbox's filesystem into a reusable snapshot that can be
-used to create new Sandboxes. The Sandbox will temporarily enter a
-'snapshotting' state and return to its previous state when complete.
 
 **Parameters**:
 
-- `name` _string_ - Name for the new snapshot
-- `timeout?` _number = 60_ - Maximum time to wait in seconds. 0 means no timeout.
-    Defaults to 60-second timeout.
+- `name` _string_
+- `timeout` _number = 60_
 
 
 **Returns**:
 
 - `Promise<void>`
 
-**Throws**:
+##### Deprecated
 
-- If timeout is a negative number
+Use `createSnapshot` instead. This method will be removed in a future version.
 
-- If the snapshot operation fails or times out
+##### See
 
-**Example:**
-
-```ts
-const sandbox = await daytona.get('my-sandbox');
-await sandbox._experimental_createSnapshot('my-snapshot');
-console.log('Snapshot created successfully');
-```
+Sandbox.createSnapshot
 
 ***
 
-#### \_experimental\_fork()
+#### ~~\_experimental\_fork()~~
 
 ```ts
 _experimental_fork(params?: {
@@ -144,36 +131,23 @@ _experimental_fork(params?: {
 }, timeout?: number): Promise<Sandbox>
 ```
 
-Forks the Sandbox, creating a new Sandbox with an identical filesystem.
-
-The forked Sandbox is a copy-on-write clone of the original. It starts
-with the same disk contents but operates independently from that point on.
-
 **Parameters**:
 
-- `params?` _Fork parameters_
-- `name?` _string_ - Optional name for the forked Sandbox. If not provided, a unique name will be generated.
-- `timeout?` _number = 60_ - Maximum time to wait in seconds. 0 means no timeout.
-    Defaults to 60-second timeout.
+- `params?` _###### name?_ - `string`
+- `timeout?` _number = 60_
 
 
 **Returns**:
 
-- `Promise<Sandbox>` - The forked Sandbox.
+- `Promise<Sandbox>`
 
-**Throws**:
+##### Deprecated
 
-- If timeout is a negative number
+Use `fork` instead. This method will be removed in a future version.
 
-- If the fork operation fails or times out
+##### See
 
-**Example:**
-
-```ts
-const sandbox = await daytona.get('my-sandbox');
-const forked = await sandbox._experimental_fork({ name: 'my-fork' });
-console.log(`Forked sandbox: ${forked.id}`);
-```
+Sandbox.fork
 
 ***
 
@@ -219,6 +193,45 @@ diagnostics, and more.
 
 ```ts
 const lsp = await sandbox.createLspServer('typescript', 'workspace/project');
+```
+
+***
+
+#### createSnapshot()
+
+```ts
+createSnapshot(name: string, timeout?: number): Promise<void>
+```
+
+Creates a snapshot from the current state of the Sandbox.
+
+This captures the Sandbox's filesystem into a reusable snapshot that can be
+used to create new Sandboxes. The Sandbox will temporarily enter a
+'snapshotting' state and return to its previous state when complete.
+
+**Parameters**:
+
+- `name` _string_ - Name for the new snapshot
+- `timeout?` _number = 60_ - Maximum time to wait in seconds. 0 means no timeout.
+    Defaults to 60-second timeout.
+
+
+**Returns**:
+
+- `Promise<void>`
+
+**Throws**:
+
+- If timeout is a negative number
+
+- If the snapshot operation fails or times out
+
+**Example:**
+
+```ts
+const sandbox = await daytona.get('my-sandbox');
+await sandbox.createSnapshot('my-snapshot');
+console.log('Snapshot created successfully');
 ```
 
 ***
@@ -317,6 +330,47 @@ Expires a signed preview url for the sandbox at the specified port.
 **Returns**:
 
 - `Promise<void>`
+
+***
+
+#### fork()
+
+```ts
+fork(params?: {
+  name: string;
+}, timeout?: number): Promise<Sandbox>
+```
+
+Forks the Sandbox, creating a new Sandbox with an identical filesystem.
+
+The forked Sandbox is a copy-on-write clone of the original. It starts
+with the same disk contents but operates independently from that point on.
+
+**Parameters**:
+
+- `params?` _Fork parameters_
+- `name?` _string_ - Optional name for the forked Sandbox. If not provided, a unique name will be generated.
+- `timeout?` _number = 60_ - Maximum time to wait in seconds. 0 means no timeout.
+    Defaults to 60-second timeout.
+
+
+**Returns**:
+
+- `Promise<Sandbox>` - The forked Sandbox.
+
+**Throws**:
+
+- If timeout is a negative number
+
+- If the fork operation fails or times out
+
+**Example:**
+
+```ts
+const sandbox = await daytona.get('my-sandbox');
+const forked = await sandbox.fork({ name: 'my-fork' });
+console.log(`Forked sandbox: ${forked.id}`);
+```
 
 ***
 

--- a/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
@@ -100,13 +100,14 @@ Daytona.list rather than constructing directly.
 #### ~~\_experimental\_createSnapshot()~~
 
 ```ts
-_experimental_createSnapshot(name: string, timeout: number): Promise<void>
+_experimental_createSnapshot(name: string, timeout?: number): Promise<void>
 ```
 
 **Parameters**:
 
-- `name` _string_
-- `timeout` _number = 60_
+- `name` _string_ - Name for the new snapshot
+- `timeout?` _number = 60_ - Maximum time to wait in seconds. 0 means no timeout.
+    Defaults to 60-second timeout.
 
 
 **Returns**:

--- a/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
@@ -127,14 +127,12 @@ Sandbox.createSnapshot
 #### ~~\_experimental\_fork()~~
 
 ```ts
-_experimental_fork(params?: {
-  name: string;
-}, timeout?: number): Promise<Sandbox>
+_experimental_fork(params?: ForkSandboxParams, timeout?: number): Promise<Sandbox>
 ```
 
 **Parameters**:
 
-- `params?` _###### name?_ - `string`
+- `params?` _ForkSandboxParams_
 - `timeout?` _number = 60_
 
 
@@ -337,9 +335,7 @@ Expires a signed preview url for the sandbox at the specified port.
 #### fork()
 
 ```ts
-fork(params?: {
-  name: string;
-}, timeout?: number): Promise<Sandbox>
+fork(params?: ForkSandboxParams, timeout?: number): Promise<Sandbox>
 ```
 
 Forks the Sandbox, creating a new Sandbox with an identical filesystem.
@@ -349,8 +345,7 @@ with the same disk contents but operates independently from that point on.
 
 **Parameters**:
 
-- `params?` _Fork parameters_
-- `name?` _string_ - Optional name for the forked Sandbox. If not provided, a unique name will be generated.
+- `params?` _ForkSandboxParams_ - Fork parameters
 - `timeout?` _number = 60_ - Maximum time to wait in seconds. 0 means no timeout.
     Defaults to 60-second timeout.
 

--- a/sdk-go/pkg/daytona/sandbox.go
+++ b/sdk-go/pkg/daytona/sandbox.go
@@ -1713,48 +1713,48 @@ func (s *Sandbox) UpdateEnv(ctx context.Context, env map[string]string, unset []
 	})
 }
 
-// ExperimentalFork forks the sandbox with a default timeout of 60 seconds,
+// Fork forks the sandbox with a default timeout of 60 seconds,
 // creating a new sandbox with an identical filesystem.
 //
 // The forked sandbox is a copy-on-write clone of the original. It starts
 // with the same disk contents but operates independently from that point on.
-// ExperimentalFork waits for the new sandbox to reach the "started" state before returning.
+// Fork waits for the new sandbox to reach the "started" state before returning.
 //
 // Example:
 //
-//	forked, err := sandbox.ExperimentalFork(ctx, nil)
+//	forked, err := sandbox.Fork(ctx, nil)
 //	if err != nil {
 //	    return err
 //	}
 //	fmt.Printf("Forked sandbox: %s\n", forked.ID)
-func (s *Sandbox) ExperimentalFork(ctx context.Context, name *string) (*Sandbox, error) {
-	return withInstrumentation(ctx, s.otel, "Sandbox", "ExperimentalFork", func(ctx context.Context) (*Sandbox, error) {
-		return s.ExperimentalForkWithTimeout(ctx, name, 60*time.Second)
+func (s *Sandbox) Fork(ctx context.Context, name *string) (*Sandbox, error) {
+	return withInstrumentation(ctx, s.otel, "Sandbox", "Fork", func(ctx context.Context) (*Sandbox, error) {
+		return s.ForkWithTimeout(ctx, name, 60*time.Second)
 	})
 }
 
-// ExperimentalForkWithTimeout forks the sandbox with a custom timeout,
+// ForkWithTimeout forks the sandbox with a custom timeout,
 // creating a new sandbox with an identical filesystem.
 //
 // The forked sandbox is a copy-on-write clone of the original. It starts
 // with the same disk contents but operates independently from that point on.
-// ExperimentalForkWithTimeout waits for the new sandbox to reach the "started" state before returning.
+// ForkWithTimeout waits for the new sandbox to reach the "started" state before returning.
 // 0 means no timeout.
 //
 // Example:
 //
-//	forked, err := sandbox.ExperimentalForkWithTimeout(ctx, nil, 2*time.Minute)
+//	forked, err := sandbox.ForkWithTimeout(ctx, nil, 2*time.Minute)
 //	if err != nil {
 //	    return err
 //	}
 //	fmt.Printf("Forked sandbox: %s\n", forked.ID)
-func (s *Sandbox) ExperimentalForkWithTimeout(ctx context.Context, name *string, timeout time.Duration) (*Sandbox, error) {
-	return withInstrumentation(ctx, s.otel, "Sandbox", "ExperimentalForkWithTimeout", func(ctx context.Context) (*Sandbox, error) {
-		return s.doExperimentalForkWithTimeout(ctx, name, timeout)
+func (s *Sandbox) ForkWithTimeout(ctx context.Context, name *string, timeout time.Duration) (*Sandbox, error) {
+	return withInstrumentation(ctx, s.otel, "Sandbox", "ForkWithTimeout", func(ctx context.Context) (*Sandbox, error) {
+		return s.doForkWithTimeout(ctx, name, timeout)
 	})
 }
 
-func (s *Sandbox) doExperimentalForkWithTimeout(ctx context.Context, name *string, timeout time.Duration) (*Sandbox, error) {
+func (s *Sandbox) doForkWithTimeout(ctx context.Context, name *string, timeout time.Duration) (*Sandbox, error) {
 	if timeout < 0 {
 		return nil, errors.NewDaytonaError("Timeout must be a non-negative number", 0, nil)
 	}
@@ -1791,7 +1791,21 @@ func (s *Sandbox) doExperimentalForkWithTimeout(ctx context.Context, name *strin
 	return forked, nil
 }
 
-// ExperimentalCreateSnapshot creates a snapshot from the current state of the sandbox
+// ExperimentalFork forks the sandbox with a default timeout of 60 seconds.
+//
+// Deprecated: Use Fork instead. This method will be removed in a future release.
+func (s *Sandbox) ExperimentalFork(ctx context.Context, name *string) (*Sandbox, error) {
+	return s.Fork(ctx, name)
+}
+
+// ExperimentalForkWithTimeout forks the sandbox with a custom timeout.
+//
+// Deprecated: Use ForkWithTimeout instead. This method will be removed in a future release.
+func (s *Sandbox) ExperimentalForkWithTimeout(ctx context.Context, name *string, timeout time.Duration) (*Sandbox, error) {
+	return s.ForkWithTimeout(ctx, name, timeout)
+}
+
+// CreateSnapshot creates a snapshot from the current state of the sandbox
 // with a default timeout of 60 seconds.
 //
 // This captures the sandbox's filesystem into a reusable snapshot that can be
@@ -1800,29 +1814,43 @@ func (s *Sandbox) doExperimentalForkWithTimeout(ctx context.Context, name *strin
 //
 // Example:
 //
-//	err := sandbox.ExperimentalCreateSnapshot(ctx, "my-snapshot")
+//	err := sandbox.CreateSnapshot(ctx, "my-snapshot")
 //	if err != nil {
 //	    return err
 //	}
-func (s *Sandbox) ExperimentalCreateSnapshot(ctx context.Context, name string) error {
-	return withInstrumentationVoid(ctx, s.otel, "Sandbox", "ExperimentalCreateSnapshot", func(ctx context.Context) error {
-		return s.ExperimentalCreateSnapshotWithTimeout(ctx, name, 60*time.Second)
+func (s *Sandbox) CreateSnapshot(ctx context.Context, name string) error {
+	return withInstrumentationVoid(ctx, s.otel, "Sandbox", "CreateSnapshot", func(ctx context.Context) error {
+		return s.CreateSnapshotWithTimeout(ctx, name, 60*time.Second)
 	})
 }
 
-// ExperimentalCreateSnapshotWithTimeout creates a snapshot from the current state of the sandbox
+// CreateSnapshotWithTimeout creates a snapshot from the current state of the sandbox
 // with a custom timeout. 0 means no timeout.
 //
 // Example:
 //
-//	err := sandbox.ExperimentalCreateSnapshotWithTimeout(ctx, "my-snapshot", 2*time.Minute)
-func (s *Sandbox) ExperimentalCreateSnapshotWithTimeout(ctx context.Context, name string, timeout time.Duration) error {
-	return withInstrumentationVoid(ctx, s.otel, "Sandbox", "ExperimentalCreateSnapshotWithTimeout", func(ctx context.Context) error {
-		return s.doExperimentalCreateSnapshotWithTimeout(ctx, name, timeout)
+//	err := sandbox.CreateSnapshotWithTimeout(ctx, "my-snapshot", 2*time.Minute)
+func (s *Sandbox) CreateSnapshotWithTimeout(ctx context.Context, name string, timeout time.Duration) error {
+	return withInstrumentationVoid(ctx, s.otel, "Sandbox", "CreateSnapshotWithTimeout", func(ctx context.Context) error {
+		return s.doCreateSnapshotWithTimeout(ctx, name, timeout)
 	})
 }
 
-func (s *Sandbox) doExperimentalCreateSnapshotWithTimeout(ctx context.Context, name string, timeout time.Duration) error {
+// ExperimentalCreateSnapshot creates a snapshot from the current state of the sandbox.
+//
+// Deprecated: Use CreateSnapshot instead. This method will be removed in a future release.
+func (s *Sandbox) ExperimentalCreateSnapshot(ctx context.Context, name string) error {
+	return s.CreateSnapshot(ctx, name)
+}
+
+// ExperimentalCreateSnapshotWithTimeout creates a snapshot with a custom timeout.
+//
+// Deprecated: Use CreateSnapshotWithTimeout instead. This method will be removed in a future release.
+func (s *Sandbox) ExperimentalCreateSnapshotWithTimeout(ctx context.Context, name string, timeout time.Duration) error {
+	return s.CreateSnapshotWithTimeout(ctx, name, timeout)
+}
+
+func (s *Sandbox) doCreateSnapshotWithTimeout(ctx context.Context, name string, timeout time.Duration) error {
 	if timeout < 0 {
 		return errors.NewDaytonaError("Timeout must be a non-negative number", 0, nil)
 	}

--- a/sdk-go/pkg/daytona/sandbox_test.go
+++ b/sdk-go/pkg/daytona/sandbox_test.go
@@ -546,8 +546,60 @@ func TestSandboxPreviewAndLabelOperations(t *testing.T) {
 	assert.Equal(t, apiclient.SANDBOXSTATE_STARTED, sandbox.State)
 }
 
-func TestSandboxExperimentalOperations(t *testing.T) {
+func TestSandboxForkAndSnapshot(t *testing.T) {
 	t.Run("fork succeeds and waits for start", func(t *testing.T) {
+		var getCount int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPost:
+				writeJSONResponse(t, w, http.StatusOK, testSandboxPayload("forked", "forked-name", apiclient.SANDBOXSTATE_STARTING))
+			case http.MethodGet:
+				getCount++
+				state := apiclient.SANDBOXSTATE_STARTING
+				if getCount > 1 {
+					state = apiclient.SANDBOXSTATE_STARTED
+				}
+				writeJSONResponse(t, w, http.StatusOK, testSandboxPayload("forked", "forked-name", state))
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		client := createTestClientWithServer(t, server)
+		sandbox := newSandboxForTest(client, "sb", "sandbox", apiclient.SANDBOXSTATE_STARTED, "us", 0, -1, false, nil)
+		forked, err := sandbox.ForkWithTimeout(context.Background(), strPtr("forked-name"), 3*time.Second)
+		require.NoError(t, err)
+		assert.Equal(t, "forked", forked.ID)
+	})
+
+	t.Run("create snapshot waits until snapshotting finishes", func(t *testing.T) {
+		var getCount int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPost:
+				w.WriteHeader(http.StatusOK)
+			case http.MethodGet:
+				getCount++
+				state := apiclient.SANDBOXSTATE_SNAPSHOTTING
+				if getCount > 1 {
+					state = apiclient.SANDBOXSTATE_STARTED
+				}
+				writeJSONResponse(t, w, http.StatusOK, testSandboxPayload("sb", "sandbox", state))
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		client := createTestClientWithServer(t, server)
+		sandbox := newSandboxForTest(client, "sb", "sandbox", apiclient.SANDBOXSTATE_STARTED, "us", 0, -1, false, nil)
+		require.NoError(t, sandbox.CreateSnapshotWithTimeout(context.Background(), "snap-name", 2*time.Second))
+	})
+}
+
+func TestSandboxDeprecatedAliases(t *testing.T) {
+	t.Run("ExperimentalFork delegates to Fork", func(t *testing.T) {
 		var getCount int
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.Method {
@@ -573,7 +625,7 @@ func TestSandboxExperimentalOperations(t *testing.T) {
 		assert.Equal(t, "forked", forked.ID)
 	})
 
-	t.Run("create snapshot waits until snapshotting finishes", func(t *testing.T) {
+	t.Run("ExperimentalCreateSnapshot delegates to CreateSnapshot", func(t *testing.T) {
 		var getCount int
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.Method {

--- a/sdk-go/pkg/daytona/sandbox_test.go
+++ b/sdk-go/pkg/daytona/sandbox_test.go
@@ -599,7 +599,7 @@ func TestSandboxForkAndSnapshot(t *testing.T) {
 }
 
 func TestSandboxDeprecatedAliases(t *testing.T) {
-	t.Run("ExperimentalFork delegates to Fork", func(t *testing.T) {
+	t.Run("ExperimentalForkWithTimeout delegates to ForkWithTimeout", func(t *testing.T) {
 		var getCount int
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.Method {
@@ -625,7 +625,7 @@ func TestSandboxDeprecatedAliases(t *testing.T) {
 		assert.Equal(t, "forked", forked.ID)
 	})
 
-	t.Run("ExperimentalCreateSnapshot delegates to CreateSnapshot", func(t *testing.T) {
+	t.Run("ExperimentalCreateSnapshotWithTimeout delegates to CreateSnapshotWithTimeout", func(t *testing.T) {
 		var getCount int
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.Method {
@@ -647,6 +647,56 @@ func TestSandboxDeprecatedAliases(t *testing.T) {
 		client := createTestClientWithServer(t, server)
 		sandbox := newSandboxForTest(client, "sb", "sandbox", apiclient.SANDBOXSTATE_STARTED, "us", 0, -1, false, nil)
 		require.NoError(t, sandbox.ExperimentalCreateSnapshotWithTimeout(context.Background(), "snap-name", 2*time.Second))
+	})
+
+	t.Run("ExperimentalFork delegates to Fork", func(t *testing.T) {
+		var getCount int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPost:
+				writeJSONResponse(t, w, http.StatusOK, testSandboxPayload("forked", "forked-name", apiclient.SANDBOXSTATE_STARTING))
+			case http.MethodGet:
+				getCount++
+				state := apiclient.SANDBOXSTATE_STARTING
+				if getCount > 1 {
+					state = apiclient.SANDBOXSTATE_STARTED
+				}
+				writeJSONResponse(t, w, http.StatusOK, testSandboxPayload("forked", "forked-name", state))
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		client := createTestClientWithServer(t, server)
+		sandbox := newSandboxForTest(client, "sb", "sandbox", apiclient.SANDBOXSTATE_STARTED, "us", 0, -1, false, nil)
+		forked, err := sandbox.ExperimentalFork(context.Background(), strPtr("forked-name"))
+		require.NoError(t, err)
+		assert.Equal(t, "forked", forked.ID)
+	})
+
+	t.Run("ExperimentalCreateSnapshot delegates to CreateSnapshot", func(t *testing.T) {
+		var getCount int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPost:
+				w.WriteHeader(http.StatusOK)
+			case http.MethodGet:
+				getCount++
+				state := apiclient.SANDBOXSTATE_SNAPSHOTTING
+				if getCount > 1 {
+					state = apiclient.SANDBOXSTATE_STARTED
+				}
+				writeJSONResponse(t, w, http.StatusOK, testSandboxPayload("sb", "sandbox", state))
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		client := createTestClientWithServer(t, server)
+		sandbox := newSandboxForTest(client, "sb", "sandbox", apiclient.SANDBOXSTATE_STARTED, "us", 0, -1, false, nil)
+		require.NoError(t, sandbox.ExperimentalCreateSnapshot(context.Background(), "snap-name"))
 	})
 }
 

--- a/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
@@ -1189,23 +1189,35 @@ public class Sandbox {
      * Forks this Sandbox, creating a new Sandbox with an identical filesystem.
      * Uses default timeout of 60 seconds.
      *
+     * <p>Example usage:
+     * <pre>{@code
+     * Sandbox forked = sandbox.fork();
+     * System.out.println(forked.getId());
+     * }</pre>
+     *
      * @return the forked {@link Sandbox} in started state
      * @throws DaytonaException if the fork operation fails or times out
      */
-    public Sandbox experimentalFork() {
-        return experimentalFork(null, 60);
+    public Sandbox fork() {
+        return fork(null, 60);
     }
 
     /**
      * Forks this Sandbox, creating a new Sandbox with an identical filesystem.
      * The forked Sandbox is a copy-on-write clone of the original.
      *
+     * <p>Example usage:
+     * <pre>{@code
+     * Sandbox forked = sandbox.fork("my-fork", 120);
+     * System.out.println(forked.getId());
+     * }</pre>
+     *
      * @param name optional name for the forked Sandbox; {@code null} for auto-generated
      * @param timeoutSeconds maximum seconds to wait for the forked Sandbox to start; {@code 0} disables timeout
      * @return the forked {@link Sandbox} in started state
      * @throws DaytonaException if the fork operation fails or times out
      */
-    public Sandbox experimentalFork(String name, long timeoutSeconds) {
+    public Sandbox fork(String name, long timeoutSeconds) {
         ForkSandbox forkReq = new ForkSandbox();
         if (name != null) {
             forkReq.setName(name);
@@ -1219,25 +1231,63 @@ public class Sandbox {
     }
 
     /**
+     * Forks this Sandbox, creating a new Sandbox with an identical filesystem.
+     * Uses default timeout of 60 seconds.
+     *
+     * @return the forked {@link Sandbox} in started state
+     * @throws DaytonaException if the fork operation fails or times out
+     * @deprecated Use {@link #fork()} instead. This method will be removed in a future version.
+     */
+    @Deprecated
+    public Sandbox experimentalFork() {
+        return fork(null, 60);
+    }
+
+    /**
+     * Forks this Sandbox, creating a new Sandbox with an identical filesystem.
+     * The forked Sandbox is a copy-on-write clone of the original.
+     *
+     * @param name optional name for the forked Sandbox; {@code null} for auto-generated
+     * @param timeoutSeconds maximum seconds to wait for the forked Sandbox to start; {@code 0} disables timeout
+     * @return the forked {@link Sandbox} in started state
+     * @throws DaytonaException if the fork operation fails or times out
+     * @deprecated Use {@link #fork(String, long)} instead. This method will be removed in a future version.
+     */
+    @Deprecated
+    public Sandbox experimentalFork(String name, long timeoutSeconds) {
+        return fork(name, timeoutSeconds);
+    }
+
+    /**
      * Creates a snapshot from the current state of this Sandbox.
      * Uses default timeout of 60 seconds.
+     *
+     * <p>Example usage:
+     * <pre>{@code
+     * sandbox.createSnapshot("my-snapshot");
+     * }</pre>
      *
      * @param name name for the new snapshot
      * @throws DaytonaException if the snapshot operation fails
      */
-    public void experimentalCreateSnapshot(String name) {
-        experimentalCreateSnapshot(name, 60);
+    public void createSnapshot(String name) {
+        createSnapshot(name, 60);
     }
 
     /**
      * Creates a snapshot from the current state of this Sandbox.
      * The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
      *
+     * <p>Example usage:
+     * <pre>{@code
+     * sandbox.createSnapshot("my-snapshot", 120);
+     * }</pre>
+     *
      * @param name name for the new snapshot
      * @param timeoutSeconds reserved timeout parameter for parity with other SDKs
      * @throws DaytonaException if the snapshot operation fails
      */
-    public void experimentalCreateSnapshot(String name, long timeoutSeconds) {
+    public void createSnapshot(String name, long timeoutSeconds) {
         if (timeoutSeconds < 0) {
             throw new DaytonaException("Timeout must be non-negative");
         }
@@ -1250,6 +1300,33 @@ public class Sandbox {
             populateFromDTO(response);
         }
         waitForSnapshotComplete(timeoutSeconds);
+    }
+
+    /**
+     * Creates a snapshot from the current state of this Sandbox.
+     * Uses default timeout of 60 seconds.
+     *
+     * @param name name for the new snapshot
+     * @throws DaytonaException if the snapshot operation fails
+     * @deprecated Use {@link #createSnapshot(String)} instead. This method will be removed in a future version.
+     */
+    @Deprecated
+    public void experimentalCreateSnapshot(String name) {
+        createSnapshot(name, 60);
+    }
+
+    /**
+     * Creates a snapshot from the current state of this Sandbox.
+     * The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
+     *
+     * @param name name for the new snapshot
+     * @param timeoutSeconds reserved timeout parameter for parity with other SDKs
+     * @throws DaytonaException if the snapshot operation fails
+     * @deprecated Use {@link #createSnapshot(String, long)} instead. This method will be removed in a future version.
+     */
+    @Deprecated
+    public void experimentalCreateSnapshot(String name, long timeoutSeconds) {
+        createSnapshot(name, timeoutSeconds);
     }
 
     private void waitForSnapshotComplete(long timeoutSeconds) {

--- a/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
@@ -1218,6 +1218,9 @@ public class Sandbox {
      * @throws DaytonaException if the fork operation fails or times out
      */
     public Sandbox fork(String name, long timeoutSeconds) {
+        if (timeoutSeconds < 0) {
+            throw new DaytonaException("Timeout must be non-negative");
+        }
         ForkSandbox forkReq = new ForkSandbox();
         if (name != null) {
             forkReq.setName(name);

--- a/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
@@ -1287,7 +1287,7 @@ public class Sandbox {
      * }</pre>
      *
      * @param name name for the new snapshot
-     * @param timeoutSeconds reserved timeout parameter for parity with other SDKs
+     * @param timeoutSeconds maximum seconds to wait for the snapshot operation to complete; {@code 0} disables timeout
      * @throws DaytonaException if the snapshot operation fails
      */
     public void createSnapshot(String name, long timeoutSeconds) {
@@ -1323,7 +1323,7 @@ public class Sandbox {
      * The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
      *
      * @param name name for the new snapshot
-     * @param timeoutSeconds reserved timeout parameter for parity with other SDKs
+     * @param timeoutSeconds maximum seconds to wait for the snapshot operation to complete; {@code 0} disables timeout
      * @throws DaytonaException if the snapshot operation fails
      * @deprecated Use {@link #createSnapshot(String, long)} instead. This method will be removed in a future version.
      */

--- a/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
@@ -371,6 +371,14 @@ class SandboxTest {
     }
 
     @Test
+    void forkRejectsNegativeTimeoutBeforeApiCall() {
+        assertThatThrownBy(() -> sandbox.fork("forked", -1))
+                .hasMessageContaining("Timeout must be non-negative");
+
+        verify(sandboxApi, org.mockito.Mockito.never()).forkSandbox(any(), any(), any());
+    }
+
+    @Test
     void forkDefaultArgumentsOmitName() {
         when(sandboxApi.forkSandbox(eq("sb-1"), any(ForkSandbox.class), isNull())).thenReturn(TestSupport.mainSandbox("sb-4", SandboxState.STARTED));
 

--- a/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/SandboxTest.java
@@ -356,25 +356,25 @@ class SandboxTest {
     }
 
     @Test
-    void experimentalForkAndSnapshotDelegate() {
+    void forkAndSnapshotDelegate() {
         when(sandboxApi.forkSandbox(eq("sb-1"), any(ForkSandbox.class), isNull())).thenReturn(TestSupport.mainSandbox("sb-2", SandboxState.STARTED));
         io.daytona.api.client.model.Sandbox snapshotting = TestSupport.mainSandbox("sb-1", SandboxState.SNAPSHOTTING);
         io.daytona.api.client.model.Sandbox started = TestSupport.mainSandbox("sb-1", SandboxState.STARTED);
         when(sandboxApi.createSandboxSnapshot(eq("sb-1"), any(CreateSandboxSnapshot.class), isNull())).thenReturn(snapshotting);
         when(sandboxApi.getSandbox("sb-1", null, null)).thenReturn(started);
 
-        Sandbox forked = sandbox.experimentalFork("forked", 2);
-        sandbox.experimentalCreateSnapshot("snap-1", 2);
+        Sandbox forked = sandbox.fork("forked", 2);
+        sandbox.createSnapshot("snap-1", 2);
 
         assertThat(forked.getId()).isEqualTo("sb-2");
         verify(sandboxApi).createSandboxSnapshot(eq("sb-1"), any(CreateSandboxSnapshot.class), isNull());
     }
 
     @Test
-    void experimentalForkDefaultArgumentsOmitName() {
+    void forkDefaultArgumentsOmitName() {
         when(sandboxApi.forkSandbox(eq("sb-1"), any(ForkSandbox.class), isNull())).thenReturn(TestSupport.mainSandbox("sb-4", SandboxState.STARTED));
 
-        sandbox.experimentalFork();
+        sandbox.fork();
 
         ArgumentCaptor<ForkSandbox> captor = ArgumentCaptor.forClass(ForkSandbox.class);
         verify(sandboxApi).forkSandbox(eq("sb-1"), captor.capture(), isNull());
@@ -382,24 +382,68 @@ class SandboxTest {
     }
 
     @Test
-    void experimentalCreateSnapshotFailsForErrorState() {
+    void createSnapshotFailsForErrorState() {
         io.daytona.api.client.model.Sandbox snapshotting = TestSupport.mainSandbox("sb-1", SandboxState.SNAPSHOTTING);
         io.daytona.api.client.model.Sandbox error = TestSupport.mainSandbox("sb-1", SandboxState.ERROR);
         when(sandboxApi.createSandboxSnapshot(eq("sb-1"), any(CreateSandboxSnapshot.class), isNull())).thenReturn(snapshotting);
         when(sandboxApi.getSandbox("sb-1", null, null)).thenReturn(error);
 
-        assertThatThrownBy(() -> sandbox.experimentalCreateSnapshot("snap-err", 2))
+        assertThatThrownBy(() -> sandbox.createSnapshot("snap-err", 2))
                 .hasMessageContaining("Sandbox entered error state: error");
     }
 
     @Test
-    void experimentalCreateSnapshotTimesOutWhenSnapshottingPersists() {
+    void createSnapshotTimesOutWhenSnapshottingPersists() {
         io.daytona.api.client.model.Sandbox snapshotting = TestSupport.mainSandbox("sb-1", SandboxState.SNAPSHOTTING);
         when(sandboxApi.createSandboxSnapshot(eq("sb-1"), any(CreateSandboxSnapshot.class), isNull())).thenReturn(snapshotting);
         when(sandboxApi.getSandbox("sb-1", null, null)).thenReturn(snapshotting, snapshotting);
 
-        assertThatThrownBy(() -> sandbox.experimentalCreateSnapshot("snap-timeout", 2))
+        assertThatThrownBy(() -> sandbox.createSnapshot("snap-timeout", 2))
                 .hasMessageContaining("did not reach target state within 2 seconds");
+    }
+
+    @Test
+    void deprecatedExperimentalForkDelegatesToFork() {
+        when(sandboxApi.forkSandbox(eq("sb-1"), any(ForkSandbox.class), isNull())).thenReturn(TestSupport.mainSandbox("sb-3", SandboxState.STARTED));
+
+        @SuppressWarnings("deprecation")
+        Sandbox forked = sandbox.experimentalFork("dep-fork", 2);
+
+        assertThat(forked.getId()).isEqualTo("sb-3");
+        verify(sandboxApi).forkSandbox(eq("sb-1"), any(ForkSandbox.class), isNull());
+    }
+
+    @Test
+    void deprecatedExperimentalForkNoArgDelegatesToFork() {
+        when(sandboxApi.forkSandbox(eq("sb-1"), any(ForkSandbox.class), isNull())).thenReturn(TestSupport.mainSandbox("sb-5", SandboxState.STARTED));
+
+        @SuppressWarnings("deprecation")
+        Sandbox forked = sandbox.experimentalFork();
+
+        assertThat(forked.getId()).isEqualTo("sb-5");
+        ArgumentCaptor<ForkSandbox> captor = ArgumentCaptor.forClass(ForkSandbox.class);
+        verify(sandboxApi).forkSandbox(eq("sb-1"), captor.capture(), isNull());
+        assertThat(captor.getValue().getName()).isNull();
+    }
+
+    @Test
+    void deprecatedExperimentalCreateSnapshotDelegatesToCreateSnapshot() {
+        io.daytona.api.client.model.Sandbox snapshotting = TestSupport.mainSandbox("sb-1", SandboxState.SNAPSHOTTING);
+        io.daytona.api.client.model.Sandbox started = TestSupport.mainSandbox("sb-1", SandboxState.STARTED);
+        when(sandboxApi.createSandboxSnapshot(eq("sb-1"), any(CreateSandboxSnapshot.class), isNull())).thenReturn(snapshotting);
+        when(sandboxApi.getSandbox("sb-1", null, null)).thenReturn(started);
+
+        @SuppressWarnings("deprecation")
+        Object unused = callDeprecatedCreateSnapshot("snap-dep", 2);
+
+        verify(sandboxApi).createSandboxSnapshot(eq("sb-1"), any(CreateSandboxSnapshot.class), isNull());
+    }
+
+    /** Helper to call deprecated void method in an expression context for @SuppressWarnings. */
+    @SuppressWarnings("deprecation")
+    private Object callDeprecatedCreateSnapshot(String name, long timeout) {
+        sandbox.experimentalCreateSnapshot(name, timeout);
+        return null;
     }
 
     @ParameterizedTest

--- a/sdk-python/src/daytona/_async/sandbox.py
+++ b/sdk-python/src/daytona/_async/sandbox.py
@@ -1169,7 +1169,7 @@ class AsyncSandbox(SandboxDto):
     @intercept_errors(message_prefix="Failed to fork sandbox: ")
     @with_timeout()
     @with_instrumentation()
-    async def _experimental_fork(self, name: str | None = None, timeout: float | None = 60) -> "AsyncSandbox":
+    async def fork(self, name: str | None = None, timeout: float | None = 60) -> "AsyncSandbox":
         """Forks the Sandbox, creating a new Sandbox with an identical filesystem.
 
         The forked Sandbox is a copy-on-write clone of the original. It starts
@@ -1188,7 +1188,7 @@ class AsyncSandbox(SandboxDto):
         Example:
             ```python
             sandbox = await daytona.get("my-sandbox")
-            forked = await sandbox._experimental_fork(name="my-fork")
+            forked = await sandbox.fork(name="my-fork")
             print(f"Forked sandbox: {forked.id}")
             ```
         """
@@ -1212,10 +1212,14 @@ class AsyncSandbox(SandboxDto):
         await forked.wait_for_sandbox_start(timeout=0)
         return forked
 
+    @deprecated(reason="Method is deprecated. Use `fork` instead. This method will be removed in a future version.")
+    async def _experimental_fork(self, name: str | None = None, timeout: float | None = 60) -> "AsyncSandbox":
+        return await self.fork(name=name, timeout=timeout)
+
     @intercept_errors(message_prefix="Failed to create snapshot: ")
     @with_timeout()
     @with_instrumentation()
-    async def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
+    async def create_snapshot(self, name: str, timeout: float | None = 60) -> None:
         """Creates a snapshot from the current state of the Sandbox.
 
         This captures the Sandbox's filesystem into a reusable snapshot that can be
@@ -1232,7 +1236,7 @@ class AsyncSandbox(SandboxDto):
         Example:
             ```python
             sandbox = await daytona.get("my-sandbox")
-            await sandbox._experimental_create_snapshot("my-snapshot")
+            await sandbox.create_snapshot("my-snapshot")
             print("Snapshot created successfully")
             ```
         """
@@ -1248,6 +1252,12 @@ class AsyncSandbox(SandboxDto):
         target_states = [s for s in SandboxState if s not in exclude]
 
         await self._wait_for_state(target_states, error_states)
+
+    @deprecated(
+        reason=("Method is deprecated. Use `create_snapshot` instead. This method will be removed in a future version.")
+    )
+    async def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
+        return await self.create_snapshot(name=name, timeout=timeout)
 
     @intercept_errors(message_prefix="Failed to pause sandbox")
     @with_timeout()

--- a/sdk-python/src/daytona/_sync/sandbox.py
+++ b/sdk-python/src/daytona/_sync/sandbox.py
@@ -1141,7 +1141,7 @@ class Sandbox(SandboxDto):
     @intercept_errors(message_prefix="Failed to fork sandbox: ")
     @with_timeout()
     @with_instrumentation()
-    def _experimental_fork(self, name: str | None = None, timeout: float | None = 60) -> "Sandbox":
+    def fork(self, name: str | None = None, timeout: float | None = 60) -> "Sandbox":
         """Forks the Sandbox, creating a new Sandbox with an identical filesystem.
 
         The forked Sandbox is a copy-on-write clone of the original. It starts
@@ -1160,7 +1160,7 @@ class Sandbox(SandboxDto):
         Example:
             ```python
             sandbox = daytona.get("my-sandbox")
-            forked = sandbox._experimental_fork(name="my-fork")
+            forked = sandbox.fork(name="my-fork")
             print(f"Forked sandbox: {forked.id}")
             ```
         """
@@ -1182,10 +1182,14 @@ class Sandbox(SandboxDto):
         forked.wait_for_sandbox_start(timeout=0)
         return forked
 
+    @deprecated(reason="Method is deprecated. Use `fork` instead. This method will be removed in a future version.")
+    def _experimental_fork(self, name: str | None = None, timeout: float | None = 60) -> "Sandbox":
+        return self.fork(name=name, timeout=timeout)
+
     @intercept_errors(message_prefix="Failed to create snapshot: ")
     @with_timeout()
     @with_instrumentation()
-    def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
+    def create_snapshot(self, name: str, timeout: float | None = 60) -> None:
         """Creates a snapshot from the current state of the Sandbox.
 
         This captures the Sandbox's filesystem into a reusable snapshot that can be
@@ -1202,7 +1206,7 @@ class Sandbox(SandboxDto):
         Example:
             ```python
             sandbox = daytona.get("my-sandbox")
-            sandbox._experimental_create_snapshot("my-snapshot")
+            sandbox.create_snapshot("my-snapshot")
             print("Snapshot created successfully")
             ```
         """
@@ -1218,6 +1222,12 @@ class Sandbox(SandboxDto):
         target_states = [s for s in SandboxState if s not in exclude]
 
         self._wait_for_state(target_states, error_states)
+
+    @deprecated(
+        reason=("Method is deprecated. Use `create_snapshot` instead. This method will be removed in a future version.")
+    )
+    def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
+        return self.create_snapshot(name=name, timeout=timeout)
 
     @intercept_errors(message_prefix="Failed to pause sandbox")
     @with_timeout()

--- a/sdk-python/tests/test_async_sandbox.py
+++ b/sdk-python/tests/test_async_sandbox.py
@@ -364,6 +364,41 @@ class TestAsyncSandboxPollingSemantics:
             )
         )
 
-        forked = await sandbox._experimental_fork(name="my-fork", timeout=0)
+        forked = await sandbox.fork(name="my-fork", timeout=0)
         mock_async_sandbox_api.get_toolbox_proxy_url.assert_called_once_with("forked-id")
         assert forked.toolbox_proxy_url == "http://hydrated-fork:2280"
+
+    @pytest.mark.asyncio
+    async def test_experimental_fork_delegates_and_warns(self, mock_async_toolbox_api_client, mock_async_sandbox_api):
+        dto = make_sandbox_dto(state=SandboxState.STARTED, toolbox_proxy_url="http://original:2280")
+        sandbox = make_async_sandbox(dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+
+        fork_dto = make_sandbox_dto(
+            sandbox_id="forked-id",
+            state=SandboxState.STARTED,
+            toolbox_proxy_url="http://forked:2280",
+        )
+        mock_async_sandbox_api.fork_sandbox = AsyncMock(return_value=fork_dto)
+        mock_async_sandbox_api.get_sandbox = AsyncMock(
+            return_value=make_sandbox_dto(
+                sandbox_id="forked-id", state=SandboxState.STARTED, toolbox_proxy_url="http://forked:2280"
+            )
+        )
+
+        with pytest.warns(DeprecationWarning, match="Use `fork` instead"):
+            forked = await sandbox._experimental_fork(name="my-fork", timeout=0)
+        assert forked.id == "forked-id"
+
+    @pytest.mark.asyncio
+    async def test_experimental_create_snapshot_delegates_and_warns(
+        self, mock_async_toolbox_api_client, mock_async_sandbox_api
+    ):
+        dto = make_sandbox_dto(state=SandboxState.STARTED)
+        sandbox = make_async_sandbox(dto, mock_async_toolbox_api_client, mock_async_sandbox_api)
+
+        snapshot_dto = make_sandbox_dto(state=SandboxState.STARTED)
+        mock_async_sandbox_api.create_sandbox_snapshot = AsyncMock(return_value=snapshot_dto)
+        mock_async_sandbox_api.get_sandbox = AsyncMock(return_value=make_sandbox_dto(state=SandboxState.STARTED))
+
+        with pytest.warns(DeprecationWarning, match="Use `create_snapshot` instead"):
+            await sandbox._experimental_create_snapshot("my-snapshot", timeout=0)

--- a/sdk-python/tests/test_sandbox.py
+++ b/sdk-python/tests/test_sandbox.py
@@ -281,3 +281,53 @@ class TestSandboxPollingSemantics:
         ]
         sandbox.pause(timeout=0)
         assert sandbox.state == SandboxState.STOPPED
+
+    def test_fork(self, mock_toolbox_api_client, mock_sandbox_api):
+        dto = make_sandbox_dto(state=SandboxState.STARTED, toolbox_proxy_url="http://original:2280")
+        sandbox = make_sandbox(dto, mock_toolbox_api_client, mock_sandbox_api)
+
+        fork_dto = make_sandbox_dto(
+            sandbox_id="forked-id",
+            state=SandboxState.STARTED,
+            toolbox_proxy_url="http://forked:2280",
+        )
+        mock_sandbox_api.fork_sandbox = MagicMock(return_value=fork_dto)
+        mock_sandbox_api.get_sandbox = MagicMock(
+            return_value=make_sandbox_dto(
+                sandbox_id="forked-id", state=SandboxState.STARTED, toolbox_proxy_url="http://forked:2280"
+            )
+        )
+
+        forked = sandbox.fork(name="my-fork", timeout=0)
+        assert forked.id == "forked-id"
+
+    def test_experimental_fork_delegates_and_warns(self, mock_toolbox_api_client, mock_sandbox_api):
+        dto = make_sandbox_dto(state=SandboxState.STARTED, toolbox_proxy_url="http://original:2280")
+        sandbox = make_sandbox(dto, mock_toolbox_api_client, mock_sandbox_api)
+
+        fork_dto = make_sandbox_dto(
+            sandbox_id="forked-id",
+            state=SandboxState.STARTED,
+            toolbox_proxy_url="http://forked:2280",
+        )
+        mock_sandbox_api.fork_sandbox = MagicMock(return_value=fork_dto)
+        mock_sandbox_api.get_sandbox = MagicMock(
+            return_value=make_sandbox_dto(
+                sandbox_id="forked-id", state=SandboxState.STARTED, toolbox_proxy_url="http://forked:2280"
+            )
+        )
+
+        with pytest.warns(DeprecationWarning, match="Use `fork` instead"):
+            forked = sandbox._experimental_fork(name="my-fork", timeout=0)
+        assert forked.id == "forked-id"
+
+    def test_experimental_create_snapshot_delegates_and_warns(self, mock_toolbox_api_client, mock_sandbox_api):
+        dto = make_sandbox_dto(state=SandboxState.STARTED)
+        sandbox = make_sandbox(dto, mock_toolbox_api_client, mock_sandbox_api)
+
+        snapshot_dto = make_sandbox_dto(state=SandboxState.STARTED)
+        mock_sandbox_api.create_sandbox_snapshot = MagicMock(return_value=snapshot_dto)
+        mock_sandbox_api.get_sandbox = MagicMock(return_value=make_sandbox_dto(state=SandboxState.STARTED))
+
+        with pytest.warns(DeprecationWarning, match="Use `create_snapshot` instead"):
+            sandbox._experimental_create_snapshot("my-snapshot", timeout=0)

--- a/sdk-ruby/lib/daytona/sandbox.rb
+++ b/sdk-ruby/lib/daytona/sandbox.rb
@@ -839,7 +839,7 @@ module Daytona
     # @param name [String, nil] Optional name for the forked Sandbox
     # @param timeout [Numeric] Maximum wait time in seconds (defaults to 60 s)
     # @return [Daytona::Sandbox] The forked Sandbox
-    def experimental_fork(name: nil, timeout: DEFAULT_TIMEOUT) # rubocop:disable Metrics/MethodLength
+    def fork(name: nil, timeout: DEFAULT_TIMEOUT) # rubocop:disable Metrics/MethodLength
       forked_dto = nil
       with_timeout(
         timeout:,
@@ -867,7 +867,7 @@ module Daytona
     # @param name [String] Name for the new snapshot
     # @param timeout [Numeric] Maximum wait time in seconds (defaults to 60 s)
     # @return [void]
-    def experimental_create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
+    def create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
       with_timeout(
         timeout:,
         message: "Sandbox #{id} snapshot failed within the #{timeout} seconds timeout period",
@@ -876,6 +876,18 @@ module Daytona
           process_response(response)
         }
       ) { wait_for_snapshot_complete }
+    end
+
+    # @deprecated Use {#fork} instead. This method will be removed in a future version.
+    def experimental_fork(name: nil, timeout: DEFAULT_TIMEOUT)
+      warn('[DEPRECATION] `experimental_fork` is deprecated. Use `fork` instead.', uplevel: 1)
+      fork(name:, timeout:)
+    end
+
+    # @deprecated Use {#create_snapshot} instead. This method will be removed in a future version.
+    def experimental_create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
+      warn('[DEPRECATION] `experimental_create_snapshot` is deprecated. Use `create_snapshot` instead.', uplevel: 1)
+      create_snapshot(name:, timeout:)
     end
 
     # Pauses the Sandbox, freezing all running processes.
@@ -907,7 +919,7 @@ module Daytona
                 :refresh, :refresh_activity, :revoke_ssh_access, :start, :recover, :stop,
                 :create_lsp_server, :validate_ssh_access, :wait_for_sandbox_start,
                 :wait_for_sandbox_stop, :resize, :wait_for_resize_complete,
-                :experimental_fork, :experimental_create_snapshot, :pause
+                :fork, :create_snapshot, :pause
 
     instrument :archive, :auto_archive_interval=, :auto_delete_interval=, :auto_pause_interval=, :auto_stop_interval=,
                :ttl_minutes=,
@@ -919,7 +931,7 @@ module Daytona
                :refresh, :refresh_activity, :revoke_ssh_access, :start, :recover, :stop,
                :create_lsp_server, :validate_ssh_access, :wait_for_sandbox_start,
                :wait_for_sandbox_stop, :resize, :wait_for_resize_complete,
-               :experimental_fork, :experimental_create_snapshot, :pause,
+               :fork, :create_snapshot, :pause,
                component: 'Sandbox'
 
     private

--- a/sdk-ruby/lib/daytona/sandbox.rb
+++ b/sdk-ruby/lib/daytona/sandbox.rb
@@ -878,12 +878,16 @@ module Daytona
       ) { wait_for_snapshot_complete }
     end
 
+    # Deprecated: Use +fork+ instead. This method will be removed in a future version.
+    #
     # @deprecated Use {#fork} instead. This method will be removed in a future version.
     def experimental_fork(name: nil, timeout: DEFAULT_TIMEOUT)
       warn('[DEPRECATION] `experimental_fork` is deprecated. Use `fork` instead.', uplevel: 1)
       fork(name:, timeout:)
     end
 
+    # Deprecated: Use +create_snapshot+ instead. This method will be removed in a future version.
+    #
     # @deprecated Use {#create_snapshot} instead. This method will be removed in a future version.
     def experimental_create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
       warn('[DEPRECATION] `experimental_create_snapshot` is deprecated. Use `create_snapshot` instead.', uplevel: 1)

--- a/sdk-ruby/spec/daytona/sandbox_spec.rb
+++ b/sdk-ruby/spec/daytona/sandbox_spec.rb
@@ -741,16 +741,54 @@ RSpec.describe Daytona::Sandbox do
     end
   end
 
-  describe '#experimental_create_snapshot' do
+  describe '#create_snapshot' do
     it 'creates a snapshot and waits for completion' do
       allow(sandbox_api).to receive(:create_sandbox_snapshot).with('sandbox-123', anything)
       allow(sandbox_api).to receive(:get_sandbox).with('sandbox-123').and_return(build_sandbox_dto(state: DaytonaApiClient::SandboxState::STARTED))
 
-      sandbox.experimental_create_snapshot(name: 'snap-1', timeout: 5)
+      sandbox.create_snapshot(name: 'snap-1', timeout: 5)
 
       expect(sandbox_api).to have_received(:create_sandbox_snapshot) do |_id, request|
         expect(request.name).to eq('snap-1')
       end
+    end
+  end
+
+  describe '#fork' do
+    it 'forks the sandbox and returns the forked sandbox' do
+      forked_dto = build_sandbox_dto(id: 'forked-456', state: DaytonaApiClient::SandboxState::STARTED)
+      allow(sandbox_api).to receive(:fork_sandbox).with('sandbox-123', anything).and_return(forked_dto)
+      allow(sandbox_api).to receive(:get_sandbox).with('forked-456').and_return(forked_dto)
+
+      result = sandbox.fork(name: 'my-fork', timeout: 5)
+
+      expect(result).to be_a(Daytona::Sandbox)
+      expect(result.id).to eq('forked-456')
+      expect(sandbox_api).to have_received(:fork_sandbox) do |_id, request|
+        expect(request.name).to eq('my-fork')
+      end
+    end
+  end
+
+  describe '#experimental_create_snapshot (deprecated)' do
+    it 'delegates to #create_snapshot and emits a deprecation warning' do
+      allow(sandbox).to receive(:create_snapshot)
+
+      expect { sandbox.experimental_create_snapshot(name: 'snap-1', timeout: 5) }
+        .to output(/DEPRECATION.*experimental_create_snapshot/).to_stderr
+
+      expect(sandbox).to have_received(:create_snapshot).with(name: 'snap-1', timeout: 5)
+    end
+  end
+
+  describe '#experimental_fork (deprecated)' do
+    it 'delegates to #fork and emits a deprecation warning' do
+      allow(sandbox).to receive(:fork)
+
+      expect { sandbox.experimental_fork(name: 'my-fork', timeout: 5) }
+        .to output(/DEPRECATION.*experimental_fork/).to_stderr
+
+      expect(sandbox).to have_received(:fork).with(name: 'my-fork', timeout: 5)
     end
   end
 

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -922,12 +922,20 @@ export class Daytona implements AsyncDisposable {
    *
    * @example
    * const sandbox = await daytona.get('my-sandbox-id');
-   * const forked = await daytona._experimental_fork(sandbox, { name: 'my-fork' });
+   * const forked = await daytona.fork(sandbox, { name: 'my-fork' });
    * console.log(`Forked sandbox: ${forked.id}`);
    */
   @WithInstrumentation()
+  public async fork(sandbox: Sandbox, params?: { name?: string }, timeout = 60): Promise<Sandbox> {
+    return await sandbox.fork(params, timeout)
+  }
+
+  /**
+   * @deprecated Use `fork` instead. This method will be removed in a future version.
+   * @see {@link Daytona.fork}
+   */
   public async _experimental_fork(sandbox: Sandbox, params?: { name?: string }, timeout = 60): Promise<Sandbox> {
-    return await sandbox._experimental_fork(params, timeout)
+    return this.fork(sandbox, params, timeout)
   }
 
   /**

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -220,6 +220,16 @@ export type CreateSandboxFromSnapshotParams = CreateSandboxBaseParams & {
 }
 
 /**
+ * Parameters for forking a Sandbox.
+ *
+ * @property {string} [name] - Optional name for the forked Sandbox. If not provided, a unique name will be generated.
+ */
+export type ForkSandboxParams = {
+  /** Optional name for the forked Sandbox. If not provided, a unique name will be generated. */
+  name?: string
+}
+
+/**
  * Main class for interacting with the Daytona API.
  * Provides methods for creating, managing, and interacting with Daytona Sandboxes.
  * Can be initialized either with explicit configuration or using environment variables.
@@ -915,7 +925,7 @@ export class Daytona implements AsyncDisposable {
    * Forks a Sandbox, creating a new Sandbox with an identical filesystem.
    *
    * @param {Sandbox} sandbox - The Sandbox to fork
-   * @param {object} [params] - Fork parameters
+   * @param {ForkSandboxParams} [params] - Fork parameters
    * @param {string} [params.name] - Optional name for the forked Sandbox
    * @param {number} [timeout] - Timeout in seconds (0 means no timeout, default is 60)
    * @returns {Promise<Sandbox>} The forked Sandbox
@@ -926,7 +936,7 @@ export class Daytona implements AsyncDisposable {
    * console.log(`Forked sandbox: ${forked.id}`);
    */
   @WithInstrumentation()
-  public async fork(sandbox: Sandbox, params?: { name?: string }, timeout = 60): Promise<Sandbox> {
+  public async fork(sandbox: Sandbox, params?: ForkSandboxParams, timeout = 60): Promise<Sandbox> {
     return await sandbox.fork(params, timeout)
   }
 
@@ -934,7 +944,7 @@ export class Daytona implements AsyncDisposable {
    * @deprecated Use `fork` instead. This method will be removed in a future version.
    * @see {@link Daytona.fork}
    */
-  public async _experimental_fork(sandbox: Sandbox, params?: { name?: string }, timeout = 60): Promise<Sandbox> {
+  public async _experimental_fork(sandbox: Sandbox, params?: ForkSandboxParams, timeout = 60): Promise<Sandbox> {
     return this.fork(sandbox, params, timeout)
   }
 

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -465,12 +465,12 @@ export class Sandbox {
    *
    * @example
    * const sandbox = await daytona.get('my-sandbox');
-   * const forked = await sandbox._experimental_fork({ name: 'my-fork' });
+   * const forked = await sandbox.fork({ name: 'my-fork' });
    * console.log(`Forked sandbox: ${forked.id}`);
    */
   @WithInstrumentation()
   @withEvents
-  public async _experimental_fork(params?: { name?: string }, timeout = 60): Promise<Sandbox> {
+  public async fork(params?: { name?: string }, timeout = 60): Promise<Sandbox> {
     if (timeout < 0) {
       throw new DaytonaValidationError('Timeout must be a non-negative number')
     }
@@ -504,6 +504,14 @@ export class Sandbox {
   }
 
   /**
+   * @deprecated Use `fork` instead. This method will be removed in a future version.
+   * @see {@link Sandbox.fork}
+   */
+  public async _experimental_fork(params?: { name?: string }, timeout = 60): Promise<Sandbox> {
+    return this.fork(params, timeout)
+  }
+
+  /**
    * Creates a snapshot from the current state of the Sandbox.
    *
    * This captures the Sandbox's filesystem into a reusable snapshot that can be
@@ -519,12 +527,12 @@ export class Sandbox {
    *
    * @example
    * const sandbox = await daytona.get('my-sandbox');
-   * await sandbox._experimental_createSnapshot('my-snapshot');
+   * await sandbox.createSnapshot('my-snapshot');
    * console.log('Snapshot created successfully');
    */
   @WithInstrumentation()
   @withEvents
-  public async _experimental_createSnapshot(name: string, timeout = 60): Promise<void> {
+  public async createSnapshot(name: string, timeout = 60): Promise<void> {
     if (timeout < 0) {
       throw new DaytonaValidationError('Timeout must be a non-negative number')
     }
@@ -540,6 +548,14 @@ export class Sandbox {
     const timeElapsed = Date.now() - startTime
     const remainingTimeout = timeout ? Math.max(0.001, timeout - timeElapsed / 1000) : timeout
     await this.waitForSnapshotComplete(remainingTimeout)
+  }
+
+  /**
+   * @deprecated Use `createSnapshot` instead. This method will be removed in a future version.
+   * @see {@link Sandbox.createSnapshot}
+   */
+  public async _experimental_createSnapshot(name: string, timeout = 60): Promise<void> {
+    return this.createSnapshot(name, timeout)
   }
 
   private async waitForSnapshotComplete(timeout: number) {

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -551,6 +551,9 @@ export class Sandbox {
   }
 
   /**
+   * @param {string} name - Name for the new snapshot
+   * @param {number} [timeout] - Maximum time to wait in seconds. 0 means no timeout.
+   *                            Defaults to 60-second timeout.
    * @deprecated Use `createSnapshot` instead. This method will be removed in a future version.
    * @see {@link Sandbox.createSnapshot}
    */

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -26,7 +26,7 @@ import type {
   MetricSeries,
 } from '@daytona/api-client'
 import { Daytona } from './Daytona'
-import type { Resources } from './Daytona'
+import type { ForkSandboxParams, Resources } from './Daytona'
 import {
   FileSystemApi,
   GitApi,
@@ -455,7 +455,7 @@ export class Sandbox {
    * The forked Sandbox is a copy-on-write clone of the original. It starts
    * with the same disk contents but operates independently from that point on.
    *
-   * @param {object} [params] - Fork parameters
+   * @param {ForkSandboxParams} [params] - Fork parameters
    * @param {string} [params.name] - Optional name for the forked Sandbox. If not provided, a unique name will be generated.
    * @param {number} [timeout] - Maximum time to wait in seconds. 0 means no timeout.
    *                            Defaults to 60-second timeout.
@@ -470,7 +470,7 @@ export class Sandbox {
    */
   @WithInstrumentation()
   @withEvents
-  public async fork(params?: { name?: string }, timeout = 60): Promise<Sandbox> {
+  public async fork(params?: ForkSandboxParams, timeout = 60): Promise<Sandbox> {
     if (timeout < 0) {
       throw new DaytonaValidationError('Timeout must be a non-negative number')
     }
@@ -507,7 +507,7 @@ export class Sandbox {
    * @deprecated Use `fork` instead. This method will be removed in a future version.
    * @see {@link Sandbox.fork}
    */
-  public async _experimental_fork(params?: { name?: string }, timeout = 60): Promise<Sandbox> {
+  public async _experimental_fork(params?: ForkSandboxParams, timeout = 60): Promise<Sandbox> {
     return this.fork(params, timeout)
   }
 

--- a/sdk-typescript/src/__tests__/Daytona.test.ts
+++ b/sdk-typescript/src/__tests__/Daytona.test.ts
@@ -129,6 +129,7 @@ jest.mock('../Sandbox', () => ({
       stop: jest.fn(),
       delete: jest.fn(),
       waitUntilStarted: jest.fn(),
+      fork: jest.fn(),
       _experimental_fork: jest.fn(),
     }
     mockSandboxCtor(dto, ...rest)
@@ -539,6 +540,7 @@ describe('Daytona', () => {
         .mockRejectedValue(
           new DaytonaTimeoutError('slow start', 504, undefined, 'PROCESS_EXECUTION_TIMEOUT', 'DAYTONA_DAEMON'),
         ),
+      fork: jest.fn(),
       _experimental_fork: jest.fn(),
     }))
 
@@ -594,18 +596,30 @@ describe('Daytona', () => {
     expect(call[5]).toBe('{"team":"sdk","env":"test"}') // labels JSON
   })
 
-  it('delegates experimental fork to the sandbox instance', async () => {
+  it('delegates fork to the sandbox instance', async () => {
     const { Daytona } = await import('../Daytona')
     const instance = new Daytona({ apiKey: 'k', apiUrl: 'http://api', target: 'us' })
 
     const sandbox = {
-      _experimental_fork: jest.fn().mockResolvedValue({ id: 'forked' }),
+      fork: jest.fn().mockResolvedValue({ id: 'forked' }),
     }
 
-    await expect(instance._experimental_fork(sandbox as never, { name: 'forked' }, 12)).resolves.toEqual({
+    await expect(instance.fork(sandbox as never, { name: 'forked' }, 12)).resolves.toEqual({
       id: 'forked',
     })
-    expect(sandbox._experimental_fork).toHaveBeenCalledWith({ name: 'forked' }, 12)
+    expect(sandbox.fork).toHaveBeenCalledWith({ name: 'forked' }, 12)
+  })
+
+  it('_experimental_fork delegates to fork', async () => {
+    const { Daytona } = await import('../Daytona')
+    const instance = new Daytona({ apiKey: 'k', apiUrl: 'http://api', target: 'us' })
+
+    const forkSpy = jest.spyOn(instance, 'fork').mockResolvedValue({ id: 'forked' } as never)
+
+    await expect(instance._experimental_fork({} as never, { name: 'alias' }, 7)).resolves.toEqual({
+      id: 'forked',
+    })
+    expect(forkSpy).toHaveBeenCalledWith({}, { name: 'alias' }, 7)
   })
 
   it('delegates get/list/start/stop/delete methods', async () => {

--- a/sdk-typescript/src/__tests__/Sandbox.test.ts
+++ b/sdk-typescript/src/__tests__/Sandbox.test.ts
@@ -300,11 +300,31 @@ describe('Sandbox', () => {
     sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
     sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
 
-    await sandbox._experimental_createSnapshot('snap-1', 5)
+    await sandbox.createSnapshot('snap-1', 5)
 
     expect(sandboxApi.createSandboxSnapshot).toHaveBeenCalledWith('sb-1', { name: 'snap-1' }, undefined, {
       timeout: 5000,
     })
+  })
+
+  it('_experimental_createSnapshot delegates to createSnapshot', async () => {
+    const { sandbox } = makeSandbox()
+    const spy = jest.spyOn(sandbox, 'createSnapshot').mockResolvedValue(undefined)
+
+    await sandbox._experimental_createSnapshot('snap-2', 10)
+
+    expect(spy).toHaveBeenCalledWith('snap-2', 10)
+  })
+
+  it('_experimental_fork delegates to fork', async () => {
+    const { sandbox } = makeSandbox()
+    const fakeFork = { id: 'forked-sb' } as unknown as import('../Sandbox').Sandbox
+    const spy = jest.spyOn(sandbox, 'fork').mockResolvedValue(fakeFork)
+
+    const result = await sandbox._experimental_fork({ name: 'clone' }, 30)
+
+    expect(spy).toHaveBeenCalledWith({ name: 'clone' }, 30)
+    expect(result).toBe(fakeFork)
   })
 
   it('waitUntilStarted throws when sandbox enters an error state', async () => {

--- a/sdk-typescript/src/index.ts
+++ b/sdk-typescript/src/index.ts
@@ -9,6 +9,7 @@ export type {
   CreateSandboxFromImageParams,
   CreateSandboxFromSnapshotParams,
   DaytonaConfig,
+  ForkSandboxParams,
   Resources,
   VolumeMount,
 } from './Daytona'


### PR DESCRIPTION
## Stabilize `fork` and `createSnapshot` across all SDKs

Promotes the sandbox fork and snapshot-creation methods from experimental to stable in all 5 SDKs (TypeScript, Python, Go, Java, Ruby).

### Changes
- New stable methods carry the full implementation, docs, and instrumentation/events:
  - TS: `sandbox.fork()`, `sandbox.createSnapshot()`, `daytona.fork(sandbox, ...)`
  - Python: `fork()` / `create_snapshot()` (sync + async)
  - Go: `Fork`, `ForkWithTimeout`, `CreateSnapshot`, `CreateSnapshotWithTimeout`
  - Java: `fork()` / `createSnapshot()` (+ timeout overloads)
  - Ruby: `fork` / `create_snapshot`
- Existing `experimental*` / `_experimental_*` methods are kept as thin deprecated delegates — **no breaking changes** for current users. Each is marked deprecated per language convention (JSDoc `@deprecated`, `@deprecated` decorator, `// Deprecated:`, `@Deprecated`, YARD `@deprecated` + runtime warning).
- Deprecated wrappers carry no instrumentation/events to avoid double emission; telemetry is emitted under the new operation names.
- Tests updated to exercise the stable methods, plus new tests asserting each deprecated alias delegates correctly (and warns where applicable).

### Not changed
- The `_experimental` client config (OTel flag) remains experimental.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes sandbox fork and snapshot creation to stable APIs across TypeScript, Python, Go, Java, and Ruby, and deprecates the experimental aliases. Docs updated with corrected method signatures and clear deprecation notes; no breaking changes.

- **New Features**
  - Stable methods added across all SDKs with full instrumentation/events and docs.
  - Deprecated wrappers delegate to the stable methods and do not emit events (to avoid double telemetry).
  - Java: `fork(String, long)` now validates non‑negative timeout before calling the API.
  - TypeScript: introduced `ForkSandboxParams` so docs show the optional `name` correctly; type exported from `Daytona`.
  - Docs regenerated to fix method signatures and deprecation callouts across SDKs.
  - Tests updated to cover stable methods and verify deprecation delegation (incl. Go alias coverage).
  - No change to the `_experimental` client config flag.

- **Migration**
  - TypeScript: `sandbox._experimental_fork` -> `sandbox.fork`; `sandbox._experimental_createSnapshot` -> `sandbox.createSnapshot`; `daytona._experimental_fork` -> `daytona.fork`.
  - Python (sync/async): `_experimental_fork` -> `fork`; `_experimental_create_snapshot` -> `create_snapshot`.
  - Go: `ExperimentalFork` -> `Fork`; `ExperimentalForkWithTimeout` -> `ForkWithTimeout`; `ExperimentalCreateSnapshot` -> `CreateSnapshot`; `ExperimentalCreateSnapshotWithTimeout` -> `CreateSnapshotWithTimeout`.
  - Java: `experimentalFork(...)` -> `fork(...)`; `experimentalCreateSnapshot(...)` -> `createSnapshot(...)`.
  - Ruby: `experimental_fork` -> `fork`; `experimental_create_snapshot` -> `create_snapshot`.
  - If you track telemetry by operation name, update dashboards to the new names (`Fork`, `ForkWithTimeout`, `CreateSnapshot`, `CreateSnapshotWithTimeout`).

<sup>Written for commit ac33e3dc6d19d69b38efa56ff454f287b7d0489f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

