### PR TITLE
fix(sdk-python): replace deprecated asyncio.iscoroutinefunction with inspect.iscoroutinefunction

### DIFF
--- a/sdk-python/src/daytona/_async/sandbox.py
+++ b/sdk-python/src/daytona/_async/sandbox.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import inspect
 import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
@@ -85,7 +86,7 @@ def with_events(cls: _T) -> _T:
         if not callable(method):
             continue
 
-        if asyncio.iscoroutinefunction(method):
+        if inspect.iscoroutinefunction(method):
 
             @functools.wraps(method)
             async def async_wrapper(self: Any, *args: Any, _m: Any = method, **kwargs: Any) -> Any:

--- a/sdk-python/src/daytona/_utils/otel_decorator.py
+++ b/sdk-python/src/daytona/_utils/otel_decorator.py
@@ -3,7 +3,6 @@
 
 """OpenTelemetry instrumentation decorators for tracing and metrics."""
 
-import asyncio
 import functools
 import inspect
 import time
@@ -119,7 +118,7 @@ def with_span(
 
             return cast(F, sync_gen_wrapper)
 
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
 
             @functools.wraps(func)
             async def async_wrapper(*args: object, **kwargs: object) -> object:
@@ -246,7 +245,7 @@ def with_metric(
 
             return cast(F, sync_gen_wrapper)
 
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
 
             @functools.wraps(func)
             async def async_wrapper(*args, **kwargs):


### PR DESCRIPTION
## Summary

On Python 3.14, `asyncio.iscoroutinefunction` emits a `DeprecationWarning`
(slated for removal in Python 3.16). Users running the SDK on 3.14 see this
warning spammed in their test output (reported by a customer — fired 122×
from `otel_decorator.py` alone).

This replaces the remaining `asyncio.iscoroutinefunction` call sites with
`inspect.iscoroutinefunction`, which is the documented replacement and a
strict behavioral superset since Python 3.12.

## Changes

- `sdk-python/src/daytona/_utils/otel_decorator.py` — 2 call sites, removed now-unused `import asyncio`
- `sdk-python/src/daytona/_async/sandbox.py` — 1 call site in the `with_events` decorator

All other call sites (`errors.py`, `timeout.py`, `_async/filesystem.py`) already used `inspect`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction` to stop DeprecationWarning spam on Python 3.14 and prepare for removal in 3.16. Updated call sites in `sdk-python/src/daytona/_utils/otel_decorator.py` and `sdk-python/src/daytona/_async/sandbox.py`, and removed an unused `asyncio` import.

<sup>Written for commit e45d4487669e41d595e9fcd7e611af9687c2911e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

