### PR TITLE
feat(typescript): add DaytonaConfig.requestTimeoutMs client-side HTTP timeout

### DIFF
--- a/artifacts/sdk-docs/typescript-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/daytona.mdx
@@ -496,6 +496,16 @@ Configuration options for initializing the Daytona client.
     is provided, and must be set either here or in the environment variable `DAYTONA_ORGANIZATION_ID`.
 - `otelEnabled?` _boolean_ - OpenTelemetry tracing enabled.
     If set, all SDK operations will be traced.
+- `requestTimeoutMs?` _number_ - Maximum time in milliseconds the SDK waits for a single HTTP response before
+    failing the request. Applies to the Daytona API client and to the toolbox
+    clients of every Sandbox obtained from this Daytona instance. Defaults to
+    24 hours; `0` disables the deadline.
+    
+    This is a client-side deadline only — it does not cancel the operation on
+    the server. Calls that carry their own operation or execution timeout
+    (e.g. `create`, `start`, `stop`, `fork`, `process.executeCommand`,
+    `process.codeRun`) are not capped by this value; their HTTP wait is
+    bounded by that per-call timeout instead.
 - ~~`serverUrl?`~~ _string_ - **_Deprecated_** - Use `apiUrl` instead. This property will be removed in future versions.
 - `target?` _string_ - Target location for Sandboxes
 - ~~`useDeprecatedPolling?`~~ _boolean_ - Observe sandbox state by legacy polling instead of WebSocket event streaming.

--- a/artifacts/sdk-docs/typescript-sdk/process.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/process.mdx
@@ -41,7 +41,8 @@ new Process(
    clientConfig: Configuration, 
    apiClient: ProcessApi, 
    getPreviewToken: () => Promise<string>, 
-   language?: string): Process
+   language?: string, 
+   requestTimeoutMs?: number): Process
 ```
 
 **Parameters**:
@@ -50,6 +51,7 @@ new Process(
 - `apiClient` _ProcessApi_
 - `getPreviewToken` _\(\) =\> Promise\<string\>_
 - `language?` _string_
+- `requestTimeoutMs?` _number_
 
 
 **Returns**:

--- a/artifacts/sdk-docs/typescript-sdk/process.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/process.mdx
@@ -73,7 +73,9 @@ Executes code in the Sandbox using the appropriate language runtime.
 
 - `code` _string_ - Code to execute
 - `params?` _CodeRunParams_ - Parameters for code execution
-- `timeout?` _number_ - Maximum time in seconds to wait for execution to complete
+- `timeout?` _number_ - Maximum time in seconds to wait for execution to complete. The execution is
+    terminated when it elapses. The HTTP request waits for the full timeout, even beyond
+    the client-wide `requestTimeoutMs`; `0` disables the server-side limit.
 
 
 **Returns**:
@@ -319,7 +321,9 @@ Executes a shell command in the Sandbox.
 - `command` _string_ - Shell command to execute
 - `cwd?` _string_ - Working directory for command execution. If not specified, uses the sandbox working directory.
 - `env?` _Record\<string, string\>_ - Environment variables to set for the command
-- `timeout?` _number_ - Maximum time in seconds to wait for the command to complete.
+- `timeout?` _number_ - Maximum time in seconds to wait for the command to complete. The command is
+    terminated when it elapses. The HTTP request waits for the full timeout, even beyond
+    the client-wide `requestTimeoutMs`; `0` disables the server-side limit.
 
 
 **Returns**:

--- a/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
@@ -73,7 +73,8 @@ new Sandbox(
    axiosInstance: AxiosInstance, 
    sandboxApi: SandboxApi, 
    getAnalyticsApiUrl: () => Promise<string>, 
-   subscriptionManager: EventSubscriptionManager): Sandbox
+   subscriptionManager: EventSubscriptionManager, 
+   requestTimeoutMs?: number): Sandbox
 ```
 
 Creates a new Sandbox instance.
@@ -89,6 +90,7 @@ Daytona.list rather than constructing directly.
 - `sandboxApi` _SandboxApi_ - API client for Sandbox operations
 - `getAnalyticsApiUrl` _\(\) =\> Promise\<string\>_
 - `subscriptionManager` _EventSubscriptionManager_ - Event subscription manager for real-time updates
+- `requestTimeoutMs?` _number_
 
 
 **Returns**:

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -748,6 +748,7 @@ export class Daytona implements AsyncDisposable {
         this.sandboxApi,
         this.getAnalyticsApiUrl,
         this.eventSubscriptionManager,
+        this.requestTimeoutMs,
       )
 
       if (sandbox.state !== 'started') {
@@ -790,6 +791,7 @@ export class Daytona implements AsyncDisposable {
       this.sandboxApi,
       this.getAnalyticsApiUrl,
       this.eventSubscriptionManager,
+      this.requestTimeoutMs,
     )
   }
 
