### PR TITLE
feat(cli): add organization members command for listing org members

### DIFF
--- a/cli/cmd/organization/members.go
+++ b/cli/cmd/organization/members.go
@@ -1,0 +1,73 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package organization
+
+import (
+	"context"
+	"fmt"
+
+	apiclient "github.com/daytona/clients/api-client-go"
+	apiclient_cli "github.com/daytona/clients/cli/apiclient"
+	"github.com/daytona/clients/cli/cmd/common"
+	"github.com/daytona/clients/cli/config"
+	"github.com/daytona/clients/cli/views/organization"
+	"github.com/spf13/cobra"
+)
+
+var MembersCmd = &cobra.Command{
+	Use:   "members [ORGANIZATION]",
+	Short: "List members of an organization",
+	Long:  "List members of an organization. Defaults to the active organization if none is specified.",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+
+		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
+		if err != nil {
+			return err
+		}
+
+		organizationId, err := resolveOrganizationId(ctx, apiClient, args)
+		if err != nil {
+			return err
+		}
+
+		memberList, res, err := apiClient.OrganizationsAPI.ListOrganizationMembers(ctx, organizationId).Execute()
+		if err != nil {
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		if common.FormatFlag != "" {
+			formattedData := common.NewFormatter(memberList)
+			formattedData.Print()
+			return nil
+		}
+
+		organization.ListOrganizationMembers(memberList)
+		return nil
+	},
+}
+
+func resolveOrganizationId(ctx context.Context, apiClient *apiclient.APIClient, args []string) (string, error) {
+	if len(args) == 0 {
+		return config.GetActiveOrganizationId()
+	}
+
+	orgList, res, err := apiClient.OrganizationsAPI.ListOrganizations(ctx).Execute()
+	if err != nil {
+		return "", apiclient_cli.HandleErrorResponse(res, err)
+	}
+
+	for _, org := range orgList {
+		if org.Id == args[0] || org.Name == args[0] {
+			return org.Id, nil
+		}
+	}
+
+	return "", fmt.Errorf("organization %s not found", args[0])
+}
+
+func init() {
+	common.RegisterFormatFlag(MembersCmd)
+}

--- a/cli/cmd/organization/organization.go
+++ b/cli/cmd/organization/organization.go
@@ -31,4 +31,5 @@ func init() {
 	OrganizationCmd.AddCommand(CreateCmd)
 	OrganizationCmd.AddCommand(UseCmd)
 	OrganizationCmd.AddCommand(DeleteCmd)
+	OrganizationCmd.AddCommand(MembersCmd)
 }

--- a/cli/views/organization/members.go
+++ b/cli/views/organization/members.go
@@ -1,0 +1,115 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package organization
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	apiclient "github.com/daytona/clients/api-client-go"
+	"github.com/daytona/clients/cli/views/common"
+	"github.com/daytona/clients/cli/views/util"
+)
+
+type MemberRowData struct {
+	Name          string
+	Email         string
+	Role          string
+	AssignedRoles string
+	Joined        string
+}
+
+func ListOrganizationMembers(memberList []apiclient.OrganizationUser) {
+	if len(memberList) == 0 {
+		common.RenderInfoMessageBold("No members found")
+		return
+	}
+
+	SortOrganizationMembers(&memberList)
+
+	headers := []string{"Name", "Email", "Role", "Assigned Roles", "Joined"}
+
+	data := [][]string{}
+
+	for _, m := range memberList {
+		var rowData *MemberRowData
+		var row []string
+
+		rowData = getMemberTableRowData(m)
+		row = getRowFromMemberRowData(*rowData)
+		data = append(data, row)
+	}
+
+	table := util.GetTableView(data, headers, nil, func() {
+		renderUnstyledMemberList(memberList)
+	})
+
+	fmt.Println(table)
+}
+
+func SortOrganizationMembers(memberList *[]apiclient.OrganizationUser) {
+	sort.Slice(*memberList, func(i, j int) bool {
+		return (*memberList)[i].CreatedAt.Before((*memberList)[j].CreatedAt)
+	})
+}
+
+func getMemberTableRowData(member apiclient.OrganizationUser) *MemberRowData {
+	rowData := MemberRowData{"", "", "", "", ""}
+	rowData.Name = member.Name + util.AdditionalPropertyPadding
+	rowData.Email = member.Email
+	rowData.Role = member.Role
+	rowData.AssignedRoles = getAssignedRolesLabel(member.AssignedRoles)
+	rowData.Joined = util.GetTimeSinceLabel(member.CreatedAt)
+
+	return &rowData
+}
+
+func getAssignedRolesLabel(assignedRoles []apiclient.OrganizationRole) string {
+	if len(assignedRoles) == 0 {
+		return "-"
+	}
+
+	roleNames := []string{}
+	for _, role := range assignedRoles {
+		roleNames = append(roleNames, role.Name)
+	}
+
+	return strings.Join(roleNames, ", ")
+}
+
+func renderUnstyledMemberList(memberList []apiclient.OrganizationUser) {
+	for _, member := range memberList {
+		RenderMemberInfo(&member)
+
+		if member.UserId != memberList[len(memberList)-1].UserId {
+			fmt.Printf("\n%s\n\n", common.SeparatorString)
+		}
+	}
+}
+
+func RenderMemberInfo(member *apiclient.OrganizationUser) {
+	var output string
+
+	output += "\n"
+	output += getInfoLine("Name", member.Name) + "\n"
+	output += getInfoLine("Email", member.Email) + "\n"
+	output += getInfoLine("Role", member.Role) + "\n"
+	output += getInfoLine("Assigned Roles", getAssignedRolesLabel(member.AssignedRoles)) + "\n"
+	output += getInfoLine("Joined", util.GetTimeSinceLabel(member.CreatedAt)) + "\n"
+
+	renderUnstyledInfo(output)
+}
+
+func getRowFromMemberRowData(rowData MemberRowData) []string {
+	row := []string{
+		common.NameStyle.Render(rowData.Name),
+		common.DefaultRowDataStyle.Render(rowData.Email),
+		common.DefaultRowDataStyle.Render(rowData.Role),
+		common.DefaultRowDataStyle.Render(rowData.AssignedRoles),
+		common.DefaultRowDataStyle.Render(rowData.Joined),
+	}
+
+	return row
+}


### PR DESCRIPTION
## Description

Adds `daytona organization members [ORGANIZATION]` to list organization members —
name, email, role, assigned roles, and join date. Requested by a customer who needs
to run access reviews across their organizations and export evidence for auditors.

- Defaults to the active organization; accepts an org name or ID to query any org
  you belong to without switching
- Supports `--format json|yaml` for scripted/audit output
- Follows the existing org command patterns (same auth gate, error handling, and
  table/fallback rendering as `organization list`)

Audit across all orgs:

    daytona org list -f json | jq -r '.[].id' | xargs -I{} daytona org members {} -f json


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `daytona organization members [ORGANIZATION]` to list organization members with name, email, role, assigned roles, and join date. Supports JSON/YAML output for audits; defaults to the active org and can target any org by name or ID.

- **New Features**
  - New `organization members` subcommand under `organization`.
  - Defaults to active org; accepts org name or ID without switching.
  - Table output by default; `--format json|yaml` for scripts.
  - Reuses existing auth, error handling, and table/fallback rendering.

<sup>Written for commit 217bc092add2739051f7517ba14edd396b0d1411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

