### PR TITLE
feat(sdk-typescript): distinguish client-side argument validation from server 400s and restore timeout compatibility

### DIFF
--- a/artifacts/sdk-docs/typescript-sdk/errors.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/errors.mdx
@@ -327,6 +327,7 @@ The request was malformed or invalid (HTTP 400).
 ### Extended by
 
 - `DaytonaValidationError`
+- `DaytonaInvalidFilePathError`
 - `DaytonaLspServerNotInitializedError`
 
 ### Accessors
@@ -917,6 +918,79 @@ new DaytonaFileNotFoundError(
 ##### Inherited from
 
 `DaytonaNotFoundError`.`constructor`
+## DaytonaFileReadFailedError
+
+The daemon could not read the sandbox file (code `FILE_READ_FAILED`).
+
+**Properties**:
+
+- `code?` _string_
+    - _Inherited from_: `DaytonaInternalServerError.code`
+- `headers?` _AxiosHeaders_
+    - _Inherited from_: `DaytonaInternalServerError.headers`
+- `source?` _string_
+    - _Inherited from_: `DaytonaInternalServerError.source`
+- `statusCode?` _number_
+    - _Inherited from_: `DaytonaInternalServerError.statusCode`
+
+
+
+
+**Extends:**
+
+- `DaytonaInternalServerError`
+
+### Accessors
+
+#### errorCode
+
+_Inherited from_: `DaytonaInternalServerError.errorCode`
+
+##### Get Signature
+
+```ts
+get errorCode(): string
+```
+
+###### Deprecated
+
+Use DaytonaError.code instead. Kept so existing
+`err.errorCode` reads keep returning the machine-readable code.
+
+**Returns**:
+
+- `string` - the machine-readable error code, or `undefined` when the
+    response did not carry one (same as DaytonaError.code)
+
+### Constructors
+
+#### new DaytonaFileReadFailedError()
+
+```ts
+new DaytonaFileReadFailedError(
+   message: string, 
+   statusCode?: number, 
+   headers?: AxiosHeaders, 
+   code?: string, 
+   source?: string): DaytonaFileReadFailedError
+```
+
+**Parameters**:
+
+- `message` _string_
+- `statusCode?` _number_
+- `headers?` _AxiosHeaders_
+- `code?` _string_
+- `source?` _string_
+
+
+**Returns**:
+
+- `DaytonaFileReadFailedError`
+
+##### Inherited from
+
+`DaytonaInternalServerError`.`constructor`
 ## DaytonaForbiddenError
 
 The authenticated caller lacks permission for the operation (HTTP 403).
@@ -1606,6 +1680,10 @@ A Daytona service failed unexpectedly (HTTP 500).
 
 - `DaytonaError`
 
+### Extended by
+
+- `DaytonaFileReadFailedError`
+
 ### Accessors
 
 #### errorCode
@@ -1657,6 +1735,170 @@ new DaytonaInternalServerError(
 ##### Inherited from
 
 `DaytonaError`.`constructor`
+## DaytonaInvalidArgumentError
+
+The SDK rejected the caller's arguments locally, before any request was
+sent. `statusCode`, `code` and `source` are always `undefined` — no Daytona
+service was contacted, so there is no HTTP status to report.
+
+**Properties**:
+
+- `code?` _string_
+    - _Inherited from_: `DaytonaValidationError.code`
+- `headers?` _AxiosHeaders_
+    - _Inherited from_: `DaytonaValidationError.headers`
+- `source?` _string_
+    - _Inherited from_: `DaytonaValidationError.source`
+- `statusCode?` _number_
+    - _Inherited from_: `DaytonaValidationError.statusCode`
+
+
+
+
+Distinct from DaytonaBadRequestError (a service returned HTTP 400)
+and DaytonaUnprocessableEntityError (a service returned HTTP 422).
+This one always means: fix the arguments at the call site.
+
+**Example:**
+
+```ts
+try {
+  await sandbox.setAutoStopInterval(-1)
+} catch (err) {
+  if (err instanceof DaytonaInvalidArgumentError) {
+    // never reached the API — the value itself is invalid
+  }
+}
+```
+
+**Extends:**
+
+- `DaytonaValidationError`
+
+### Accessors
+
+#### errorCode
+
+_Inherited from_: `DaytonaValidationError.errorCode`
+
+##### Get Signature
+
+```ts
+get errorCode(): string
+```
+
+###### Deprecated
+
+Use DaytonaError.code instead. Kept so existing
+`err.errorCode` reads keep returning the machine-readable code.
+
+**Returns**:
+
+- `string` - the machine-readable error code, or `undefined` when the
+    response did not carry one (same as DaytonaError.code)
+
+### Constructors
+
+#### new DaytonaInvalidArgumentError()
+
+```ts
+new DaytonaInvalidArgumentError(
+   message: string, 
+   statusCode?: number, 
+   headers?: AxiosHeaders, 
+   code?: string, 
+   source?: string): DaytonaInvalidArgumentError
+```
+
+**Parameters**:
+
+- `message` _string_
+- `statusCode?` _number_
+- `headers?` _AxiosHeaders_
+- `code?` _string_
+- `source?` _string_
+
+
+**Returns**:
+
+- `DaytonaInvalidArgumentError`
+
+##### Inherited from
+
+`DaytonaValidationError`.`constructor`
+## DaytonaInvalidFilePathError
+
+The supplied file path was rejected by the daemon (code `INVALID_FILE_PATH`).
+
+**Properties**:
+
+- `code?` _string_
+    - _Inherited from_: `DaytonaBadRequestError.code`
+- `headers?` _AxiosHeaders_
+    - _Inherited from_: `DaytonaBadRequestError.headers`
+- `source?` _string_
+    - _Inherited from_: `DaytonaBadRequestError.source`
+- `statusCode?` _number_
+    - _Inherited from_: `DaytonaBadRequestError.statusCode`
+
+
+
+
+**Extends:**
+
+- `DaytonaBadRequestError`
+
+### Accessors
+
+#### errorCode
+
+_Inherited from_: `DaytonaBadRequestError.errorCode`
+
+##### Get Signature
+
+```ts
+get errorCode(): string
+```
+
+###### Deprecated
+
+Use DaytonaError.code instead. Kept so existing
+`err.errorCode` reads keep returning the machine-readable code.
+
+**Returns**:
+
+- `string` - the machine-readable error code, or `undefined` when the
+    response did not carry one (same as DaytonaError.code)
+
+### Constructors
+
+#### new DaytonaInvalidFilePathError()
+
+```ts
+new DaytonaInvalidFilePathError(
+   message: string, 
+   statusCode?: number, 
+   headers?: AxiosHeaders, 
+   code?: string, 
+   source?: string): DaytonaInvalidFilePathError
+```
+
+**Parameters**:
+
+- `message` _string_
+- `statusCode?` _number_
+- `headers?` _AxiosHeaders_
+- `code?` _string_
+- `source?` _string_
+
+
+**Returns**:
+
+- `DaytonaInvalidFilePathError`
+
+##### Inherited from
+
+`DaytonaBadRequestError`.`constructor`
 ## DaytonaLspServerNotInitializedError
 
 The LSP server must be initialized first (code `LSP_SERVER_NOT_INITIALIZED`).
@@ -1883,6 +2125,27 @@ new DaytonaProcessExecutionTimeoutError(
 ##### Inherited from
 
 `DaytonaTimeoutError`.`constructor`
+
+### Methods
+
+#### \[hasInstance\]()
+
+```ts
+static hasInstance: boolean
+```
+
+**Parameters**:
+
+- `value` _unknown_
+
+
+**Returns**:
+
+- `boolean`
+
+##### Inherited from
+
+`DaytonaTimeoutError`.[`[hasInstance]`](Errors.md#hasinstance-6)
 ## DaytonaProcessNotFoundError
 
 The sandbox process does not exist (code `PROCESS_NOT_FOUND`).
@@ -2344,6 +2607,13 @@ The operation timed out (HTTP 408, or 504 when a gateway timed out).
 
 
 
+Also matches DaytonaConnectionTimeoutError via `instanceof`, even
+though that class sits under DaytonaConnectionError in the prototype
+chain. Transport timeouts were raised as `DaytonaTimeoutError` before
+`DaytonaConnectionTimeoutError` existed, so this keeps pre-existing
+`catch (err) { if (err instanceof DaytonaTimeoutError) ... }` blocks working
+— the same compatibility the Python SDK gets from inheriting both classes.
+
 **Extends:**
 
 - `DaytonaError`
@@ -2403,6 +2673,23 @@ new DaytonaTimeoutError(
 ##### Inherited from
 
 `DaytonaError`.`constructor`
+
+### Methods
+
+#### \[hasInstance\]()
+
+```ts
+static hasInstance: boolean
+```
+
+**Parameters**:
+
+- `value` _unknown_
+
+
+**Returns**:
+
+- `boolean`
 ## DaytonaUnprocessableEntityError
 
 The request was well-formed but semantically invalid (HTTP 422).
@@ -2478,7 +2765,9 @@ new DaytonaUnprocessableEntityError(
 `DaytonaError`.`constructor`
 ## ~~DaytonaValidationError~~
 
-### Deprecated
+Legacy umbrella for validation failures. Kept so existing
+`catch (err) { if (err instanceof DaytonaValidationError) ... }` blocks keep
+matching both server-returned HTTP 400s and locally rejected arguments.
 
 **Properties**:
 
@@ -2494,13 +2783,23 @@ new DaytonaUnprocessableEntityError(
 
 
 
-Use DaytonaBadRequestError instead. Re-exported so
-existing `catch (err) { if (err instanceof DaytonaValidationError) ... }`
-blocks keep working.
+### Deprecated
+
+Do not throw or catch this directly in new code. Branch on the
+precise class instead:
+- DaytonaInvalidArgumentError — the SDK rejected your arguments
+  locally, before any request was sent.
+- DaytonaBadRequestError — a Daytona service returned HTTP 400.
+- DaytonaUnprocessableEntityError — a Daytona service returned
+  HTTP 422 (well-formed but semantically invalid).
 
 **Extends:**
 
 - `DaytonaBadRequestError`
+
+### Extended by
+
+- `DaytonaInvalidArgumentError`
 
 ### Accessors
 

--- a/sdk-typescript/src/CodeInterpreter.ts
+++ b/sdk-typescript/src/CodeInterpreter.ts
@@ -14,8 +14,8 @@ import { Configuration } from '@daytona/api-client'
 import {
   DaytonaConnectionError,
   DaytonaError,
+  DaytonaInvalidArgumentError,
   DaytonaTimeoutError,
-  DaytonaValidationError,
 } from './errors/DaytonaError'
 import type { ExecutionError, ExecutionResult, RunCodeOptions } from './types/CodeInterpreter'
 import { createSandboxWebSocket } from './utils/WebSocket'
@@ -75,7 +75,7 @@ export class CodeInterpreter {
    */
   public async runCode(code: string, options: RunCodeOptions = {}): Promise<ExecutionResult> {
     if (!code || !code.trim()) {
-      throw new DaytonaValidationError('Code is required for execution')
+      throw new DaytonaInvalidArgumentError('Code is required for execution')
     }
 
     const url = `${this.clientConfig.basePath.replace(/^http/, 'ws')}/process/interpreter/execute`

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -22,8 +22,8 @@ import {
   DaytonaAuthenticationError,
   createAxiosDaytonaError,
   DaytonaError,
+  DaytonaInvalidArgumentError,
   DaytonaTimeoutError,
-  DaytonaValidationError,
 } from './errors/DaytonaError'
 import { Image } from './Image'
 import { Sandbox } from './Sandbox'
@@ -555,7 +555,7 @@ export class Daytona implements AsyncDisposable {
     if (params.language) {
       const validLanguages = Object.values(CodeLanguage) as string[]
       if (!validLanguages.includes(params.language)) {
-        throw new DaytonaValidationError(
+        throw new DaytonaInvalidArgumentError(
           `Invalid ${CODE_TOOLBOX_LANGUAGE_LABEL}: ${params.language}. Supported languages: ${validLanguages.join(', ')}`,
         )
       }
@@ -563,31 +563,33 @@ export class Daytona implements AsyncDisposable {
     }
 
     if (options.timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
 
     if (
       params.autoStopInterval !== undefined &&
       (!Number.isInteger(params.autoStopInterval) || params.autoStopInterval < 0)
     ) {
-      throw new DaytonaValidationError('autoStopInterval must be a non-negative integer')
+      throw new DaytonaInvalidArgumentError('autoStopInterval must be a non-negative integer')
     }
 
     if (
       params.autoPauseInterval !== undefined &&
       (!Number.isInteger(params.autoPauseInterval) || params.autoPauseInterval < 0)
     ) {
-      throw new DaytonaValidationError('autoPauseInterval must be a non-negative integer')
+      throw new DaytonaInvalidArgumentError('autoPauseInterval must be a non-negative integer')
     }
 
     if (params.autoStopInterval && params.autoPauseInterval) {
-      throw new DaytonaValidationError(
+      throw new DaytonaInvalidArgumentError(
         'autoStopInterval and autoPauseInterval are mutually exclusive. Set at most one of them to a non-zero value',
       )
     }
 
     if (params.autoPauseInterval && (params.ephemeral || params.autoDeleteInterval === 0)) {
-      throw new DaytonaValidationError('Ephemeral sandboxes cannot have auto-pause enabled. Set autoPauseInterval to 0')
+      throw new DaytonaInvalidArgumentError(
+        'Ephemeral sandboxes cannot have auto-pause enabled. Set autoPauseInterval to 0',
+      )
     }
 
     if (params.ephemeral) {
@@ -603,11 +605,11 @@ export class Daytona implements AsyncDisposable {
       params.autoArchiveInterval !== undefined &&
       (!Number.isInteger(params.autoArchiveInterval) || params.autoArchiveInterval < 0)
     ) {
-      throw new DaytonaValidationError('autoArchiveInterval must be a non-negative integer')
+      throw new DaytonaInvalidArgumentError('autoArchiveInterval must be a non-negative integer')
     }
 
     if (params.ttlMinutes !== undefined && (!Number.isInteger(params.ttlMinutes) || params.ttlMinutes < 0)) {
-      throw new DaytonaValidationError('ttlMinutes must be a non-negative integer')
+      throw new DaytonaInvalidArgumentError('ttlMinutes must be a non-negative integer')
     }
 
     try {

--- a/sdk-typescript/src/Image.ts
+++ b/sdk-typescript/src/Image.ts
@@ -5,7 +5,7 @@
 
 import * as pathe from 'pathe'
 import { quote, parse as parseShellQuote } from 'shell-quote'
-import { DaytonaNotFoundError, DaytonaValidationError } from './errors/DaytonaError'
+import { DaytonaInvalidArgumentError, DaytonaNotFoundError } from './errors/DaytonaError'
 import { dynamicRequire } from './utils/Import'
 
 const SUPPORTED_PYTHON_SERIES = ['3.9', '3.10', '3.11', '3.12', '3.13'] as const
@@ -120,7 +120,7 @@ export class Image {
       throw new DaytonaNotFoundError(`Requirements file ${requirementsTxt} does not exist`)
     }
     if (!fs.statSync(expandedPath).isFile()) {
-      throw new DaytonaValidationError(`Requirements path ${requirementsTxt} exists but is not a file`)
+      throw new DaytonaInvalidArgumentError(`Requirements path ${requirementsTxt} exists but is not a file`)
     }
 
     const extraArgs = this.formatPipInstallArgs(options)
@@ -154,7 +154,7 @@ export class Image {
       throw new DaytonaNotFoundError(`pyproject.toml file ${pyprojectToml} does not exist`)
     }
     if (!fs.statSync(expandedPath).isFile()) {
-      throw new DaytonaValidationError(`pyproject.toml path ${pyprojectToml} exists but is not a file`)
+      throw new DaytonaInvalidArgumentError(`pyproject.toml path ${pyprojectToml} exists but is not a file`)
     }
 
     let tomlData: any
@@ -163,7 +163,7 @@ export class Image {
       tomlData = toml.parse(fs.readFileSync(expandedPath, 'utf-8')) as any
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
-      throw new DaytonaValidationError(`Invalid pyproject.toml file ${pyprojectToml}: ${errorMessage}`)
+      throw new DaytonaInvalidArgumentError(`Invalid pyproject.toml file ${pyprojectToml}: ${errorMessage}`)
     }
 
     const dependencies: string[] = []
@@ -173,7 +173,7 @@ export class Image {
         'No [project.dependencies] section in pyproject.toml file. ' +
         'See https://packaging.python.org/en/latest/guides/writing-pyproject-toml ' +
         'for further file format guidelines.'
-      throw new DaytonaValidationError(msg)
+      throw new DaytonaInvalidArgumentError(msg)
     }
 
     dependencies.push(...tomlData.project.dependencies)
@@ -181,7 +181,7 @@ export class Image {
     if (options?.optionalDependencies && tomlData.project['optional-dependencies']) {
       const optionalGroups = tomlData.project['optional-dependencies']
       if (typeof optionalGroups !== 'object' || Array.isArray(optionalGroups)) {
-        throw new DaytonaValidationError('optional-dependencies must be a mapping in pyproject.toml')
+        throw new DaytonaInvalidArgumentError('optional-dependencies must be a mapping in pyproject.toml')
       }
 
       for (const group of options.optionalDependencies) {
@@ -221,7 +221,7 @@ export class Image {
       throw new DaytonaNotFoundError(`Local file ${localPath} does not exist`)
     }
     if (!fs.statSync(expandedPath).isFile()) {
-      throw new DaytonaValidationError(`Local path ${localPath} exists but is not a file`)
+      throw new DaytonaInvalidArgumentError(`Local path ${localPath} exists but is not a file`)
     }
 
     this._contextList.push({ sourcePath: expandedPath, archivePath: expandedPath })
@@ -252,7 +252,7 @@ export class Image {
       throw new DaytonaNotFoundError(`Local directory ${localPath} does not exist`)
     }
     if (!fs.statSync(expandedPath).isDirectory()) {
-      throw new DaytonaValidationError(`Local path ${localPath} exists but is not a directory`)
+      throw new DaytonaInvalidArgumentError(`Local path ${localPath} exists but is not a directory`)
     }
 
     this._contextList.push({ sourcePath: expandedPath, archivePath: expandedPath })
@@ -304,7 +304,7 @@ export class Image {
       .map(([key]) => key)
 
     if (nonStringKeys.length) {
-      throw new DaytonaValidationError(`Image ENV variables must be strings. Invalid keys: ${nonStringKeys}`)
+      throw new DaytonaInvalidArgumentError(`Image ENV variables must be strings. Invalid keys: ${nonStringKeys}`)
     }
 
     for (const [key, val] of Object.entries(envVars)) {
@@ -343,7 +343,7 @@ export class Image {
    */
   entrypoint(entrypointCommands: string[]): Image {
     if (!Array.isArray(entrypointCommands) || !entrypointCommands.every((x) => typeof x === 'string')) {
-      throw new DaytonaValidationError('entrypoint_commands must be a list of strings')
+      throw new DaytonaInvalidArgumentError('entrypoint_commands must be a list of strings')
     }
 
     const argsStr = entrypointCommands.map((arg) => `"${arg}"`).join(', ')
@@ -365,7 +365,7 @@ export class Image {
    */
   cmd(cmd: string[]): Image {
     if (!Array.isArray(cmd) || !cmd.every((x) => typeof x === 'string')) {
-      throw new DaytonaValidationError('Image CMD must be a list of strings')
+      throw new DaytonaInvalidArgumentError('Image CMD must be a list of strings')
     }
 
     const cmdStr = cmd.map((arg) => `"${arg}"`).join(', ')
@@ -397,7 +397,7 @@ export class Image {
         throw new DaytonaNotFoundError(`Context directory ${contextDir} does not exist`)
       }
       if (!fs.statSync(expandedPath).isDirectory()) {
-        throw new DaytonaValidationError(`Context path ${contextDir} exists but is not a directory`)
+        throw new DaytonaInvalidArgumentError(`Context path ${contextDir} exists but is not a directory`)
       }
     }
 
@@ -438,7 +438,7 @@ export class Image {
       throw new DaytonaNotFoundError(`Dockerfile ${path} does not exist`)
     }
     if (!fs.statSync(expandedPath).isFile()) {
-      throw new DaytonaValidationError(`Dockerfile path ${path} exists but is not a file`)
+      throw new DaytonaInvalidArgumentError(`Dockerfile path ${path} exists but is not a file`)
     }
 
     const dockerfileContent = fs.readFileSync(expandedPath, 'utf-8')
@@ -562,7 +562,7 @@ export class Image {
           flatten(item)
         }
       } else {
-        throw new DaytonaValidationError(`${functionName}: ${argName} must only contain strings`)
+        throw new DaytonaInvalidArgumentError(`${functionName}: ${argName} must only contain strings`)
       }
     }
 
@@ -583,7 +583,7 @@ export class Image {
     }
 
     if (!SUPPORTED_PYTHON_SERIES.includes(pythonVersion)) {
-      throw new DaytonaValidationError(
+      throw new DaytonaInvalidArgumentError(
         `Unsupported Python version: ${pythonVersion}. ` +
           `Daytona supports the following series: ${SUPPORTED_PYTHON_SERIES.join(', ')}`,
       )

--- a/sdk-typescript/src/LspServer.ts
+++ b/sdk-typescript/src/LspServer.ts
@@ -5,7 +5,7 @@
 
 import { LspApi } from '@daytona/toolbox-api-client'
 import type { CompletionList, LspSymbol } from '@daytona/toolbox-api-client'
-import { DaytonaValidationError } from './errors/DaytonaError'
+import { DaytonaInvalidArgumentError } from './errors/DaytonaError'
 import { WithInstrumentation } from './utils/otel.decorator'
 
 /**
@@ -56,7 +56,7 @@ export class LspServer {
     private readonly apiClient: LspApi,
   ) {
     if (!Object.values(LspLanguageId).includes(this.languageId)) {
-      throw new DaytonaValidationError(
+      throw new DaytonaInvalidArgumentError(
         `Invalid languageId: ${this.languageId}. Supported values are: ${Object.values(LspLanguageId).join(', ')}`,
       )
     }

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -43,7 +43,12 @@ import { FileSystem } from './FileSystem'
 import { Git } from './Git'
 import { Process } from './Process'
 import { LspLanguageId, LspServer } from './LspServer'
-import { DaytonaError, DaytonaNotFoundError, DaytonaTimeoutError, DaytonaValidationError } from './errors/DaytonaError'
+import {
+  DaytonaError,
+  DaytonaInvalidArgumentError,
+  DaytonaNotFoundError,
+  DaytonaTimeoutError,
+} from './errors/DaytonaError'
 import { CODE_TOOLBOX_LANGUAGE_LABEL } from './Daytona'
 import { ComputerUse } from './ComputerUse'
 import type { AxiosInstance } from 'axios'
@@ -385,7 +390,7 @@ export class Sandbox {
   @withEvents
   public async start(timeout = 60): Promise<void> {
     if (timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
 
     const startTime = Date.now()
@@ -411,7 +416,7 @@ export class Sandbox {
   @withEvents
   public async recover(timeout = 60): Promise<void> {
     if (timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
 
     const startTime = Date.now()
@@ -440,7 +445,7 @@ export class Sandbox {
   @withEvents
   public async stop(timeout = 60, force = false): Promise<void> {
     if (timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
     const startTime = Date.now()
     await this.sandboxApi.stopSandbox(this.id, undefined, force, { timeout: timeout * 1000 })
@@ -460,7 +465,7 @@ export class Sandbox {
    * @param {number} [timeout] - Maximum time to wait in seconds. 0 means no timeout.
    *                            Defaults to 60-second timeout.
    * @returns {Promise<Sandbox>} The forked Sandbox.
-   * @throws {DaytonaValidationError} - If timeout is a negative number
+   * @throws {DaytonaInvalidArgumentError} - If timeout is a negative number
    * @throws {DaytonaError} - If the fork operation fails or times out
    *
    * @example
@@ -472,7 +477,7 @@ export class Sandbox {
   @withEvents
   public async fork(params?: ForkSandboxParams, timeout = 60): Promise<Sandbox> {
     if (timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
 
     const startTime = Date.now()
@@ -522,7 +527,7 @@ export class Sandbox {
    * @param {number} [timeout] - Maximum time to wait in seconds. 0 means no timeout.
    *                            Defaults to 60-second timeout.
    * @returns {Promise<void>}
-   * @throws {DaytonaValidationError} - If timeout is a negative number
+   * @throws {DaytonaInvalidArgumentError} - If timeout is a negative number
    * @throws {DaytonaError} - If the snapshot operation fails or times out
    *
    * @example
@@ -534,7 +539,7 @@ export class Sandbox {
   @withEvents
   public async createSnapshot(name: string, timeout = 60): Promise<void> {
     if (timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
 
     const startTime = Date.now()
@@ -585,7 +590,7 @@ export class Sandbox {
    * @param {number} [timeout] - Maximum time to wait in seconds. 0 means no timeout.
    *                            Defaults to 60-second timeout.
    * @returns {Promise<void>}
-   * @throws {DaytonaValidationError} - If timeout is a negative number
+   * @throws {DaytonaInvalidArgumentError} - If timeout is a negative number
    * @throws {DaytonaError} - If the pause operation fails or times out
    *
    * @example
@@ -597,7 +602,7 @@ export class Sandbox {
   @withEvents
   public async pause(timeout = 60): Promise<void> {
     if (timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
 
     const startTime = Date.now()
@@ -640,7 +645,7 @@ export class Sandbox {
   @withEvents
   public async delete(timeout = 60, wait = false): Promise<void> {
     if (timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
 
     const startTime = Date.now()
@@ -684,7 +689,7 @@ export class Sandbox {
   @withEvents
   public async waitUntilStarted(timeout = 60) {
     if (timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
 
     if (this.state === SandboxState.STARTED) {
@@ -715,7 +720,7 @@ export class Sandbox {
   @withEvents
   public async waitUntilStopped(timeout = 60) {
     if (timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
 
     // Treat destroyed as stopped to cover ephemeral sandboxes that are automatically deleted after stopping
@@ -790,7 +795,7 @@ export class Sandbox {
   @withEvents
   public async setAutostopInterval(interval: number): Promise<void> {
     if (!Number.isInteger(interval) || interval < 0) {
-      throw new DaytonaValidationError('autoStopInterval must be a non-negative integer')
+      throw new DaytonaInvalidArgumentError('autoStopInterval must be a non-negative integer')
     }
 
     await this.sandboxApi.setAutostopInterval(this.id, interval)
@@ -823,7 +828,7 @@ export class Sandbox {
   @WithInstrumentation()
   public async setAutoPauseInterval(interval: number): Promise<void> {
     if (!Number.isInteger(interval) || interval < 0) {
-      throw new DaytonaValidationError('autoPauseInterval must be a non-negative integer')
+      throw new DaytonaInvalidArgumentError('autoPauseInterval must be a non-negative integer')
     }
 
     await this.sandboxApi.setAutoPauseInterval(this.id, interval)
@@ -851,7 +856,7 @@ export class Sandbox {
   @WithInstrumentation()
   public async setTtl(ttlMinutes: number): Promise<void> {
     if (!Number.isInteger(ttlMinutes) || ttlMinutes < 0) {
-      throw new DaytonaValidationError('ttlMinutes must be a non-negative integer')
+      throw new DaytonaInvalidArgumentError('ttlMinutes must be a non-negative integer')
     }
 
     await this.sandboxApi.setTtl(this.id, ttlMinutes)
@@ -877,7 +882,7 @@ export class Sandbox {
   @withEvents
   public async setAutoArchiveInterval(interval: number): Promise<void> {
     if (!Number.isInteger(interval) || interval < 0) {
-      throw new DaytonaValidationError('autoArchiveInterval must be a non-negative integer')
+      throw new DaytonaInvalidArgumentError('autoArchiveInterval must be a non-negative integer')
     }
     await this.sandboxApi.setAutoArchiveInterval(this.id, interval)
     this.autoArchiveInterval = interval
@@ -934,7 +939,7 @@ export class Sandbox {
       settings.networkAllowList === undefined &&
       settings.domainAllowList === undefined
     ) {
-      throw new DaytonaValidationError(
+      throw new DaytonaInvalidArgumentError(
         'At least one of networkBlockAll, networkAllowList or domainAllowList must be set',
       )
     }
@@ -1148,10 +1153,10 @@ export class Sandbox {
   @withEvents
   public async resize(resources: Pick<Resources, 'cpu' | 'memory' | 'disk'>, timeout = 60): Promise<void> {
     if (timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
     if ('gpu' in resources || 'gpuType' in resources) {
-      throw new DaytonaValidationError(
+      throw new DaytonaInvalidArgumentError(
         'Resize does not support changes to gpu or gpuType — to change GPU, create a new Sandbox',
       )
     }
@@ -1183,7 +1188,7 @@ export class Sandbox {
   @withEvents
   public async waitForResizeComplete(timeout = 60): Promise<void> {
     if (timeout < 0) {
-      throw new DaytonaValidationError('Timeout must be a non-negative number')
+      throw new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
     }
 
     if (this.state !== SandboxState.RESIZING) {

--- a/sdk-typescript/src/__tests__/DaytonaError.test.ts
+++ b/sdk-typescript/src/__tests__/DaytonaError.test.ts
@@ -10,15 +10,20 @@ import {
   DaytonaAuthenticationError,
   DaytonaAuthorizationError,
   DaytonaBadGatewayError,
+  DaytonaBadRequestError,
   DaytonaConflictError,
   DaytonaConnectionError,
   DaytonaConnectionTimeoutError,
   DaytonaError,
   DaytonaFileNotFoundError,
+  DaytonaFileReadFailedError,
   DaytonaGitAuthFailedError,
   DaytonaGoneError,
   DaytonaInternalServerError,
+  DaytonaInvalidArgumentError,
+  DaytonaInvalidFilePathError,
   DaytonaNotFoundError,
+  DaytonaProcessExecutionTimeoutError,
   DaytonaRateLimitError,
   DaytonaServiceUnavailableError,
   DaytonaSessionEndedError,
@@ -59,6 +64,68 @@ describe('DaytonaError construction', () => {
   it('preserves deprecated alias class names', () => {
     expect(new DaytonaValidationError('bad request').name).toBe('DaytonaValidationError')
     expect(new DaytonaAuthorizationError('forbidden').name).toBe('DaytonaAuthorizationError')
+  })
+})
+
+describe('DaytonaInvalidArgumentError (client-side validation)', () => {
+  it('carries no response metadata', () => {
+    const err = new DaytonaInvalidArgumentError('Timeout must be a non-negative number')
+    expect(err.name).toBe('DaytonaInvalidArgumentError')
+    expect(err.message).toBe('Timeout must be a non-negative number')
+    expect(err.statusCode).toBeUndefined()
+    expect(err.code).toBeUndefined()
+    expect(err.source).toBeUndefined()
+  })
+
+  it('still matches legacy validation catches', () => {
+    const err = new DaytonaInvalidArgumentError('bad arg')
+    expect(err).toBeInstanceOf(DaytonaValidationError)
+    expect(err).toBeInstanceOf(DaytonaBadRequestError)
+    expect(err).toBeInstanceOf(DaytonaError)
+  })
+
+  it('is distinct from server-returned 400 and 422 errors', () => {
+    const local = new DaytonaInvalidArgumentError('bad arg')
+    const badRequest = createDaytonaError('server rejected', 400)
+    const unprocessable = createDaytonaError('semantically invalid', 422)
+
+    expect(badRequest).not.toBeInstanceOf(DaytonaInvalidArgumentError)
+    expect(unprocessable).not.toBeInstanceOf(DaytonaInvalidArgumentError)
+    expect(local).not.toBeInstanceOf(DaytonaUnprocessableEntityError)
+    expect(badRequest.statusCode).toBe(400)
+    expect(local.statusCode).toBeUndefined()
+  })
+
+  it('is not produced by status-code classification', () => {
+    expect(errorClassFromStatusCode(400)).not.toBe(DaytonaInvalidArgumentError)
+  })
+})
+
+describe('DaytonaConnectionTimeoutError legacy timeout compatibility', () => {
+  it('matches DaytonaTimeoutError as well as DaytonaConnectionError', () => {
+    const err = new DaytonaConnectionTimeoutError('Operation timed out')
+    expect(err).toBeInstanceOf(DaytonaTimeoutError)
+    expect(err).toBeInstanceOf(DaytonaConnectionError)
+    expect(err).toBeInstanceOf(DaytonaError)
+  })
+
+  it('does not make plain connection errors look like timeouts', () => {
+    expect(new DaytonaConnectionError('ECONNREFUSED')).not.toBeInstanceOf(DaytonaTimeoutError)
+  })
+
+  it('does not leak the widened match into DaytonaTimeoutError subclasses', () => {
+    const err = new DaytonaConnectionTimeoutError('Operation timed out')
+    expect(err).not.toBeInstanceOf(DaytonaProcessExecutionTimeoutError)
+  })
+
+  it('leaves ordinary timeout classification untouched', () => {
+    const err = createDaytonaError('gateway timed out', 504)
+    expect(err).toBeInstanceOf(DaytonaTimeoutError)
+    expect(err).not.toBeInstanceOf(DaytonaConnectionError)
+
+    const processTimeout = createDaytonaError('too slow', 408, undefined, 'PROCESS_EXECUTION_TIMEOUT', 'DAYTONA_DAEMON')
+    expect(processTimeout).toBeInstanceOf(DaytonaProcessExecutionTimeoutError)
+    expect(processTimeout).toBeInstanceOf(DaytonaTimeoutError)
   })
 })
 
@@ -111,6 +178,20 @@ describe('Domain code classification with status-class inheritance', () => {
     const err = createDaytonaError('a11y bus down', 503, undefined, 'A11Y_UNAVAILABLE', 'DAYTONA_DAEMON')
     expect(err).toBeInstanceOf(DaytonaA11yUnavailableError)
     expect(err).toBeInstanceOf(DaytonaServiceUnavailableError)
+  })
+
+  it('daemon INVALID_FILE_PATH inherits from DaytonaBadRequestError', () => {
+    const err = createDaytonaError('invalid file path: ..', 400, undefined, 'INVALID_FILE_PATH', 'DAYTONA_DAEMON')
+    expect(err).toBeInstanceOf(DaytonaInvalidFilePathError)
+    expect(err).toBeInstanceOf(DaytonaBadRequestError)
+    expect(err.code).toBe('INVALID_FILE_PATH')
+  })
+
+  it('daemon FILE_READ_FAILED inherits from DaytonaInternalServerError', () => {
+    const err = createDaytonaError('failed to access file', 500, undefined, 'FILE_READ_FAILED', 'DAYTONA_DAEMON')
+    expect(err).toBeInstanceOf(DaytonaFileReadFailedError)
+    expect(err).toBeInstanceOf(DaytonaInternalServerError)
+    expect(err.code).toBe('FILE_READ_FAILED')
   })
 
   it('falls back to status class when (source, code) is unknown', () => {

--- a/sdk-typescript/src/__tests__/LspServer.test.ts
+++ b/sdk-typescript/src/__tests__/LspServer.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createApiResponse } from './helpers'
-import { DaytonaValidationError } from '../errors/DaytonaError'
+import { DaytonaInvalidArgumentError } from '../errors/DaytonaError'
 
 jest.mock('@daytona/toolbox-api-client', () => ({}), { virtual: true })
 
@@ -30,7 +30,7 @@ describe('LspServer', () => {
     const { LspServer } = await import('../LspServer')
 
     expect(() => new LspServer('rust' as never, '/workspace/project', apiClient as never)).toThrow(
-      DaytonaValidationError,
+      DaytonaInvalidArgumentError,
     )
     expect(() => new LspServer('rust' as never, '/workspace/project', apiClient as never)).toThrow(
       'Invalid languageId: rust. Supported values are: python, typescript, javascript',

--- a/sdk-typescript/src/errors/DaytonaError.ts
+++ b/sdk-typescript/src/errors/DaytonaError.ts
@@ -63,8 +63,26 @@ export class DaytonaAuthenticationError extends DaytonaError {}
 export class DaytonaForbiddenError extends DaytonaError {}
 /** The requested resource does not exist (HTTP 404). */
 export class DaytonaNotFoundError extends DaytonaError {}
-/** The operation timed out (HTTP 408, or 504 when a gateway timed out). */
-export class DaytonaTimeoutError extends DaytonaError {}
+/**
+ * The operation timed out (HTTP 408, or 504 when a gateway timed out).
+ *
+ * Also matches {@link DaytonaConnectionTimeoutError} via `instanceof`, even
+ * though that class sits under {@link DaytonaConnectionError} in the prototype
+ * chain. Transport timeouts were raised as `DaytonaTimeoutError` before
+ * `DaytonaConnectionTimeoutError` existed, so this keeps pre-existing
+ * `catch (err) { if (err instanceof DaytonaTimeoutError) ... }` blocks working
+ * — the same compatibility the Python SDK gets from inheriting both classes.
+ */
+export class DaytonaTimeoutError extends DaytonaError {
+  static [Symbol.hasInstance](value: unknown): boolean {
+    // Only the base class widens; subclasses (e.g. ProcessExecutionTimeout)
+    // must keep exact prototype-chain semantics.
+    if (this === DaytonaTimeoutError && value instanceof DaytonaConnectionTimeoutError) {
+      return true
+    }
+    return Function.prototype[Symbol.hasInstance].call(this, value)
+  }
+}
 /** The request conflicts with the current state of the resource (HTTP 409). */
 export class DaytonaConflictError extends DaytonaError {}
 /** The resource existed but is permanently gone (HTTP 410). */
@@ -91,9 +109,17 @@ export class DaytonaServiceUnavailableError extends DaytonaError {}
 // ============================================================================
 
 /**
- * @deprecated Use {@link DaytonaBadRequestError} instead. Re-exported so
- * existing `catch (err) { if (err instanceof DaytonaValidationError) ... }`
- * blocks keep working.
+ * Legacy umbrella for validation failures. Kept so existing
+ * `catch (err) { if (err instanceof DaytonaValidationError) ... }` blocks keep
+ * matching both server-returned HTTP 400s and locally rejected arguments.
+ *
+ * @deprecated Do not throw or catch this directly in new code. Branch on the
+ * precise class instead:
+ * - {@link DaytonaInvalidArgumentError} — the SDK rejected your arguments
+ *   locally, before any request was sent.
+ * - {@link DaytonaBadRequestError} — a Daytona service returned HTTP 400.
+ * - {@link DaytonaUnprocessableEntityError} — a Daytona service returned
+ *   HTTP 422 (well-formed but semantically invalid).
  */
 export class DaytonaValidationError extends DaytonaBadRequestError {}
 
@@ -101,6 +127,33 @@ export class DaytonaValidationError extends DaytonaBadRequestError {}
  * @deprecated Use {@link DaytonaForbiddenError} instead.
  */
 export class DaytonaAuthorizationError extends DaytonaForbiddenError {}
+
+// Not part of the deprecated set above. It extends DaytonaValidationError only
+// so pre-existing `instanceof DaytonaValidationError` / `DaytonaBadRequestError`
+// catches keep matching local argument rejections; reparent it directly onto
+// DaytonaError in the next major.
+
+/**
+ * The SDK rejected the caller's arguments locally, before any request was
+ * sent. `statusCode`, `code` and `source` are always `undefined` — no Daytona
+ * service was contacted, so there is no HTTP status to report.
+ *
+ * Distinct from {@link DaytonaBadRequestError} (a service returned HTTP 400)
+ * and {@link DaytonaUnprocessableEntityError} (a service returned HTTP 422).
+ * This one always means: fix the arguments at the call site.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await sandbox.setAutoStopInterval(-1)
+ * } catch (err) {
+ *   if (err instanceof DaytonaInvalidArgumentError) {
+ *     // never reached the API — the value itself is invalid
+ *   }
+ * }
+ * ```
+ */
+export class DaytonaInvalidArgumentError extends DaytonaValidationError {}
 
 /** Network connection failure (can't connect or mid-request drop). */
 export class DaytonaConnectionError extends DaytonaError {}
@@ -131,6 +184,10 @@ export class DaytonaGitMergeConflictError extends DaytonaConflictError {}
 export class DaytonaFileNotFoundError extends DaytonaNotFoundError {}
 /** Access to the sandbox file was denied (code `FILE_ACCESS_DENIED`). */
 export class DaytonaFileAccessDeniedError extends DaytonaForbiddenError {}
+/** The supplied file path was rejected by the daemon (code `INVALID_FILE_PATH`). */
+export class DaytonaInvalidFilePathError extends DaytonaBadRequestError {}
+/** The daemon could not read the sandbox file (code `FILE_READ_FAILED`). */
+export class DaytonaFileReadFailedError extends DaytonaInternalServerError {}
 
 // --- LSP (daemon) ---
 /** The LSP server must be initialized first (code `LSP_SERVER_NOT_INITIALIZED`). */
@@ -160,7 +217,9 @@ export class DaytonaRecordingFfmpegNotFoundError extends DaytonaServiceUnavailab
  *
  * Code strings are kept inline (not imported from the generated clients) so
  * tests that virtual-mock the API client modules don't break module init.
- * Drift is caught by the cross-language code-catalog generator + CI checks.
+ *
+ * There is currently NO automated drift check against the daemon's
+ * `DaemonErrorCode` enum — keep this map in sync by hand when codes are added.
  */
 const CODE_TO_ERROR_CLASS: Record<string, typeof DaytonaError> = {
   // Daemon
@@ -173,6 +232,8 @@ const CODE_TO_ERROR_CLASS: Record<string, typeof DaytonaError> = {
   'DAYTONA_DAEMON|GIT_MERGE_CONFLICT': DaytonaGitMergeConflictError,
   'DAYTONA_DAEMON|FILE_NOT_FOUND': DaytonaFileNotFoundError,
   'DAYTONA_DAEMON|FILE_ACCESS_DENIED': DaytonaFileAccessDeniedError,
+  'DAYTONA_DAEMON|INVALID_FILE_PATH': DaytonaInvalidFilePathError,
+  'DAYTONA_DAEMON|FILE_READ_FAILED': DaytonaFileReadFailedError,
   'DAYTONA_DAEMON|LSP_SERVER_NOT_INITIALIZED': DaytonaLspServerNotInitializedError,
   'DAYTONA_DAEMON|PROCESS_EXECUTION_TIMEOUT': DaytonaProcessExecutionTimeoutError,
   'DAYTONA_DAEMON|PROCESS_NOT_FOUND': DaytonaProcessNotFoundError,

--- a/sdk-typescript/src/index.ts
+++ b/sdk-typescript/src/index.ts
@@ -40,6 +40,8 @@ export {
   // Base + status-code classes
   DaytonaError,
   DaytonaBadRequestError,
+  // Client-side (pre-flight) argument validation
+  DaytonaInvalidArgumentError,
   // Deprecated aliases
   DaytonaValidationError,
   DaytonaAuthenticationError,
@@ -67,6 +69,8 @@ export {
   DaytonaGitMergeConflictError,
   DaytonaFileNotFoundError,
   DaytonaFileAccessDeniedError,
+  DaytonaInvalidFilePathError,
+  DaytonaFileReadFailedError,
   DaytonaLspServerNotInitializedError,
   DaytonaProcessExecutionTimeoutError,
   DaytonaProcessNotFoundError,


### PR DESCRIPTION
## Summary

Separates **client-side argument validation** from **server-returned HTTP 400**
in the TypeScript SDK, and repairs a silent backward-compatibility break in
transport-timeout classification. No breaking changes.

## Why

`DaytonaValidationError` was deprecated as "an old name for
`DaytonaBadRequestError`", but ~49 call sites throw it for *preflight* argument
validation — before any request is sent, with `statusCode`/`code`/`source` all
`undefined`. That made "you passed a bad argument" indistinguishable from "the
server rejected your request", and pointed users at an HTTP-status class for
something that never touched the network. The defect was **type identity**, not
metadata.

## Changes

**New `DaytonaInvalidArgumentError`** — thrown for local argument rejection only.
Retargeted all local throws in `Daytona.ts`, `Image.ts`, `Sandbox.ts`,
`LspServer.ts`, `CodeInterpreter.ts`. Named to match Go's `ErrInvalidArgument`,
Java's `IllegalArgumentException` and gRPC's `INVALID_ARGUMENT`; "Validation" was
avoided as the anchor because it already means 400 in TS/Python/Ruby/Go but 422
in Java.

**Fixed transport-timeout regression.** Before the typed-error refactor, axios
timeouts were raised as `DaytonaTimeoutError`. Afterwards they became
`DaytonaConnectionTimeoutError`, which extends `DaytonaConnectionError` only — so
`catch (e) { if (e instanceof DaytonaTimeoutError) }` silently stopped matching.
The Python SDK avoided this by inheriting both classes; TS had no equivalent.
Restored via a static `Symbol.hasInstance` on `DaytonaTimeoutError`, guarded so
subclasses keep exact prototype-chain semantics.

**Added two missing daemon error codes.** `INVALID_FILE_PATH` →
`DaytonaInvalidFilePathError` (400) and `FILE_READ_FAILED` →
`DaytonaFileReadFailedError` (500). Both are in the daemon's `DaemonErrorCode`
enum and emitted from `download_files.go`, but were absent from every SDK.

**Corrected a false comment** claiming drift was caught by "the cross-language
code-catalog generator + CI checks" — no such generator or check exists, which is
how the two codes above went unnoticed.

## Compatibility

Every change is strictly widening:

- `DaytonaInvalidArgumentError` extends `DaytonaValidationError`, so existing
  `instanceof DaytonaValidationError` / `DaytonaBadRequestError` catches still match.
- `STATUS_CODE_TO_ERROR[400]` intentionally still maps to `DaytonaValidationError`
  to preserve legacy matching for remote 400s.
- Connection timeouts now match `DaytonaTimeoutError` **in addition to**
  `DaytonaConnectionError`.

Audited every pre-refactor error class for the same class of break; the timeout
case was the only one.

## New catch ladder

```ts
catch (e) {
  if (e instanceof DaytonaInvalidArgumentError) {}      // fix your arguments — no request was sent
  else if (e instanceof DaytonaUnprocessableEntityError) {} // server: semantically invalid (422)
  else if (e instanceof DaytonaBadRequestError) {}      // server: malformed request (400)
}

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates client-side argument errors from server 400s in the TypeScript SDK and restores legacy timeout matching for connection timeouts. Adds missing daemon error codes and updates docs and tests; no breaking changes.

- New Features
  - New `DaytonaInvalidArgumentError` for local preflight validation (no request sent). Replaces previous local throws across the SDK and remains compatible by extending `DaytonaValidationError`; exported from `sdk-typescript` index.
  - Added mappings for daemon codes: `INVALID_FILE_PATH` → `DaytonaInvalidFilePathError` (400), `FILE_READ_FAILED` → `DaytonaFileReadFailedError` (500).

- Bug Fixes
  - Restored timeout compatibility: `DaytonaConnectionTimeoutError` now matches `instanceof DaytonaTimeoutError` (via `Symbol.hasInstance`) so existing catch blocks continue to work.
  - Removed a misleading comment about non-existent cross-language code-catalog checks.

<sup>Written for commit f46d38a52434bdeca0d35e25337457d6f57e8842. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