@@ -889,6 +891,7 @@ export class Daytona implements AsyncDisposable {
             sandboxApi,
             getAnalyticsApiUrl,
             eventSubscriptionManager,
+            requestTimeoutMs,
           )
         }
 

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -44,6 +44,8 @@ import type { NodeSDK } from '@opentelemetry/sdk-node'
 
 export const CODE_TOOLBOX_LANGUAGE_LABEL = 'code-toolbox-language'
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 24 * 60 * 60 * 1000
+
 /**
  * Represents a volume mount for a Sandbox.
  *
@@ -108,6 +110,19 @@ export interface DaytonaConfig {
    * WebSockets are unavailable.
    */
   useDeprecatedPolling?: boolean
+  /**
+   * Maximum time in milliseconds the SDK waits for a single HTTP response before
+   * failing the request. Applies to the Daytona API client and to the toolbox
+   * clients of every Sandbox obtained from this Daytona instance. Defaults to
+   * 24 hours; `0` disables the deadline.
+   *
+   * This is a client-side deadline only — it does not cancel the operation on
+   * the server. Calls that carry their own operation or execution timeout
+   * (e.g. `create`, `start`, `stop`, `fork`, `process.executeCommand`,
+   * `process.codeRun`) are not capped by this value; their HTTP wait is
+   * bounded by that per-call timeout instead.
+   */
+  requestTimeoutMs?: number
   /** Configuration for experimental features */
   _experimental?: Record<string, any>
 }
@@ -287,6 +302,7 @@ export class Daytona implements AsyncDisposable {
   private readonly jwtToken?: string
   private readonly organizationId?: string
   private readonly apiUrl: string
+  private readonly requestTimeoutMs?: number
   private otelSdk?: NodeSDK
   private eventDispatcher?: EventDispatcher
   private eventSubscriptionManager: EventSubscriptionManager
@@ -309,6 +325,13 @@ export class Daytona implements AsyncDisposable {
       this.organizationId = config?.organizationId
       apiUrl = config?.apiUrl || config?.serverUrl
       this.target = config?.target
+      if (
+        config?.requestTimeoutMs !== undefined &&
+        (!Number.isFinite(config.requestTimeoutMs) || config.requestTimeoutMs < 0)
+      ) {
+        throw new DaytonaInvalidArgumentError('requestTimeoutMs must be a non-negative finite number of milliseconds')
+      }
+      this.requestTimeoutMs = config?.requestTimeoutMs
     }
 
     let _envReader: DaytonaEnvReader | null | undefined
@@ -375,7 +398,7 @@ export class Daytona implements AsyncDisposable {
       },
     })
 
-    const axiosInstance = Daytona.createAxiosInstance()
+    const axiosInstance = Daytona.createAxiosInstance(this.requestTimeoutMs)
 
     this.sandboxApi = new SandboxApi(configuration, '', axiosInstance)
     this.objectStorageApi = new ObjectStorageApi(configuration, '', axiosInstance)
@@ -721,7 +744,7 @@ export class Daytona implements AsyncDisposable {
       const sandbox = new Sandbox(
         await this.ensureToolboxProxyUrl(sandboxInstance),
         new Configuration(structuredClone(this.clientConfig)),
-        Daytona.createAxiosInstance(),
+        Daytona.createAxiosInstance(this.requestTimeoutMs),
         this.sandboxApi,
         this.getAnalyticsApiUrl,
         this.eventSubscriptionManager,
@@ -763,7 +786,7 @@ export class Daytona implements AsyncDisposable {
     return new Sandbox(
       sandboxInstance,
       structuredClone(this.clientConfig),
-      Daytona.createAxiosInstance(),
+      Daytona.createAxiosInstance(this.requestTimeoutMs),
       this.sandboxApi,
       this.getAnalyticsApiUrl,
       this.eventSubscriptionManager,
@@ -782,7 +805,7 @@ export class Daytona implements AsyncDisposable {
    * }
    */
   public list(query?: ListSandboxesQuery): AsyncIterableIterator<Sandbox> {
-    const { sandboxApi, clientConfig, eventSubscriptionManager } = this
+    const { sandboxApi, clientConfig, eventSubscriptionManager, requestTimeoutMs } = this
     const getAnalyticsApiUrl = this.getAnalyticsApiUrl
     const ensureToolboxProxyUrl = this.ensureToolboxProxyUrl.bind(this)
     const tracer = trace.getTracer('')
@@ -862,7 +885,7 @@ export class Daytona implements AsyncDisposable {
           yield new Sandbox(
             hydratedSandbox,
             structuredClone(clientConfig),
-            Daytona.createAxiosInstance(),
+            Daytona.createAxiosInstance(requestTimeoutMs),
             sandboxApi,
             getAnalyticsApiUrl,
             eventSubscriptionManager,
@@ -970,9 +993,9 @@ export class Daytona implements AsyncDisposable {
   /**
    * @hidden
    */
-  public static createAxiosInstance(): AxiosInstance {
+  public static createAxiosInstance(requestTimeoutMs?: number): AxiosInstance {
     const axiosInstance = axios.create({
-      timeout: 24 * 60 * 60 * 1000, // 24 hours
+      timeout: requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     })
 
     // Request interceptor: Inject trace context into headers

--- a/sdk-typescript/src/Process.ts
+++ b/sdk-typescript/src/Process.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { RawAxiosRequestConfig } from 'axios'
 import { Configuration, ProcessApi } from '@daytona/toolbox-api-client'
 import type {
   Command,
@@ -29,6 +30,21 @@ export const MAX_PREFIX_LEN = Math.max(STDOUT_PREFIX_BYTES.length, STDERR_PREFIX
 // Capability token advertised on PTY WebSocket connects so the daemon sends the
 // "exited" control message; clients that don't send it only get the close frame.
 const PTY_EXIT_CONTROL_SUBPROTOCOL = 'X-Daytona-Pty-Exit-Control'
+
+// Pads the per-request HTTP deadline over the server-side execution timeout,
+// mirroring Go's execContext (timeout + 5s) and Python's `_request_timeout = timeout + 5`.
+const EXEC_TIMEOUT_BUFFER_MS = 5000
+
+// With an explicit execution timeout the HTTP wait must not be capped by the
+// client-wide timeout (DaytonaConfig.requestTimeoutMs): the request is bounded
+// by the execution timeout + buffer instead. A non-positive timeout leaves the
+// wait uncapped (0 disables the server-side limit; negatives fail fast at the API).
+function execRequestOptions(timeout?: number): RawAxiosRequestConfig | undefined {
+  if (timeout === undefined) {
+    return undefined
+  }
+  return { timeout: timeout > 0 ? timeout * 1000 + EXEC_TIMEOUT_BUFFER_MS : 0 }
+}
 
 /**
  * Parameters for code execution.
@@ -74,7 +90,9 @@ export class Process {
    * @param {string} command - Shell command to execute
    * @param {string} [cwd] - Working directory for command execution. If not specified, uses the sandbox working directory.
    * @param {Record<string, string>} [env] - Environment variables to set for the command
-   * @param {number} [timeout] - Maximum time in seconds to wait for the command to complete.
+   * @param {number} [timeout] - Maximum time in seconds to wait for the command to complete. The command is
+   *                             terminated when it elapses. The HTTP request waits for the full timeout, even beyond
+   *                             the client-wide `requestTimeoutMs`; `0` disables the server-side limit.
    * @returns {Promise<ExecuteResponse>} Command execution results containing:
    *                                    - exitCode: The command's exit status
    *                                    - result: Standard output from the command
@@ -100,12 +118,15 @@ export class Process {
     env?: Record<string, string>,
     timeout?: number,
   ): Promise<ExecuteResponse> {
-    const response = await this.apiClient.executeCommand({
-      command,
-      timeout,
-      cwd: cwd,
-      envs: env && Object.keys(env).length ? env : undefined,
-    })
+    const response = await this.apiClient.executeCommand(
+      {
+        command,
+        timeout,
+        cwd: cwd,
+        envs: env && Object.keys(env).length ? env : undefined,
+      },
+      execRequestOptions(timeout),
+    )
 
     const result = response.data.result ?? ''
     return {
@@ -122,7 +143,9 @@ export class Process {
    *
    * @param {string} code - Code to execute
    * @param {CodeRunParams} params - Parameters for code execution
-   * @param {number} [timeout] - Maximum time in seconds to wait for execution to complete
+   * @param {number} [timeout] - Maximum time in seconds to wait for execution to complete. The execution is
+   *                             terminated when it elapses. The HTTP request waits for the full timeout, even beyond
+   *                             the client-wide `requestTimeoutMs`; `0` disables the server-side limit.
    * @returns {Promise<ExecuteResponse>} Code execution results containing:
    *                                    - exitCode: The execution's exit status
    *                                    - result: Standard output from the code
@@ -188,7 +211,7 @@ export class Process {
       envs: params?.env,
       timeout,
     }
-    const response = await this.apiClient.codeRun(request)
+    const response = await this.apiClient.codeRun(request, execRequestOptions(timeout))
     const data = response.data
 
     const charts = data.artifacts?.charts?.map(parseChart) ?? []

--- a/sdk-typescript/src/Process.ts
+++ b/sdk-typescript/src/Process.ts
@@ -35,17 +35,6 @@ const PTY_EXIT_CONTROL_SUBPROTOCOL = 'X-Daytona-Pty-Exit-Control'
 // mirroring Go's execContext (timeout + 5s) and Python's `_request_timeout = timeout + 5`.
 const EXEC_TIMEOUT_BUFFER_MS = 5000
 
-// With an explicit execution timeout the HTTP wait must not be capped by the
-// client-wide timeout (DaytonaConfig.requestTimeoutMs): the request is bounded
-// by the execution timeout + buffer instead. A non-positive timeout leaves the
-// wait uncapped (0 disables the server-side limit; negatives fail fast at the API).
-function execRequestOptions(timeout?: number): RawAxiosRequestConfig | undefined {
-  if (timeout === undefined) {
-    return undefined
-  }
-  return { timeout: timeout > 0 ? timeout * 1000 + EXEC_TIMEOUT_BUFFER_MS : 0 }
-}
-
 /**
  * Parameters for code execution.
  */
@@ -82,7 +71,21 @@ export class Process {
     private readonly apiClient: ProcessApi,
     private readonly getPreviewToken: () => Promise<string>,
     private readonly language?: string,
+    private readonly requestTimeoutMs?: number,
   ) {}
+
+  // With an explicit execution timeout the HTTP wait must not be capped by a
+  // configured bounded DaytonaConfig.requestTimeoutMs: the request is bounded by
+  // the execution timeout + buffer instead. A non-positive execution timeout
+  // leaves the wait uncapped (0 disables the server-side limit; negatives fail
+  // fast at the API). Without a configured positive requestTimeoutMs no override
+  // is applied, preserving the client-wide default deadline as-is.
+  private execRequestOptions(timeout?: number): RawAxiosRequestConfig | undefined {
+    if (timeout === undefined || this.requestTimeoutMs === undefined || this.requestTimeoutMs <= 0) {
+      return undefined
+    }
+    return { timeout: timeout > 0 ? timeout * 1000 + EXEC_TIMEOUT_BUFFER_MS : 0 }
+  }
 
   /**
    * Executes a shell command in the Sandbox.
@@ -125,7 +128,7 @@ export class Process {
         cwd: cwd,
         envs: env && Object.keys(env).length ? env : undefined,
       },
-      execRequestOptions(timeout),
+      this.execRequestOptions(timeout),
     )
 
     const result = response.data.result ?? ''
@@ -211,7 +214,7 @@ export class Process {
       envs: params?.env,
       timeout,
     }
-    const response = await this.apiClient.codeRun(request, execRequestOptions(timeout))
+    const response = await this.apiClient.codeRun(request, this.execRequestOptions(timeout))
     const data = response.data
 
     const charts = data.artifacts?.charts?.map(parseChart) ?? []

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -296,7 +296,11 @@ export class Sandbox {
       basePath: analyticsApiUrl,
       apiKey: this.clientConfig.baseOptions?.headers?.Authorization,
     })
-    return new AnalyticsTelemetryApi(analyticsConfig, undefined, Daytona.createAxiosInstance())
+    return new AnalyticsTelemetryApi(
+      analyticsConfig,
+      undefined,
+      Daytona.createAxiosInstance(this.axiosInstance.defaults.timeout),
+    )
   }
 
   /**
@@ -496,7 +500,7 @@ export class Sandbox {
     const forkedSandbox = new Sandbox(
       sandboxWithProxyUrl,
       structuredClone(this.clientConfig),
-      Daytona.createAxiosInstance(),
+      Daytona.createAxiosInstance(this.axiosInstance.defaults.timeout),
       this.sandboxApi,
       this.getAnalyticsApiUrl,
       this.subscriptionManager,

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -194,6 +194,7 @@ export class Sandbox {
     private readonly sandboxApi: SandboxApi,
     private readonly getAnalyticsApiUrl: () => Promise<string | undefined>,
     private readonly subscriptionManager: EventSubscriptionManager,
+    private readonly requestTimeoutMs?: number,
   ) {
     this.processSandboxDto(sandboxDto)
 
@@ -207,6 +208,7 @@ export class Sandbox {
       new ProcessApi(this.clientConfig, '', this.axiosInstance),
       getPreviewToken,
       language,
+      this.requestTimeoutMs,
     )
     this.codeInterpreter = new CodeInterpreter(
       this.clientConfig,
@@ -296,11 +298,7 @@ export class Sandbox {
       basePath: analyticsApiUrl,
       apiKey: this.clientConfig.baseOptions?.headers?.Authorization,
     })
-    return new AnalyticsTelemetryApi(
-      analyticsConfig,
-      undefined,
-      Daytona.createAxiosInstance(this.axiosInstance.defaults.timeout),
-    )
+    return new AnalyticsTelemetryApi(analyticsConfig, undefined, Daytona.createAxiosInstance(this.requestTimeoutMs))
   }
 
   /**
@@ -500,10 +498,11 @@ export class Sandbox {
     const forkedSandbox = new Sandbox(
       sandboxWithProxyUrl,
       structuredClone(this.clientConfig),
-      Daytona.createAxiosInstance(this.axiosInstance.defaults.timeout),
+      Daytona.createAxiosInstance(this.requestTimeoutMs),
       this.sandboxApi,
       this.getAnalyticsApiUrl,
       this.subscriptionManager,
+      this.requestTimeoutMs,
     )
 
     const timeElapsed = Date.now() - startTime

--- a/sdk-typescript/src/__tests__/Daytona.test.ts
+++ b/sdk-typescript/src/__tests__/Daytona.test.ts
@@ -216,6 +216,52 @@ describe('Daytona', () => {
     delete process.env.DAYTONA_USE_DEPRECATED_POLLING
   })
 
+  it('creates axios instances with the 24h default timeout when requestTimeoutMs is omitted', async () => {
+    const { Daytona } = await import('../Daytona')
+
+    new Daytona({ apiKey: 'k', apiUrl: 'http://api', target: 'us' })
+
+    expect(mockAxiosCreate).toHaveBeenCalledWith(expect.objectContaining({ timeout: 24 * 60 * 60 * 1000 }))
+  })
+
+  it('applies requestTimeoutMs to the API client axios instance', async () => {
+    const { Daytona } = await import('../Daytona')
+
+    new Daytona({ apiKey: 'k', apiUrl: 'http://api', target: 'us', requestTimeoutMs: 5000 })
+
+    expect(mockAxiosCreate).toHaveBeenCalledWith(expect.objectContaining({ timeout: 5000 }))
+  })
+
+  it('disables the HTTP timeout when requestTimeoutMs is 0', async () => {
+    const { Daytona } = await import('../Daytona')
+
+    new Daytona({ apiKey: 'k', apiUrl: 'http://api', target: 'us', requestTimeoutMs: 0 })
+
+    expect(mockAxiosCreate).toHaveBeenCalledWith(expect.objectContaining({ timeout: 0 }))
+  })
+
+  it.each([-1, Number.NaN, Number.POSITIVE_INFINITY])('rejects invalid requestTimeoutMs %p', async (value) => {
+    const { Daytona } = await import('../Daytona')
+
+    expect(() => new Daytona({ apiKey: 'k', apiUrl: 'http://api', target: 'us', requestTimeoutMs: value })).toThrow(
+      'requestTimeoutMs must be a non-negative finite number of milliseconds',
+    )
+  })
+
+  it('propagates requestTimeoutMs to sandbox toolbox axios instances', async () => {
+    const { Daytona } = await import('../Daytona')
+    const instance = new Daytona({ apiKey: 'k', apiUrl: 'http://api', target: 'us', requestTimeoutMs: 7000 })
+
+    mockSandboxApi.getSandbox.mockResolvedValue(
+      createApiResponse({ id: 'sb-timeout', state: 'started', toolboxProxyUrl: 'http://sandbox-proxy/' }),
+    )
+    mockAxiosCreate.mockClear()
+
+    await instance.get('sb-timeout')
+
+    expect(mockAxiosCreate).toHaveBeenCalledWith(expect.objectContaining({ timeout: 7000 }))
+  })
+
   it('reads constructor values from env when config omitted', async () => {
     process.env.DAYTONA_API_KEY = 'env-key'
     process.env.DAYTONA_API_URL = 'https://env.daytona/api'

--- a/sdk-typescript/src/__tests__/DaytonaError.test.ts
+++ b/sdk-typescript/src/__tests__/DaytonaError.test.ts
@@ -209,13 +209,26 @@ describe('Domain code classification with status-class inheritance', () => {
 
 describe('Axios error mapping', () => {
   it('classifies Axios timeouts as DaytonaConnectionTimeoutError', () => {
-    const error = new AxiosError('timeout of 1000ms exceeded', 'ECONNABORTED')
+    const error = new AxiosError('timeout of 1000ms exceeded', 'ECONNABORTED', { timeout: 1000 } as never)
 
     const daytonaError = createAxiosDaytonaError(error)
 
     expect(daytonaError).toBeInstanceOf(DaytonaConnectionTimeoutError)
     expect(daytonaError).toBeInstanceOf(DaytonaConnectionError)
-    expect(daytonaError.message).toBe('Operation timed out')
+    expect(daytonaError.message).toBe(
+      'HTTP request timed out after 1000ms waiting for a response. This is a client-side deadline' +
+        ' (DaytonaConfig.requestTimeoutMs, or the per-call operation/execution timeout); any operation' +
+        ' already started on the server may still be running.',
+    )
+  })
+
+  it('omits the deadline value when the request config carries no timeout', () => {
+    const error = new AxiosError('timeout of 0ms exceeded', 'ETIMEDOUT')
+
+    const daytonaError = createAxiosDaytonaError(error)
+
+    expect(daytonaError).toBeInstanceOf(DaytonaConnectionTimeoutError)
+    expect(daytonaError.message).toContain('HTTP request timed out waiting for a response')
   })
 
   it('classifies network failures without a response as DaytonaConnectionError', () => {

--- a/sdk-typescript/src/__tests__/Process.test.ts
+++ b/sdk-typescript/src/__tests__/Process.test.ts
@@ -33,7 +33,7 @@ jest.mock('../PtyHandle', () => ({
 }))
 
 describe('Process', () => {
-  const makeProcess = async (language = 'python') => {
+  const makeProcess = async (language = 'python', requestTimeoutMs?: number) => {
     const { Process } = await import('../Process')
     const apiClient = {
       executeCommand: jest.fn(),
@@ -60,7 +60,13 @@ describe('Process', () => {
       baseOptions: { headers: { Authorization: 'Bearer t' } },
     } as unknown as Configuration
 
-    const process = new Process(cfg, apiClient as unknown as never, async () => 'preview-token', language)
+    const process = new Process(
+      cfg,
+      apiClient as unknown as never,
+      async () => 'preview-token',
+      language,
+      requestTimeoutMs,
+    )
 
     return { process, apiClient }
   }
@@ -82,24 +88,48 @@ describe('Process', () => {
         cwd: '/tmp',
         envs: { GOOD_KEY: '1' },
       },
-      { timeout: 9000 },
+      undefined,
     )
   })
 
-  it('executeCommand without timeout leaves the client-wide HTTP timeout in effect', async () => {
+  it('executeCommand with exec timeout does not override the HTTP deadline when requestTimeoutMs is not configured', async () => {
     const { process, apiClient } = await makeProcess()
+
+    apiClient.executeCommand.mockResolvedValue(createApiResponse({ exitCode: 0, result: '' }))
+    await process.executeCommand('sleep 3', undefined, undefined, 4)
+    expect(apiClient.executeCommand).toHaveBeenCalledWith(expect.objectContaining({ timeout: 4 }), undefined)
+  })
+
+  it('executeCommand with exec timeout is not capped by a configured requestTimeoutMs', async () => {
+    const { process, apiClient } = await makeProcess('python', 5000)
+
+    apiClient.executeCommand.mockResolvedValue(createApiResponse({ exitCode: 0, result: '' }))
+    await process.executeCommand('sleep 3', undefined, undefined, 4)
+    expect(apiClient.executeCommand).toHaveBeenCalledWith(expect.objectContaining({ timeout: 4 }), { timeout: 9000 })
+  })
+
+  it('executeCommand without exec timeout leaves the configured requestTimeoutMs in effect', async () => {
+    const { process, apiClient } = await makeProcess('python', 5000)
 
     apiClient.executeCommand.mockResolvedValue(createApiResponse({ exitCode: 0, result: '' }))
     await process.executeCommand('ls')
     expect(apiClient.executeCommand).toHaveBeenCalledWith(expect.anything(), undefined)
   })
 
-  it('executeCommand with timeout 0 uncaps the HTTP wait', async () => {
-    const { process, apiClient } = await makeProcess()
+  it('executeCommand with exec timeout 0 uncaps the HTTP wait under a configured requestTimeoutMs', async () => {
+    const { process, apiClient } = await makeProcess('python', 5000)
 
     apiClient.executeCommand.mockResolvedValue(createApiResponse({ exitCode: 0, result: '' }))
     await process.executeCommand('sleep 100', undefined, undefined, 0)
     expect(apiClient.executeCommand).toHaveBeenCalledWith(expect.objectContaining({ timeout: 0 }), { timeout: 0 })
+  })
+
+  it('executeCommand applies no override when requestTimeoutMs is 0 (deadline already disabled)', async () => {
+    const { process, apiClient } = await makeProcess('python', 0)
+
+    apiClient.executeCommand.mockResolvedValue(createApiResponse({ exitCode: 0, result: '' }))
+    await process.executeCommand('sleep 3', undefined, undefined, 4)
+    expect(apiClient.executeCommand).toHaveBeenCalledWith(expect.anything(), undefined)
   })
 
   it('executeCommand omits envs when empty', async () => {
@@ -187,8 +217,15 @@ describe('Process', () => {
         envs: { NODE_ENV: 'test' },
         timeout: 10,
       },
-      { timeout: 15000 },
+      undefined,
     )
+  })
+
+  it('codeRun with exec timeout is not capped by a configured requestTimeoutMs', async () => {
+    const { process, apiClient } = await makeProcess('typescript', 5000)
+    apiClient.codeRun.mockResolvedValue(createApiResponse({ exitCode: 0, result: '', artifacts: {} }))
+    await process.codeRun('console.log(1)', undefined, 10)
+    expect(apiClient.codeRun).toHaveBeenCalledWith(expect.objectContaining({ timeout: 10 }), { timeout: 15000 })
   })
 
   it('codeRun throws when language not set', async () => {

--- a/sdk-typescript/src/__tests__/Process.test.ts
+++ b/sdk-typescript/src/__tests__/Process.test.ts
@@ -75,12 +75,31 @@ describe('Process', () => {
     apiClient.executeCommand.mockResolvedValue(createApiResponse({ exitCode: 0, result: 'hello' }))
     const result = await process.executeCommand('echo hi', '/tmp', { GOOD_KEY: '1' }, 4)
     expect(result).toMatchObject({ exitCode: 0, result: 'hello' })
-    expect(apiClient.executeCommand).toHaveBeenCalledWith({
-      command: 'echo hi',
-      timeout: 4,
-      cwd: '/tmp',
-      envs: { GOOD_KEY: '1' },
-    })
+    expect(apiClient.executeCommand).toHaveBeenCalledWith(
+      {
+        command: 'echo hi',
+        timeout: 4,
+        cwd: '/tmp',
+        envs: { GOOD_KEY: '1' },
+      },
+      { timeout: 9000 },
+    )
+  })
+
+  it('executeCommand without timeout leaves the client-wide HTTP timeout in effect', async () => {
+    const { process, apiClient } = await makeProcess()
+
+    apiClient.executeCommand.mockResolvedValue(createApiResponse({ exitCode: 0, result: '' }))
+    await process.executeCommand('ls')
+    expect(apiClient.executeCommand).toHaveBeenCalledWith(expect.anything(), undefined)
+  })
+
+  it('executeCommand with timeout 0 uncaps the HTTP wait', async () => {
+    const { process, apiClient } = await makeProcess()
+
+    apiClient.executeCommand.mockResolvedValue(createApiResponse({ exitCode: 0, result: '' }))
+    await process.executeCommand('sleep 100', undefined, undefined, 0)
+    expect(apiClient.executeCommand).toHaveBeenCalledWith(expect.objectContaining({ timeout: 0 }), { timeout: 0 })
   })
 
   it('executeCommand omits envs when empty', async () => {
@@ -88,12 +107,15 @@ describe('Process', () => {
 
     apiClient.executeCommand.mockResolvedValue(createApiResponse({ exitCode: 0, result: '' }))
     await process.executeCommand('ls')
-    expect(apiClient.executeCommand).toHaveBeenCalledWith({
-      command: 'ls',
-      timeout: undefined,
-      cwd: undefined,
-      envs: undefined,
-    })
+    expect(apiClient.executeCommand).toHaveBeenCalledWith(
+      {
+        command: 'ls',
+        timeout: undefined,
+        cwd: undefined,
+        envs: undefined,
+      },
+      undefined,
+    )
   })
 
   it('executeCommand returns artifacts with stdout', async () => {
@@ -122,13 +144,16 @@ describe('Process', () => {
     const result = await process.codeRun('print(1)')
     expect(result.exitCode).toBe(0)
     expect(result.result).toBe('ok')
-    expect(apiClient.codeRun).toHaveBeenCalledWith({
-      code: 'print(1)',
-      language: 'python',
-      argv: undefined,
-      envs: undefined,
-      timeout: undefined,
-    })
+    expect(apiClient.codeRun).toHaveBeenCalledWith(
+      {
+        code: 'print(1)',
+        language: 'python',
+        argv: undefined,
+        envs: undefined,
+        timeout: undefined,
+      },
+      undefined,
+    )
   })
 
   it('codeRun parses chart artifacts and defaults missing fields', async () => {
@@ -154,13 +179,16 @@ describe('Process', () => {
     const { process, apiClient } = await makeProcess('typescript')
     apiClient.codeRun.mockResolvedValue(createApiResponse({ exitCode: 0, result: '', artifacts: {} }))
     await process.codeRun('console.log(1)', { argv: ['--flag'], env: { NODE_ENV: 'test' } }, 10)
-    expect(apiClient.codeRun).toHaveBeenCalledWith({
-      code: 'console.log(1)',
-      language: 'typescript',
-      argv: ['--flag'],
-      envs: { NODE_ENV: 'test' },
-      timeout: 10,
-    })
+    expect(apiClient.codeRun).toHaveBeenCalledWith(
+      {
+        code: 'console.log(1)',
+        language: 'typescript',
+        argv: ['--flag'],
+        envs: { NODE_ENV: 'test' },
+        timeout: 10,
+      },
+      { timeout: 15000 },
+    )
   })
 
   it('codeRun throws when language not set', async () => {

--- a/sdk-typescript/src/errors/DaytonaError.ts
+++ b/sdk-typescript/src/errors/DaytonaError.ts
@@ -313,7 +313,13 @@ function extractAxiosErrorSource(responseData?: Record<string, unknown>): string
 
 function extractAxiosErrorMessage(error: AxiosError): string {
   if (isAxiosTimeoutError(error)) {
-    return 'Operation timed out'
+    const deadline =
+      typeof error.config?.timeout === 'number' && error.config.timeout > 0 ? ` after ${error.config.timeout}ms` : ''
+    return (
+      `HTTP request timed out${deadline} waiting for a response. This is a client-side deadline` +
+      ' (DaytonaConfig.requestTimeoutMs, or the per-call operation/execution timeout); any operation' +
+      ' already started on the server may still be running.'
+    )
   }
 
   const responseData = getAxiosResponseDataObject(error)


### PR DESCRIPTION
## Summary

Adds `requestTimeoutMs?: number` to `DaytonaConfig` — a configurable client-side HTTP
deadline for the TypeScript SDK. Requested by a customer running Temporal activity
workers who need a bounded HTTP wait when polling long-running sandbox processes;
the SDK previously hardcoded a 24-hour Axios timeout with no config knob.

TypeScript counterpart of #103 (Go `DaytonaConfig.Timeout`) and #52 (Python
`request_timeout`), following the same contract: this is a **client-side deadline
only** — it bounds how long the SDK waits for an HTTP response and does not cancel
the operation on the server.

## Changes

- **`DaytonaConfig.requestTimeoutMs`** — applies to the Daytona API client and to the
  toolbox clients of every Sandbox obtained via `create` / `get` / `list` / `fork`
  (each previously got a fresh Axios instance with the hardcoded default, so nothing
  propagated). Default stays **24h**; `0` disables the deadline; negative/non-finite
  values are rejected.
- **Exec paths honor their execution timeout** (mirrors #103) — `executeCommand` /
  `codeRun` with an explicit exec `timeout` bound the HTTP wait by
  `timeout + 5s` instead of the client-wide cap, so a bounded `requestTimeoutMs`
  never kills a still-running command. Exec `timeout` ≤ 0 leaves the wait uncapped.
- **Clearer timeout error** — client-side timeouts previously surfaced as
  `"Operation timed out"`, which is misleading (the server-side operation keeps
  running). The message now includes the deadline value, points at
  `requestTimeoutMs`, and states that the server-side operation may still be
  running. Error class unchanged (`DaytonaConnectionTimeoutError`).
- Regenerated sdk-docs artifacts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `DaytonaConfig.requestTimeoutMs` to the TypeScript SDK to cap client-side HTTP waits across API, toolbox, and analytics clients. When set, per-call exec timeouts take precedence; clearer timeout errors; default stays 24h.

- **New Features**
  - Added `DaytonaConfig.requestTimeoutMs` (ms) for all SDK Axios clients (API, Sandbox toolbox, analytics); defaults to 24h; `0` disables; rejects negative/non-finite values. Client-side only; does not cancel server operations.
  - Per-call timeouts take precedence only when a positive `requestTimeoutMs` is configured: operations with their own timeout (e.g., `create`, `start`, `stop`, `fork`, `process.executeCommand`, `process.codeRun`) use an HTTP wait of `timeout + 5s`; `0`/≤`0` leaves the wait uncapped; omitting `requestTimeoutMs` preserves the 24h default behavior.
  - Improved timeout error message: includes the deadline (when available) and notes the server operation may still be running; error class unchanged (`DaytonaConnectionTimeoutError`).
  - Updated docs and tests.

<sup>Written for commit b7f85fae7be3a529504d7a8f3b07964eefd918ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

