### PR TITLE
feat(sdk,cli): support snapshot delete/activate by ID/name

### DIFF
--- a/artifacts/sdk-docs/go-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/go-sdk/daytona.mdx
@@ -310,8 +310,10 @@ result, err := sandbox.Process.ExecuteCommand(ctx, "ls -la")
   - [func \(s \*SecretService\) Update\(ctx context.Context, secretID string, params \*types.UpdateSecretParams\) \(\*types.Secret, error\)](<#SecretService.Update>)
 - [type SnapshotService](<#SnapshotService>)
   - [func NewSnapshotService\(client \*Client\) \*SnapshotService](<#NewSnapshotService>)
+  - [func \(s \*SnapshotService\) Activate\(ctx context.Context, nameOrID string\) \(\*types.Snapshot, error\)](<#SnapshotService.Activate>)
   - [func \(s \*SnapshotService\) Create\(ctx context.Context, params \*types.CreateSnapshotParams\) \(\*types.Snapshot, \<\-chan string, error\)](<#SnapshotService.Create>)
   - [func \(s \*SnapshotService\) Delete\(ctx context.Context, snapshot \*types.Snapshot\) error](<#SnapshotService.Delete>)
+  - [func \(s \*SnapshotService\) DeleteByNameOrID\(ctx context.Context, nameOrID string\) error](<#SnapshotService.DeleteByNameOrID>)
   - [func \(s \*SnapshotService\) Get\(ctx context.Context, nameOrID string\) \(\*types.Snapshot, error\)](<#SnapshotService.Get>)
   - [func \(s \*SnapshotService\) List\(ctx context.Context, page \*int, limit \*int\) \(\*types.PaginatedSnapshots, error\)](<#SnapshotService.List>)
 - [type UploadProgress](<#UploadProgress>)
@@ -5531,6 +5533,39 @@ NewSnapshotService creates a new SnapshotService.
 
 This is typically called internally by the SDK when creating a [Client](<#Client>). Users should access SnapshotService through \[Client.Snapshot\] rather than creating it directly.
 
+<a name="SnapshotService.Activate"></a>
+### func \(\*SnapshotService\) Activate
+
+```go
+func (s *SnapshotService) Activate(ctx context.Context, nameOrID string) (*types.Snapshot, error)
+```
+
+Activate transitions a snapshot into the ACTIVE state so new sandboxes can be created from it.
+
+The reference may be either the snapshot's ID \(a UUID\) or its name. Because snapshot names may themselves be UUID\-shaped, the SDK cannot decide upfront which one was intended; it uses an optimistic\-then\-fallback strategy that mirrors the TypeScript and Python SDKs.
+
+Call\-count behavior:
+
+- Plain UUID that IS the ID: 1 request \(POST /snapshots/\{id\}/activate only\).
+- Non\-UUID name: 2 requests \(GET then POST\).
+- UUID\-shaped string that turns out to be a NAME: 3 requests \(POST returns 404 → GET resolves the name → POST by resolved ID\).
+
+Parameters:
+
+- nameOrID: The snapshot's ID or name
+
+Example:
+
+```
+snapshot, err := client.Snapshot.Activate(ctx, "my-python-env")
+if err != nil {
+    return err
+}
+fmt.Printf("Snapshot %s: %s\n", snapshot.Name, snapshot.State)
+```
+
+Returns the activated \[types.Snapshot\] or an error if the snapshot cannot be found or activation fails.
+
 <a name="SnapshotService.Create"></a>
 ### func \(\*SnapshotService\) Create
 
@@ -5599,6 +5634,40 @@ if err != nil {
 ```
 
 Returns an error if deletion fails.
+
+<a name="SnapshotService.DeleteByNameOrID"></a>
+### func \(\*SnapshotService\) DeleteByNameOrID
+
+```go
+func (s *SnapshotService) DeleteByNameOrID(ctx context.Context, nameOrID string) error
+```
+
+DeleteByNameOrID permanently removes a snapshot referenced by name or ID.
+
+The reference may be either the snapshot's ID \(a UUID\) or its name. Because snapshot names may themselves be UUID\-shaped, the SDK cannot decide upfront which one was intended; it uses an optimistic\-then\-fallback strategy that mirrors the TypeScript and Python SDKs.
+
+Call\-count behavior:
+
+- Plain UUID that IS the ID: 1 request \(DELETE only\).
+- Non\-UUID name: 2 requests \(GET then DELETE\).
+- UUID\-shaped string that turns out to be a NAME: 3 requests \(DELETE returns 404 → GET resolves the name → DELETE by resolved ID\).
+
+Sandboxes created from this snapshot will continue to work, but no new sandboxes can be created from it after deletion.
+
+Parameters:
+
+- nameOrID: The snapshot's ID or name
+
+Example:
+
+```
+err := client.Snapshot.DeleteByNameOrID(ctx, "my-python-env")
+if err != nil {
+    return err
+}
+```
+
+Returns an error if the snapshot cannot be found or deletion fails.
 
 <a name="SnapshotService.Get"></a>
 ### func \(\*SnapshotService\) Get

--- a/artifacts/sdk-docs/java-sdk/snapshot.mdx
+++ b/artifacts/sdk-docs/java-sdk/snapshot.mdx
@@ -169,15 +169,82 @@ Retrieves a snapshot by name or ID.
 
 #### delete()
 ```java
-public void delete(String id)
+public void delete(String nameOrId)
 ```
 
-Deletes a snapshot by ID.
+Deletes a snapshot by ID or name.
+
+Snapshot names may themselves be UUID-formatted, so a UUID-shaped input is first
+tried directly against the ID-only delete endpoint (1 call) and only resolved through
+the ID-or-name `GET /snapshots` lookup on a 404. Non-UUID input is resolved first (2 calls);
+a UUID-formatted name costs 3 calls in the worst case.
 
 **Parameters**:
 
-- `id` _String_ - snapshot identifier
+- `nameOrId` _String_ - snapshot identifier or name
 
 **Throws**:
 
 - `io.daytona.sdk.exception.DaytonaException` - if deletion fails
+
+#### delete()
+```java
+public void delete(Snapshot snapshot)
+```
+
+Deletes a snapshot using its already-known identifier.
+
+Issues a single delete call — no resolution is performed.
+
+**Parameters**:
+
+- `snapshot` _Snapshot_ - snapshot to delete; its `Snapshot#getId() id` is used verbatim
+
+**Throws**:
+
+- `io.daytona.sdk.exception.DaytonaException` - if deletion fails
+
+#### activate()
+```java
+public Snapshot activate(String nameOrId)
+```
+
+Activates a snapshot by ID or name.
+
+Snapshot names may themselves be UUID-formatted, so a UUID-shaped input is first
+tried directly against the ID-only activate endpoint (1 call) and only resolved through
+the ID-or-name `GET /snapshots` lookup on a 404. Non-UUID input is resolved first (2 calls);
+a UUID-formatted name costs 3 calls in the worst case.
+
+**Parameters**:
+
+- `nameOrId` _String_ - snapshot identifier or name
+
+**Returns**:
+
+- `Snapshot` - the activated `Snapshot`
+
+**Throws**:
+
+- `io.daytona.sdk.exception.DaytonaException` - if activation fails or no snapshot is found
+
+#### activate()
+```java
+public Snapshot activate(Snapshot snapshot)
+```
+
+Activates a snapshot using its already-known identifier.
+
+Issues a single activate call — no resolution is performed.
+
+**Parameters**:
+
+- `snapshot` _Snapshot_ - snapshot to activate; its `Snapshot#getId() id` is used verbatim
+
+**Returns**:
+
+- `Snapshot` - the activated `Snapshot`
+
+**Throws**:
+
+- `io.daytona.sdk.exception.DaytonaException` - if activation fails

--- a/artifacts/sdk-docs/python-sdk/async/async-snapshot.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-snapshot.mdx
@@ -75,22 +75,21 @@ async with AsyncDaytona() as daytona:
 ```python
 @intercept_errors(message_prefix="Failed to delete snapshot: ")
 @with_instrumentation()
-async def delete(snapshot: Snapshot) -> None
+async def delete(snapshot: Snapshot | str) -> None
 ```
 
 Delete a Snapshot.
 
 **Arguments**:
 
-- `snapshot` _Snapshot_ - Snapshot to delete.
+- `snapshot` _Snapshot | str_ - Snapshot to delete, or its ID or name.
   
 
 **Example**:
 
 ```python
 async with AsyncDaytona() as daytona:
-    snapshot = await daytona.snapshot.get("test-snapshot")
-    await daytona.snapshot.delete(snapshot)
+    await daytona.snapshot.delete("test-snapshot")
     print("Snapshot deleted")
 ```
 
@@ -102,11 +101,11 @@ async with AsyncDaytona() as daytona:
 async def get(name: str) -> Snapshot
 ```
 
-Get a Snapshot by name.
+Get a Snapshot by ID or name.
 
 **Arguments**:
 
-- `name` _str_ - Name of the Snapshot to get.
+- `name` _str_ - ID or name of the Snapshot to get.
   
 
 **Returns**:
@@ -156,14 +155,14 @@ daytona.snapshot.create(
 
 ```python
 @with_instrumentation()
-async def activate(snapshot: Snapshot) -> Snapshot
+async def activate(snapshot: Snapshot | str) -> Snapshot
 ```
 
 Activate a snapshot.
 
 **Arguments**:
 
-- `snapshot` _Snapshot_ - The Snapshot instance.
+- `snapshot` _Snapshot | str_ - The Snapshot instance, or its ID or name.
 
 **Returns**:
 

--- a/artifacts/sdk-docs/python-sdk/sync/snapshot.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/snapshot.mdx
@@ -75,22 +75,21 @@ for snapshot in page.items:
 ```python
 @intercept_errors(message_prefix="Failed to delete snapshot: ")
 @with_instrumentation()
-def delete(snapshot: Snapshot) -> None
+def delete(snapshot: Snapshot | str) -> None
 ```
 
 Delete a Snapshot.
 
 **Arguments**:
 
-- `snapshot` _Snapshot_ - Snapshot to delete.
+- `snapshot` _Snapshot | str_ - Snapshot to delete, or its ID or name.
   
 
 **Example**:
 
 ```python
 daytona = Daytona()
-snapshot = daytona.snapshot.get("test-snapshot")
-daytona.snapshot.delete(snapshot)
+daytona.snapshot.delete("test-snapshot")
 print("Snapshot deleted")
 ```
 
@@ -102,11 +101,11 @@ print("Snapshot deleted")
 def get(name: str) -> Snapshot
 ```
 
-Get a Snapshot by name.
+Get a Snapshot by ID or name.
 
 **Arguments**:
 
-- `name` _str_ - Name of the Snapshot to get.
+- `name` _str_ - ID or name of the Snapshot to get.
   
 
 **Returns**:
@@ -156,14 +155,14 @@ daytona.snapshot.create(
 
 ```python
 @with_instrumentation()
-def activate(snapshot: Snapshot) -> Snapshot
+def activate(snapshot: Snapshot | str) -> Snapshot
 ```
 
 Activate a snapshot.
 
 **Arguments**:
 
-- `snapshot` _Snapshot_ - The Snapshot instance.
+- `snapshot` _Snapshot | str_ - The Snapshot instance, or its ID or name.
 
 **Returns**:
 

--- a/artifacts/sdk-docs/ruby-sdk/snapshot.mdx
+++ b/artifacts/sdk-docs/ruby-sdk/snapshot.mdx
@@ -72,7 +72,10 @@ Delete a Snapshot.
 
 **Parameters**:
 
-- `snapshot` _Daytona:Snapshot_ - Snapshot to delete
+- `snapshot` _Daytona:Snapshot, String_ - Snapshot to delete, or its ID or name.
+Call cost: 1 API call for a Snapshot object or UUID string; 2 for a name
+(resolve, then delete); up to 3 in the worst case for a UUID-formatted name
+(the optimistic delete 404s, then resolve + delete).
 
 **Returns**:
 
@@ -95,11 +98,11 @@ def get(name)
 
 ```
 
-Get a Snapshot by name.
+Get a Snapshot by ID or name.
 
 **Parameters**:
 
-- `name` _String_ - Name of the Snapshot to get
+- `name` _String_ - ID or name of the Snapshot to get
 
 **Returns**:
 
@@ -150,11 +153,13 @@ def activate(snapshot)
 
 ```
 
-Activate a snapshot
+Activate a snapshot.
 
 **Parameters**:
 
-- `snapshot` _Daytona:Snapshot_ - The snapshot instance
+- `snapshot` _Daytona:Snapshot, String_ - The Snapshot instance, or its ID or name.
+Call cost matches `delete`: 1 for an object or UUID string, 2 for a name,
+up to 3 for a UUID-formatted name (optimistic 404 then resolve + activate).
 
 **Returns**:
 

--- a/artifacts/sdk-docs/typescript-sdk/snapshot.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/snapshot.mdx
@@ -37,14 +37,14 @@ new SnapshotService(
 #### activate()
 
 ```ts
-activate(snapshot: Snapshot): Promise<Snapshot>;
+activate(snapshot: string | Snapshot): Promise<Snapshot>;
 ```
 
 Activates a snapshot.
 
 **Parameters**:
 
-- `snapshot` _Snapshot_ - Snapshot to activate
+- `snapshot` _string \| Snapshot_ - Snapshot to activate, or its ID or name
 
 
 **Returns**:
@@ -84,14 +84,14 @@ await daytona.snapshot.create({ name: 'my-snapshot', image: image }, { onLogs: c
 #### delete()
 
 ```ts
-delete(snapshot: Snapshot): Promise<void>;
+delete(snapshot: string | Snapshot): Promise<void>;
 ```
 
 Deletes a Snapshot.
 
 **Parameters**:
 
-- `snapshot` _Snapshot_ - Snapshot to delete
+- `snapshot` _string \| Snapshot_ - Snapshot to delete, or its ID or name
 
 
 **Returns**:
@@ -106,22 +106,21 @@ If the Snapshot does not exist or cannot be deleted
 
 ```ts
 const daytona = new Daytona();
-const snapshot = await daytona.snapshot.get("snapshot-name");
-await daytona.snapshot.delete(snapshot);
+await daytona.snapshot.delete("snapshot-name");
 console.log("Snapshot deleted successfully");
 ```
 
 #### get()
 
 ```ts
-get(name: string): Promise<Snapshot>;
+get(idOrName: string): Promise<Snapshot>;
 ```
 
-Gets a Snapshot by its name.
+Gets a Snapshot by its ID or name.
 
 **Parameters**:
 
-- `name` _string_ - Name of the Snapshot to retrieve
+- `idOrName` _string_ - ID or name of the Snapshot to retrieve
 
 
 **Returns**:

--- a/cli/cmd/snapshot/activate.go
+++ b/cli/cmd/snapshot/activate.go
@@ -1,0 +1,60 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	apiclient_cli "github.com/daytona/clients/cli/apiclient"
+	view_common "github.com/daytona/clients/cli/views/common"
+	"github.com/spf13/cobra"
+)
+
+var ActivateCmd = &cobra.Command{
+	Use:   "activate [SNAPSHOT_ID | SNAPSHOT_NAME]",
+	Short: "Activate a snapshot",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+
+		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
+		if err != nil {
+			return err
+		}
+
+		snapshotIdOrName := args[0]
+
+		// Optimistic path: a UUID-shaped argument may be a real snapshot ID, so try
+		// the ID-only activate endpoint directly and save a round trip. On 404 the
+		// argument may instead be a UUID-formatted NAME (snapshot names may be
+		// UUID-shaped), so we fall through to the name-resolving GET; the server
+		// accepts ID-or-name there.
+		if isSnapshotId(snapshotIdOrName) {
+			_, res, err := apiClient.SnapshotsAPI.ActivateSnapshot(ctx, snapshotIdOrName).Execute()
+			if err == nil {
+				view_common.RenderInfoMessageBold(fmt.Sprintf("Snapshot %s activated", snapshotIdOrName))
+				return nil
+			}
+			if res == nil || res.StatusCode != http.StatusNotFound {
+				return apiclient_cli.HandleErrorResponse(res, err)
+			}
+		}
+
+		snapshot, res, err := apiClient.SnapshotsAPI.GetSnapshot(ctx, snapshotIdOrName).Execute()
+		if err != nil {
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		_, res, err = apiClient.SnapshotsAPI.ActivateSnapshot(ctx, snapshot.Id).Execute()
+		if err != nil {
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		view_common.RenderInfoMessageBold(fmt.Sprintf("Snapshot %s activated", snapshotIdOrName))
+
+		return nil
+	},
+}

--- a/cli/cmd/snapshot/delete.go
+++ b/cli/cmd/snapshot/delete.go
@@ -6,6 +6,7 @@ package snapshot
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	apiclient "github.com/daytona/clients/api-client-go"
 	apiclient_cli "github.com/daytona/clients/cli/apiclient"
@@ -71,6 +72,21 @@ var DeleteCmd = &cobra.Command{
 		}
 
 		snapshotIdOrName := args[0]
+
+		// Optimistic path: a UUID-shaped argument may be a real snapshot ID, so try
+		// DELETE directly and save a round trip. On 404 the argument may instead be
+		// a UUID-formatted NAME (snapshot names may be UUID-shaped), so we fall
+		// through to the name-resolving GET; the server accepts ID-or-name there.
+		if isSnapshotId(snapshotIdOrName) {
+			res, err := apiClient.SnapshotsAPI.RemoveSnapshot(ctx, snapshotIdOrName).Execute()
+			if err == nil {
+				view_common.RenderInfoMessageBold(fmt.Sprintf("Snapshot %s deleted", snapshotIdOrName))
+				return nil
+			}
+			if res == nil || res.StatusCode != http.StatusNotFound {
+				return apiclient_cli.HandleErrorResponse(res, err)
+			}
+		}
 
 		snapshot, res, err := apiClient.SnapshotsAPI.GetSnapshot(ctx, snapshotIdOrName).Execute()
 		if err != nil {

--- a/cli/cmd/snapshot/resolve.go
+++ b/cli/cmd/snapshot/resolve.go
@@ -1,0 +1,21 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package snapshot
+
+import "regexp"
+
+// snapshotIdRegex mirrors the server's uuid.validate() check (RFC 4122 v1-5 +
+// the nil UUID) so client and server always agree on what is ID-shaped.
+// Stricter than google/uuid's Validate, which accepts dashless, braced, and
+// URN forms and all versions — using that looser check here would turn the
+// name-fallback path into 400s at the server, because DELETE/activate accept
+// UUIDs only.
+var snapshotIdRegex = regexp.MustCompile(`^(?i:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$`)
+
+// isSnapshotId reports whether arg is a canonical RFC 4122 v1-5 UUID or the
+// nil UUID. Snapshot IDs are UUIDs, but names may also be UUID-shaped, so
+// callers must still fall back to the name-resolving endpoint on a 404.
+func isSnapshotId(arg string) bool {
+	return snapshotIdRegex.MatchString(arg)
+}

--- a/cli/cmd/snapshot/snapshot.go
+++ b/cli/cmd/snapshot/snapshot.go
@@ -21,4 +21,5 @@ func init() {
 	SnapshotsCmd.AddCommand(CreateCmd)
 	SnapshotsCmd.AddCommand(PushCmd)
 	SnapshotsCmd.AddCommand(DeleteCmd)
+	SnapshotsCmd.AddCommand(ActivateCmd)
 }

--- a/nx.json
+++ b/nx.json
@@ -209,5 +209,6 @@
       }
     }
   },
-  "nxCloudId": "69d4d7c6d23b3673e0643fe0"
+  "nxCloudId": "69d4d7c6d23b3673e0643fe0",
+  "analytics": false
 }

--- a/sdk-go/pkg/daytona/snapshot.go
+++ b/sdk-go/pkg/daytona/snapshot.go
@@ -6,20 +6,37 @@ package daytona
 import (
 	"bufio"
 	"context"
-	"errors"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	apiclient "github.com/daytona/clients/api-client-go"
+	sdkerrors "github.com/daytona/clients/sdk-go/pkg/errors"
 	"github.com/daytona/clients/sdk-go/pkg/types"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// snapshotIDRegex mirrors the server's uuid.validate() check
+// (RFC 4122 v1-5 + the nil UUID) so client and server always agree on what
+// is ID-shaped. It is intentionally stricter than google/uuid's Validate,
+// which accepts dashless, braced, and URN forms and all versions — using
+// that looser check here would turn the name-fallback path into 400s at the
+// server, because DELETE/activate accept UUIDs only.
+var snapshotIDRegex = regexp.MustCompile(`^(?i:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$`)
+
+// isSnapshotID reports whether s is a canonical RFC 4122 v1-5 UUID or the
+// nil UUID (00000000-...). Snapshot IDs are UUIDs, but snapshot NAMES may
+// also be UUID-shaped strings, so callers still have to disambiguate.
+func isSnapshotID(s string) bool {
+	return snapshotIDRegex.MatchString(s)
+}
 
 // SnapshotService provides snapshot (image template) management operations.
 //
@@ -362,6 +379,157 @@ func (s *SnapshotService) Delete(ctx context.Context, snapshot *types.Snapshot) 
 	})
 }
 
+// resolveSnapshotIDForIDOnlyOp turns a name-or-ID reference into the concrete
+// snapshot ID that ID-only endpoints (DELETE, activate) can accept.
+//
+// The algorithm matches the TypeScript and Python SDKs: if the reference is
+// UUID-shaped, try the ID-only op optimistically first (idOp) — the server
+// accepts UUIDs there and we save a round trip. If that returns 404, the
+// reference may be a UUID-formatted NAME (snapshot names may be UUID-shaped),
+// so fall through to GET /snapshots/{nameOrID} which the server resolves by
+// ID or name, and return the resolved ID. Non-UUID references skip the
+// optimistic call and go straight to GET.
+//
+// idOp is called at most once per invocation; on a non-404 error it is
+// returned to the caller unchanged. The bool return indicates whether idOp
+// was invoked and fully handled the operation (i.e. the caller is done).
+func (s *SnapshotService) resolveSnapshotIDForIDOnlyOp(
+	ctx context.Context,
+	nameOrID string,
+	idOp func(ctx context.Context, id string) (*http.Response, error),
+) (id string, done bool, err error) {
+	if isSnapshotID(nameOrID) {
+		httpResp, opErr := idOp(ctx, nameOrID)
+		if opErr == nil {
+			return nameOrID, true, nil
+		}
+		convertedErr := s.client.handleAPIError(opErr, httpResp)
+		if !stderrors.Is(convertedErr, sdkerrors.ErrNotFound) {
+			return "", true, convertedErr
+		}
+		// 404 → nameOrID may be a UUID-formatted NAME; fall through to resolve.
+	}
+
+	result, httpResp, getErr := s.client.apiClient.SnapshotsAPI.GetSnapshot(
+		s.client.getAuthContext(ctx),
+		nameOrID,
+	).Execute()
+	if getErr != nil {
+		return "", true, s.client.handleAPIError(getErr, httpResp)
+	}
+	return result.GetId(), false, nil
+}
+
+// DeleteByNameOrID permanently removes a snapshot referenced by name or ID.
+//
+// The reference may be either the snapshot's ID (a UUID) or its name. Because
+// snapshot names may themselves be UUID-shaped, the SDK cannot decide upfront
+// which one was intended; it uses an optimistic-then-fallback strategy that
+// mirrors the TypeScript and Python SDKs.
+//
+// Call-count behavior:
+//   - Plain UUID that IS the ID: 1 request (DELETE only).
+//   - Non-UUID name: 2 requests (GET then DELETE).
+//   - UUID-shaped string that turns out to be a NAME: 3 requests
+//     (DELETE returns 404 → GET resolves the name → DELETE by resolved ID).
+//
+// Sandboxes created from this snapshot will continue to work, but no new
+// sandboxes can be created from it after deletion.
+//
+// Parameters:
+//   - nameOrID: The snapshot's ID or name
+//
+// Example:
+//
+//	err := client.Snapshot.DeleteByNameOrID(ctx, "my-python-env")
+//	if err != nil {
+//	    return err
+//	}
+//
+// Returns an error if the snapshot cannot be found or deletion fails.
+func (s *SnapshotService) DeleteByNameOrID(ctx context.Context, nameOrID string) error {
+	return withInstrumentationVoid(ctx, s.otel, "Snapshot", "DeleteByNameOrID", func(ctx context.Context) error {
+		removeOp := func(ctx context.Context, id string) (*http.Response, error) {
+			return s.client.apiClient.SnapshotsAPI.RemoveSnapshot(
+				s.client.getAuthContext(ctx),
+				id,
+			).Execute()
+		}
+
+		resolvedID, done, err := s.resolveSnapshotIDForIDOnlyOp(ctx, nameOrID, removeOp)
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+
+		httpResp, err := removeOp(ctx, resolvedID)
+		if err != nil {
+			return s.client.handleAPIError(err, httpResp)
+		}
+		return nil
+	})
+}
+
+// Activate transitions a snapshot into the ACTIVE state so new sandboxes can
+// be created from it.
+//
+// The reference may be either the snapshot's ID (a UUID) or its name. Because
+// snapshot names may themselves be UUID-shaped, the SDK cannot decide upfront
+// which one was intended; it uses an optimistic-then-fallback strategy that
+// mirrors the TypeScript and Python SDKs.
+//
+// Call-count behavior:
+//   - Plain UUID that IS the ID: 1 request (POST /snapshots/{id}/activate only).
+//   - Non-UUID name: 2 requests (GET then POST).
+//   - UUID-shaped string that turns out to be a NAME: 3 requests
+//     (POST returns 404 → GET resolves the name → POST by resolved ID).
+//
+// Parameters:
+//   - nameOrID: The snapshot's ID or name
+//
+// Example:
+//
+//	snapshot, err := client.Snapshot.Activate(ctx, "my-python-env")
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Printf("Snapshot %s: %s\n", snapshot.Name, snapshot.State)
+//
+// Returns the activated [types.Snapshot] or an error if the snapshot cannot
+// be found or activation fails.
+func (s *SnapshotService) Activate(ctx context.Context, nameOrID string) (*types.Snapshot, error) {
+	return withInstrumentation(ctx, s.otel, "Snapshot", "Activate", func(ctx context.Context) (*types.Snapshot, error) {
+		var activatedDto *apiclient.SnapshotDto
+
+		activateOp := func(ctx context.Context, id string) (*http.Response, error) {
+			result, httpResp, err := s.client.apiClient.SnapshotsAPI.ActivateSnapshot(
+				s.client.getAuthContext(ctx),
+				id,
+			).Execute()
+			if err == nil {
+				activatedDto = result
+			}
+			return httpResp, err
+		}
+
+		resolvedID, done, err := s.resolveSnapshotIDForIDOnlyOp(ctx, nameOrID, activateOp)
+		if err != nil {
+			return nil, err
+		}
+		if done {
+			return mapSnapshotFromAPI(activatedDto), nil
+		}
+
+		httpResp, err := activateOp(ctx, resolvedID)
+		if err != nil {
+			return nil, s.client.handleAPIError(err, httpResp)
+		}
+		return mapSnapshotFromAPI(activatedDto), nil
+	})
+}
+
 // streamSnapshotBuildLogs streams build logs for a snapshot until it reaches a terminal state
 func (s *SnapshotService) streamSnapshotBuildLogs(ctx context.Context, snapshot *apiclient.SnapshotDto, logChan chan<- string) error {
 	terminalStates := map[apiclient.SnapshotState]bool{
@@ -468,7 +636,7 @@ func (s *SnapshotService) streamSnapshotBuildLogs(ctx context.Context, snapshot 
 	}
 
 	// Check for streaming errors (ignore context cancellation as it's expected when stopping the stream)
-	if streamErr != nil && !errors.Is(streamErr, context.Canceled) {
+	if streamErr != nil && !stderrors.Is(streamErr, context.Canceled) {
 		return streamErr
 	}
 

--- a/sdk-go/pkg/daytona/snapshot_test.go
+++ b/sdk-go/pkg/daytona/snapshot_test.go
@@ -6,13 +6,16 @@ package daytona
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	apiclient "github.com/daytona/clients/api-client-go"
+	sdkerrors "github.com/daytona/clients/sdk-go/pkg/errors"
 	"github.com/daytona/clients/sdk-go/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -200,4 +203,194 @@ func TestSnapshotLogStreamingHelpers(t *testing.T) {
 		assert.Equal(t, 42.5, *mapped.Size)
 		assert.Equal(t, "org-9", mapped.OrganizationID)
 	})
+}
+
+// httpCall is one recorded HTTP request against the fake API server.
+type httpCall struct {
+	Method string
+	Path   string
+}
+
+// recordingHandler builds an http.Handler that records every incoming request
+// into calls (guarded by mu) and dispatches to responders keyed by
+// "METHOD PATH". A responder whose key exactly matches is preferred; otherwise
+// the handler falls back to 404 so unregistered routes surface as ErrNotFound.
+func recordingHandler(t *testing.T, mu *sync.Mutex, calls *[]httpCall, responders map[string]http.HandlerFunc) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		*calls = append(*calls, httpCall{Method: r.Method, Path: r.URL.Path})
+		mu.Unlock()
+		key := r.Method + " " + r.URL.Path
+		if h, ok := responders[key]; ok {
+			h(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "not found"})
+	})
+}
+
+// snapshotUUID is a plain, canonical v4 UUID used as a real snapshot ID in
+// tests. UUID-shaped NAMES use a different UUID so the two branches can be
+// distinguished by the server-side fake.
+const (
+	snapshotUUID     = "11111111-1111-4111-8111-111111111111"
+	snapshotNameUUID = "22222222-2222-4222-8222-222222222222"
+)
+
+func TestSnapshotDeleteByNameOrIDNonUUIDName(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls []httpCall
+	)
+	responders := map[string]http.HandlerFunc{
+		"GET /snapshots/my-python-env": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONResponse(t, w, http.StatusOK, testSnapshotPayload(snapshotUUID, "my-python-env", apiclient.SNAPSHOTSTATE_ACTIVE))
+		},
+		"DELETE /snapshots/" + snapshotUUID: func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	}
+	server := httptest.NewServer(recordingHandler(t, &mu, &calls, responders))
+	defer server.Close()
+
+	client := createTestClientWithServer(t, server)
+	require.NoError(t, client.Snapshot.DeleteByNameOrID(context.Background(), "my-python-env"))
+
+	require.Equal(t, []httpCall{
+		{Method: http.MethodGet, Path: "/snapshots/my-python-env"},
+		{Method: http.MethodDelete, Path: "/snapshots/" + snapshotUUID},
+	}, calls)
+}
+
+func TestSnapshotDeleteByNameOrIDPlainUUIDSingleCall(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls []httpCall
+	)
+	responders := map[string]http.HandlerFunc{
+		"DELETE /snapshots/" + snapshotUUID: func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	}
+	server := httptest.NewServer(recordingHandler(t, &mu, &calls, responders))
+	defer server.Close()
+
+	client := createTestClientWithServer(t, server)
+	require.NoError(t, client.Snapshot.DeleteByNameOrID(context.Background(), snapshotUUID))
+
+	require.Equal(t, []httpCall{
+		{Method: http.MethodDelete, Path: "/snapshots/" + snapshotUUID},
+	}, calls, "plain UUID must skip the GET fallback and issue exactly one DELETE")
+}
+
+func TestSnapshotDeleteByNameOrIDUUIDFormattedNameFallback(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls []httpCall
+	)
+	// The reference IS a UUID-shaped string but it is another snapshot's NAME.
+	// snapshotNameUUID does not exist as an ID, so the optimistic DELETE 404s;
+	// the fallback GET resolves the name to snapshotUUID; the final DELETE
+	// targets snapshotUUID.
+	responders := map[string]http.HandlerFunc{
+		"DELETE /snapshots/" + snapshotNameUUID: func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": "snapshot not found"})
+		},
+		"GET /snapshots/" + snapshotNameUUID: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONResponse(t, w, http.StatusOK, testSnapshotPayload(snapshotUUID, snapshotNameUUID, apiclient.SNAPSHOTSTATE_ACTIVE))
+		},
+		"DELETE /snapshots/" + snapshotUUID: func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	}
+	server := httptest.NewServer(recordingHandler(t, &mu, &calls, responders))
+	defer server.Close()
+
+	client := createTestClientWithServer(t, server)
+	require.NoError(t, client.Snapshot.DeleteByNameOrID(context.Background(), snapshotNameUUID))
+
+	require.Equal(t, []httpCall{
+		{Method: http.MethodDelete, Path: "/snapshots/" + snapshotNameUUID},
+		{Method: http.MethodGet, Path: "/snapshots/" + snapshotNameUUID},
+		{Method: http.MethodDelete, Path: "/snapshots/" + snapshotUUID},
+	}, calls)
+}
+
+func TestSnapshotDeleteByNameOrIDUUIDNon404NoFallback(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls []httpCall
+	)
+	responders := map[string]http.HandlerFunc{
+		"DELETE /snapshots/" + snapshotUUID: func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": "forbidden"})
+		},
+	}
+	server := httptest.NewServer(recordingHandler(t, &mu, &calls, responders))
+	defer server.Close()
+
+	client := createTestClientWithServer(t, server)
+	err := client.Snapshot.DeleteByNameOrID(context.Background(), snapshotUUID)
+	require.Error(t, err)
+	assert.True(t, stderrors.Is(err, sdkerrors.ErrForbidden), "expected 403 to satisfy ErrForbidden, got %v", err)
+	require.Equal(t, []httpCall{
+		{Method: http.MethodDelete, Path: "/snapshots/" + snapshotUUID},
+	}, calls, "non-404 errors must propagate immediately without a GET fallback")
+}
+
+func TestSnapshotActivateByName(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls []httpCall
+	)
+	responders := map[string]http.HandlerFunc{
+		"GET /snapshots/my-python-env": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONResponse(t, w, http.StatusOK, testSnapshotPayload(snapshotUUID, "my-python-env", apiclient.SNAPSHOTSTATE_INACTIVE))
+		},
+		"POST /snapshots/" + snapshotUUID + "/activate": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONResponse(t, w, http.StatusOK, testSnapshotPayload(snapshotUUID, "my-python-env", apiclient.SNAPSHOTSTATE_ACTIVE))
+		},
+	}
+	server := httptest.NewServer(recordingHandler(t, &mu, &calls, responders))
+	defer server.Close()
+
+	client := createTestClientWithServer(t, server)
+	snap, err := client.Snapshot.Activate(context.Background(), "my-python-env")
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, snapshotUUID, snap.ID)
+	assert.Equal(t, "my-python-env", snap.Name)
+	assert.Equal(t, string(apiclient.SNAPSHOTSTATE_ACTIVE), snap.State)
+
+	require.Equal(t, []httpCall{
+		{Method: http.MethodGet, Path: "/snapshots/my-python-env"},
+		{Method: http.MethodPost, Path: "/snapshots/" + snapshotUUID + "/activate"},
+	}, calls)
+}
+
+func TestSnapshotDeleteByNameOrIDNonexistentNameErrNotFound(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls []httpCall
+	)
+	// No responders registered → every route falls through to 404 in the
+	// recording handler, which is exactly what the server does when a name
+	// does not resolve.
+	server := httptest.NewServer(recordingHandler(t, &mu, &calls, nil))
+	defer server.Close()
+
+	client := createTestClientWithServer(t, server)
+	err := client.Snapshot.DeleteByNameOrID(context.Background(), "ghost-snapshot")
+	require.Error(t, err)
+	assert.True(t, stderrors.Is(err, sdkerrors.ErrNotFound), "expected error to satisfy sdkerrors.ErrNotFound, got %v", err)
+	require.Equal(t, []httpCall{
+		{Method: http.MethodGet, Path: "/snapshots/ghost-snapshot"},
+	}, calls)
 }

--- a/sdk-java/src/main/java/io/daytona/sdk/SnapshotService.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/SnapshotService.java
@@ -8,6 +8,7 @@ import io.daytona.api.client.model.CreateBuildInfo;
 import io.daytona.api.client.model.CreateSnapshot;
 import io.daytona.api.client.model.SandboxClass;
 import io.daytona.sdk.exception.DaytonaException;
+import io.daytona.sdk.exception.DaytonaNotFoundException;
 import io.daytona.sdk.model.PaginatedSnapshots;
 import io.daytona.sdk.model.Snapshot;
 import okhttp3.OkHttpClient;
@@ -17,6 +18,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.regex.Pattern;
 
 /**
  * Service for managing Daytona Snapshots.
@@ -24,6 +27,16 @@ import java.util.function.Consumer;
  * <p>Provides operations to create, list, retrieve, and delete snapshots.
  */
 public class SnapshotService {
+    /**
+     * Matches RFC 4122 UUIDs (versions 1-5) and the nil UUID — the same set the
+     * Daytona API recognizes as snapshot IDs. Anything else is treated as a name.
+     *
+     * <p>Note: {@link java.util.UUID#fromString(String)} is intentionally NOT used
+     * for validation because it accepts non-canonical forms (e.g. {@code 1-1-1-1-1}).
+     */
+    private static final Pattern SNAPSHOT_ID_PATTERN = Pattern.compile(
+            "(?i)^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$");
+
     private final SnapshotsApi snapshotsApi;
     private final OkHttpClient httpClient;
     private final String apiKey;
@@ -215,13 +228,96 @@ public class SnapshotService {
     }
 
     /**
-     * Deletes a snapshot by ID.
+     * Deletes a snapshot by ID or name.
      *
-     * @param id snapshot identifier
+     * <p>Snapshot names may themselves be UUID-formatted, so a UUID-shaped input is first
+     * tried directly against the ID-only delete endpoint (1 call) and only resolved through
+     * the ID-or-name {@code GET /snapshots} lookup on a 404. Non-UUID input is resolved first (2 calls);
+     * a UUID-formatted name costs 3 calls in the worst case.
+     *
+     * @param nameOrId snapshot identifier or name
      * @throws io.daytona.sdk.exception.DaytonaException if deletion fails
      */
-    public void delete(String id) {
-        ExceptionMapper.runMain(() -> snapshotsApi.removeSnapshot(id, null));
+    public void delete(String nameOrId) {
+        callWithResolvedId(nameOrId, id -> {
+            ExceptionMapper.runMain(() -> snapshotsApi.removeSnapshot(id, null));
+            return null;
+        });
+    }
+
+    /**
+     * Deletes a snapshot using its already-known identifier.
+     *
+     * <p>Issues a single delete call — no resolution is performed.
+     *
+     * @param snapshot snapshot to delete; its {@link Snapshot#getId() id} is used verbatim
+     * @throws io.daytona.sdk.exception.DaytonaException if deletion fails
+     */
+    public void delete(Snapshot snapshot) {
+        ExceptionMapper.runMain(() -> snapshotsApi.removeSnapshot(snapshot.getId(), null));
+    }
+
+    /**
+     * Activates a snapshot by ID or name.
+     *
+     * <p>Snapshot names may themselves be UUID-formatted, so a UUID-shaped input is first
+     * tried directly against the ID-only activate endpoint (1 call) and only resolved through
+     * the ID-or-name {@code GET /snapshots} lookup on a 404. Non-UUID input is resolved first (2 calls);
+     * a UUID-formatted name costs 3 calls in the worst case.
+     *
+     * @param nameOrId snapshot identifier or name
+     * @return the activated {@link Snapshot}
+     * @throws io.daytona.sdk.exception.DaytonaException if activation fails or no snapshot is found
+     */
+    public Snapshot activate(String nameOrId) {
+        io.daytona.api.client.model.SnapshotDto snapshotDto = callWithResolvedId(
+                nameOrId,
+                id -> ExceptionMapper.callMain(() -> snapshotsApi.activateSnapshot(id, null)));
+        return toSnapshot(snapshotDto);
+    }
+
+    /**
+     * Activates a snapshot using its already-known identifier.
+     *
+     * <p>Issues a single activate call — no resolution is performed.
+     *
+     * @param snapshot snapshot to activate; its {@link Snapshot#getId() id} is used verbatim
+     * @return the activated {@link Snapshot}
+     * @throws io.daytona.sdk.exception.DaytonaException if activation fails
+     */
+    public Snapshot activate(Snapshot snapshot) {
+        io.daytona.api.client.model.SnapshotDto snapshotDto = ExceptionMapper.callMain(
+                () -> snapshotsApi.activateSnapshot(snapshot.getId(), null));
+        return toSnapshot(snapshotDto);
+    }
+
+    /**
+     * Invokes an ID-based Snapshot operation, resolving {@code nameOrId} with as few API
+     * calls as possible.
+     *
+     * <p>A UUID-shaped input is optimistically tried as an ID (1 call). If the API responds
+     * 404, the input may still be a UUID-formatted name; the method falls back to
+     * {@link #get(String) get} to resolve the real ID and retries the operation. Any 404
+     * from the final call — or from {@code get()} — propagates to the caller.
+     *
+     * @param nameOrId snapshot identifier or name
+     * @param operation ID-only operation to invoke
+     * @param <T> operation return type
+     */
+    private <T> T callWithResolvedId(String nameOrId, Function<String, T> operation) {
+        if (isSnapshotId(nameOrId)) {
+            try {
+                return operation.apply(nameOrId);
+            } catch (DaytonaNotFoundException e) {
+                // Not an existing ID — may still be a UUID-formatted name; fall through to resolution.
+            }
+        }
+        Snapshot resolved = get(nameOrId);
+        return operation.apply(resolved.getId());
+    }
+
+    private static boolean isSnapshotId(String value) {
+        return value != null && SNAPSHOT_ID_PATTERN.matcher(value).matches();
     }
 
     private String stateString(io.daytona.api.client.model.SnapshotDto dto) {

--- a/sdk-java/src/test/java/io/daytona/sdk/SnapshotServiceTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/SnapshotServiceTest.java
@@ -9,6 +9,7 @@ import io.daytona.api.client.model.SnapshotDto;
 import io.daytona.api.client.model.SnapshotState;
 import io.daytona.api.client.model.Url;
 import io.daytona.sdk.exception.DaytonaException;
+import io.daytona.sdk.exception.DaytonaForbiddenException;
 import io.daytona.sdk.exception.DaytonaNotFoundException;
 import io.daytona.sdk.exception.DaytonaServerException;
 import io.daytona.sdk.model.PaginatedSnapshots;
@@ -24,6 +25,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -38,11 +40,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SnapshotServiceTest {
+
+    private static final String CANONICAL_UUID = "11111111-1111-4111-8111-111111111111";
 
     @Mock
     private SnapshotsApi snapshotsApi;
@@ -186,14 +192,132 @@ class SnapshotServiceTest {
     }
 
     @Test
-    void getAndDeleteDelegate() {
+    void getDelegates() {
         when(snapshotsApi.getSnapshot("snapshot", null)).thenReturn(snapshotDto("snap-1", "snapshot", SnapshotState.ACTIVE));
 
         Snapshot snapshot = snapshotService.get("snapshot");
-        snapshotService.delete("snap-1");
 
         assertThat(snapshot.getName()).isEqualTo("snapshot");
-        verify(snapshotsApi).removeSnapshot("snap-1", null);
+        assertThat(snapshot.getId()).isEqualTo("snap-1");
+    }
+
+    @Test
+    void deleteByNameResolvesIdFirstThenRemoves() {
+        when(snapshotsApi.getSnapshot("the-name", null))
+                .thenReturn(snapshotDto(CANONICAL_UUID, "the-name", SnapshotState.ACTIVE));
+
+        snapshotService.delete("the-name");
+
+        InOrder order = inOrder(snapshotsApi);
+        order.verify(snapshotsApi).getSnapshot("the-name", null);
+        order.verify(snapshotsApi).removeSnapshot(CANONICAL_UUID, null);
+        order.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void deleteByUuidCallsRemoveDirectlyWithoutResolution() {
+        snapshotService.delete(CANONICAL_UUID);
+
+        verify(snapshotsApi).removeSnapshot(CANONICAL_UUID, null);
+        verify(snapshotsApi, never()).getSnapshot(any(), any());
+    }
+
+    @Test
+    void deleteByUuidFormattedNameFallsBackToResolutionAfter404() {
+        String other = "22222222-2222-4222-8222-222222222222";
+        io.daytona.api.client.ApiException notFound =
+                new io.daytona.api.client.ApiException(404, "boom", null, "{\"message\":\"not found\"}");
+        org.mockito.Mockito.doThrow(notFound)
+                .doNothing()
+                .when(snapshotsApi).removeSnapshot(any(), isNull());
+        when(snapshotsApi.getSnapshot(CANONICAL_UUID, null))
+                .thenReturn(snapshotDto(other, CANONICAL_UUID, SnapshotState.ACTIVE));
+
+        snapshotService.delete(CANONICAL_UUID);
+
+        InOrder order = inOrder(snapshotsApi);
+        order.verify(snapshotsApi).removeSnapshot(CANONICAL_UUID, null);
+        order.verify(snapshotsApi).getSnapshot(CANONICAL_UUID, null);
+        order.verify(snapshotsApi).removeSnapshot(other, null);
+        order.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void deleteByUuidForbiddenPropagatesAndDoesNotResolve() throws Exception {
+        org.mockito.Mockito.doThrow(new io.daytona.api.client.ApiException(403, "boom", null, "{\"message\":\"denied\"}"))
+                .when(snapshotsApi).removeSnapshot(CANONICAL_UUID, null);
+
+        assertThatThrownBy(() -> snapshotService.delete(CANONICAL_UUID))
+                .isInstanceOf(DaytonaForbiddenException.class)
+                .hasMessage("denied");
+        verify(snapshotsApi, never()).getSnapshot(any(), any());
+    }
+
+    @Test
+    void deleteByNamePropagatesNotFoundFromResolution() {
+        when(snapshotsApi.getSnapshot("missing", null))
+                .thenThrow(new io.daytona.api.client.ApiException(404, "boom", null, "{\"message\":\"gone\"}"));
+
+        assertThatThrownBy(() -> snapshotService.delete("missing"))
+                .isInstanceOf(DaytonaNotFoundException.class)
+                .hasMessage("gone");
+    }
+
+    @Test
+    void deleteSnapshotOverloadUsesDtoIdDirectly() {
+        Snapshot snapshot = new Snapshot();
+        snapshot.setId(CANONICAL_UUID);
+        snapshot.setName("some-name");
+
+        snapshotService.delete(snapshot);
+
+        verify(snapshotsApi).removeSnapshot(CANONICAL_UUID, null);
+        verify(snapshotsApi, never()).getSnapshot(any(), any());
+    }
+
+    @Test
+    void activateByNameResolvesFirstAndReturnsMappedSnapshot() {
+        when(snapshotsApi.getSnapshot("the-name", null))
+                .thenReturn(snapshotDto(CANONICAL_UUID, "the-name", SnapshotState.INACTIVE));
+        when(snapshotsApi.activateSnapshot(CANONICAL_UUID, null))
+                .thenReturn(snapshotDto(CANONICAL_UUID, "the-name", SnapshotState.ACTIVE));
+
+        Snapshot result = snapshotService.activate("the-name");
+
+        assertThat(result.getId()).isEqualTo(CANONICAL_UUID);
+        assertThat(result.getName()).isEqualTo("the-name");
+        assertThat(result.getState()).isEqualTo("active");
+        InOrder order = inOrder(snapshotsApi);
+        order.verify(snapshotsApi).getSnapshot("the-name", null);
+        order.verify(snapshotsApi).activateSnapshot(CANONICAL_UUID, null);
+        order.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void activateByUuidCallsActivateDirectlyWithoutResolution() {
+        when(snapshotsApi.activateSnapshot(CANONICAL_UUID, null))
+                .thenReturn(snapshotDto(CANONICAL_UUID, "the-name", SnapshotState.ACTIVE));
+
+        Snapshot result = snapshotService.activate(CANONICAL_UUID);
+
+        assertThat(result.getId()).isEqualTo(CANONICAL_UUID);
+        verify(snapshotsApi).activateSnapshot(CANONICAL_UUID, null);
+        verify(snapshotsApi, never()).getSnapshot(any(), any());
+    }
+
+    @Test
+    void activateSnapshotOverloadUsesDtoIdDirectly() {
+        Snapshot snapshot = new Snapshot();
+        snapshot.setId(CANONICAL_UUID);
+        snapshot.setName("some-name");
+        when(snapshotsApi.activateSnapshot(CANONICAL_UUID, null))
+                .thenReturn(snapshotDto(CANONICAL_UUID, "some-name", SnapshotState.ACTIVE));
+
+        Snapshot result = snapshotService.activate(snapshot);
+
+        assertThat(result.getState()).isEqualTo("active");
+        verify(snapshotsApi).activateSnapshot(CANONICAL_UUID, null);
+        verify(snapshotsApi, never()).getSnapshot(any(), any());
     }
 
     @ParameterizedTest

--- a/sdk-python/src/daytona/_async/snapshot.py
+++ b/sdk-python/src/daytona/_async/snapshot.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Callable, cast
+from collections.abc import Awaitable
+from typing import Callable, TypeVar, cast
 
 from daytona_api_client_async import (
     CreateBuildInfo,
@@ -13,6 +14,7 @@ from daytona_api_client_async import (
     SnapshotsApi,
     SnapshotState,
 )
+from daytona_api_client_async.exceptions import NotFoundException
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
@@ -20,9 +22,11 @@ from .._utils.stream import process_streaming_response
 from .._utils.timeout import with_timeout
 from ..common.errors import DaytonaError, DaytonaValidationError
 from ..common.image import Image
-from ..common.snapshot import CreateSnapshotParams, PaginatedSnapshots, Snapshot
+from ..common.snapshot import CreateSnapshotParams, PaginatedSnapshots, Snapshot, is_snapshot_id
 from ..internal.shared_session import SharedAiohttpSession
 from .object_storage import AsyncObjectStorage
+
+T = TypeVar("T")
 
 
 class AsyncSnapshotService:
@@ -77,29 +81,28 @@ class AsyncSnapshotService:
 
     @intercept_errors(message_prefix="Failed to delete snapshot: ")
     @with_instrumentation()
-    async def delete(self, snapshot: Snapshot) -> None:
+    async def delete(self, snapshot: Snapshot | str) -> None:
         """Delete a Snapshot.
 
         Args:
-            snapshot (Snapshot): Snapshot to delete.
+            snapshot (Snapshot | str): Snapshot to delete, or its ID or name.
 
         Example:
             ```python
             async with AsyncDaytona() as daytona:
-                snapshot = await daytona.snapshot.get("test-snapshot")
-                await daytona.snapshot.delete(snapshot)
+                await daytona.snapshot.delete("test-snapshot")
                 print("Snapshot deleted")
             ```
         """
-        await self.__snapshots_api.remove_snapshot(snapshot.id)
+        await self.__call_with_resolved_id(snapshot, self.__snapshots_api.remove_snapshot)
 
     @intercept_errors(message_prefix="Failed to get snapshot: ")
     @with_instrumentation()
     async def get(self, name: str) -> Snapshot:
-        """Get a Snapshot by name.
+        """Get a Snapshot by ID or name.
 
         Args:
-            name (str): Name of the Snapshot to get.
+            name (str): ID or name of the Snapshot to get.
 
         Returns:
             Snapshot: The Snapshot object.
@@ -223,14 +226,32 @@ class AsyncSnapshotService:
         return created_snapshot if isinstance(created_snapshot, Snapshot) else Snapshot.from_dto(created_snapshot)
 
     @with_instrumentation()
-    async def activate(self, snapshot: Snapshot) -> Snapshot:
+    async def activate(self, snapshot: Snapshot | str) -> Snapshot:
         """Activate a snapshot.
         Args:
-            snapshot (Snapshot): The Snapshot instance.
+            snapshot (Snapshot | str): The Snapshot instance, or its ID or name.
         Returns:
             Snapshot: The activated Snapshot instance.
         """
-        return Snapshot.from_dto(await self.__snapshots_api.activate_snapshot(snapshot.id))
+        return Snapshot.from_dto(await self.__call_with_resolved_id(snapshot, self.__snapshots_api.activate_snapshot))
+
+    async def __call_with_resolved_id(self, snapshot: Snapshot | str, operation: Callable[[str], Awaitable[T]]) -> T:
+        """Invokes an ID-based snapshot operation, resolving the identifier with as few
+        API calls as possible: a UUID-shaped string is first tried directly as an ID
+        (snapshot names may themselves be UUID-formatted, so a miss falls back to
+        name resolution), while any other string costs one resolution call.
+        """
+        if not isinstance(snapshot, str):
+            return await operation(snapshot.id)
+
+        if is_snapshot_id(snapshot):
+            try:
+                return await operation(snapshot)
+            except NotFoundException:
+                pass
+
+        resolved = await self.__snapshots_api.get_snapshot(snapshot)
+        return await operation(resolved.id)
 
     @staticmethod
     @with_instrumentation()

--- a/sdk-python/src/daytona/_sync/snapshot.py
+++ b/sdk-python/src/daytona/_sync/snapshot.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-from typing import Callable, cast
+from typing import Callable, TypeVar, cast
 
 from daytona_api_client import CreateBuildInfo, CreateSnapshot
 from daytona_api_client import GpuType as SyncGpuType
 from daytona_api_client import ObjectStorageApi
 from daytona_api_client import SandboxClass as SyncSandboxClass
 from daytona_api_client import SnapshotDto, SnapshotsApi, SnapshotState
+from daytona_api_client.exceptions import NotFoundException
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
@@ -20,8 +21,10 @@ from .._utils.stream import process_streaming_response
 from .._utils.timeout import with_timeout
 from ..common.errors import DaytonaError, DaytonaValidationError
 from ..common.image import Image
-from ..common.snapshot import CreateSnapshotParams, PaginatedSnapshots, Snapshot
+from ..common.snapshot import CreateSnapshotParams, PaginatedSnapshots, Snapshot, is_snapshot_id
 from .object_storage import ObjectStorage
+
+T = TypeVar("T")
 
 
 class SnapshotService:
@@ -71,29 +74,28 @@ class SnapshotService:
 
     @intercept_errors(message_prefix="Failed to delete snapshot: ")
     @with_instrumentation()
-    def delete(self, snapshot: Snapshot) -> None:
+    def delete(self, snapshot: Snapshot | str) -> None:
         """Delete a Snapshot.
 
         Args:
-            snapshot (Snapshot): Snapshot to delete.
+            snapshot (Snapshot | str): Snapshot to delete, or its ID or name.
 
         Example:
             ```python
             daytona = Daytona()
-            snapshot = daytona.snapshot.get("test-snapshot")
-            daytona.snapshot.delete(snapshot)
+            daytona.snapshot.delete("test-snapshot")
             print("Snapshot deleted")
             ```
         """
-        self.__snapshots_api.remove_snapshot(snapshot.id)
+        self.__call_with_resolved_id(snapshot, self.__snapshots_api.remove_snapshot)
 
     @intercept_errors(message_prefix="Failed to get snapshot: ")
     @with_instrumentation()
     def get(self, name: str) -> Snapshot:
-        """Get a Snapshot by name.
+        """Get a Snapshot by ID or name.
 
         Args:
-            name (str): Name of the Snapshot to get.
+            name (str): ID or name of the Snapshot to get.
 
         Returns:
             Snapshot: The Snapshot object.
@@ -223,14 +225,32 @@ class SnapshotService:
         return created_snapshot if isinstance(created_snapshot, Snapshot) else Snapshot.from_dto(created_snapshot)
 
     @with_instrumentation()
-    def activate(self, snapshot: Snapshot) -> Snapshot:
+    def activate(self, snapshot: Snapshot | str) -> Snapshot:
         """Activate a snapshot.
         Args:
-            snapshot (Snapshot): The Snapshot instance.
+            snapshot (Snapshot | str): The Snapshot instance, or its ID or name.
         Returns:
             Snapshot: The activated Snapshot instance.
         """
-        return Snapshot.from_dto(self.__snapshots_api.activate_snapshot(snapshot.id))
+        return Snapshot.from_dto(self.__call_with_resolved_id(snapshot, self.__snapshots_api.activate_snapshot))
+
+    def __call_with_resolved_id(self, snapshot: Snapshot | str, operation: Callable[[str], T]) -> T:
+        """Invokes an ID-based snapshot operation, resolving the identifier with as few
+        API calls as possible: a UUID-shaped string is first tried directly as an ID
+        (snapshot names may themselves be UUID-formatted, so a miss falls back to
+        name resolution), while any other string costs one resolution call.
+        """
+        if not isinstance(snapshot, str):
+            return operation(snapshot.id)
+
+        if is_snapshot_id(snapshot):
+            try:
+                return operation(snapshot)
+            except NotFoundException:
+                pass
+
+        resolved = self.__snapshots_api.get_snapshot(snapshot)
+        return operation(resolved.id)
 
     @staticmethod
     @with_instrumentation()

--- a/sdk-python/src/daytona/common/snapshot.py
+++ b/sdk-python/src/daytona/common/snapshot.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import re
+
 from pydantic import BaseModel
 
 from daytona_api_client import BuildInfo
@@ -14,6 +16,18 @@ from daytona_api_client_async import SnapshotDto as AsyncSnapshotDto
 
 from .image import Image
 from .sandbox import Resources
+
+# Matches RFC 4122 UUIDs (versions 1-5) and the nil UUID - the same set the
+# Daytona API recognizes as snapshot IDs. Anything else is treated as a name.
+_UUID_PATTERN = re.compile(
+    r"^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+    + r"|00000000-0000-0000-0000-000000000000)$",
+    re.IGNORECASE,
+)
+
+
+def is_snapshot_id(value: str) -> bool:
+    return _UUID_PATTERN.match(value) is not None
 
 
 class Snapshot(SyncSnapshotDto):

--- a/sdk-python/tests/test_snapshot.py
+++ b/sdk-python/tests/test_snapshot.py
@@ -22,6 +22,8 @@ class TestSyncSnapshotService:
 
     def _make_snapshot_dto(self, name="test-snapshot"):
         dto = MagicMock()
+        dto.id = "snap-123"
+        dto.name = name
         dto.model_dump.return_value = {
             "id": "snap-123",
             "organization_id": "org-1",
@@ -100,6 +102,51 @@ class TestSyncSnapshotService:
         service.delete(snap)
         api.remove_snapshot.assert_called_once_with("snap-123")
 
+    def test_delete_by_name(self):
+        service, api = self._make_service()
+        api.get_snapshot.return_value = self._make_snapshot_dto()
+        api.remove_snapshot.return_value = None
+
+        service.delete("test-snapshot")
+
+        api.get_snapshot.assert_called_once_with("test-snapshot")
+        api.remove_snapshot.assert_called_once_with("snap-123")
+
+    def test_delete_by_uuid_id_skips_resolution(self):
+        service, api = self._make_service()
+        api.remove_snapshot.return_value = None
+        snapshot_id = "9f0a2b52-6a5f-4bd6-9c1e-1c9a1cf7d3aa"
+
+        service.delete(snapshot_id)
+
+        api.get_snapshot.assert_not_called()
+        api.remove_snapshot.assert_called_once_with(snapshot_id)
+
+    def test_delete_by_uuid_name_falls_back_to_resolution(self):
+        from daytona_api_client.exceptions import NotFoundException
+
+        service, api = self._make_service()
+        uuid_name = "9f0a2b52-6a5f-4bd6-9c1e-1c9a1cf7d3aa"
+        api.remove_snapshot.side_effect = [NotFoundException(), None]
+        api.get_snapshot.return_value = self._make_snapshot_dto(name=uuid_name)
+
+        service.delete(uuid_name)
+
+        api.get_snapshot.assert_called_once_with(uuid_name)
+        assert api.remove_snapshot.call_args_list[0].args == (uuid_name,)
+        assert api.remove_snapshot.call_args_list[1].args == ("snap-123",)
+
+    def test_delete_by_uuid_propagates_non_404(self):
+        from daytona_api_client.exceptions import ForbiddenException
+
+        service, api = self._make_service()
+        api.remove_snapshot.side_effect = ForbiddenException()
+
+        with pytest.raises(DaytonaError):
+            service.delete("9f0a2b52-6a5f-4bd6-9c1e-1c9a1cf7d3aa")
+
+        api.get_snapshot.assert_not_called()
+
     def test_activate(self):
         service, api = self._make_service()
         api.activate_snapshot.return_value = self._make_snapshot_dto(name="active-snapshot")
@@ -107,6 +154,16 @@ class TestSyncSnapshotService:
         result = service.activate(Snapshot.model_validate(self._make_snapshot_dto().model_dump()))
 
         assert result.name == "active-snapshot"
+
+    def test_activate_by_name(self):
+        service, api = self._make_service()
+        api.get_snapshot.return_value = self._make_snapshot_dto()
+        api.activate_snapshot.return_value = self._make_snapshot_dto(name="active-snapshot")
+
+        result = service.activate("test-snapshot")
+
+        assert result.name == "active-snapshot"
+        api.activate_snapshot.assert_called_once_with("snap-123")
 
     def test_process_image_context_returns_empty_for_images_without_context(self):
         assert (
@@ -145,6 +202,8 @@ class TestAsyncSnapshotService:
 
     def _make_snapshot_dto(self, name="test-snapshot"):
         dto = MagicMock()
+        dto.id = "snap-123"
+        dto.name = name
         dto.model_dump.return_value = {
             "id": "snap-123",
             "organization_id": "org-1",
@@ -219,6 +278,66 @@ class TestAsyncSnapshotService:
         )
         await service.delete(snap)
         api.remove_snapshot.assert_called_once_with("snap-123")
+
+    @pytest.mark.asyncio
+    async def test_delete_by_name(self):
+        service, api = self._make_service()
+        api.get_snapshot.return_value = self._make_snapshot_dto()
+        api.remove_snapshot.return_value = None
+
+        await service.delete("test-snapshot")
+
+        api.get_snapshot.assert_called_once_with("test-snapshot")
+        api.remove_snapshot.assert_called_once_with("snap-123")
+
+    @pytest.mark.asyncio
+    async def test_delete_by_uuid_id_skips_resolution(self):
+        service, api = self._make_service()
+        api.remove_snapshot.return_value = None
+        snapshot_id = "9f0a2b52-6a5f-4bd6-9c1e-1c9a1cf7d3aa"
+
+        await service.delete(snapshot_id)
+
+        api.get_snapshot.assert_not_called()
+        api.remove_snapshot.assert_called_once_with(snapshot_id)
+
+    @pytest.mark.asyncio
+    async def test_delete_by_uuid_name_falls_back_to_resolution(self):
+        from daytona_api_client_async.exceptions import NotFoundException
+
+        service, api = self._make_service()
+        uuid_name = "9f0a2b52-6a5f-4bd6-9c1e-1c9a1cf7d3aa"
+        api.remove_snapshot.side_effect = [NotFoundException(), None]
+        api.get_snapshot.return_value = self._make_snapshot_dto(name=uuid_name)
+
+        await service.delete(uuid_name)
+
+        api.get_snapshot.assert_called_once_with(uuid_name)
+        assert api.remove_snapshot.call_args_list[0].args == (uuid_name,)
+        assert api.remove_snapshot.call_args_list[1].args == ("snap-123",)
+
+    @pytest.mark.asyncio
+    async def test_delete_by_uuid_propagates_non_404(self):
+        from daytona_api_client_async.exceptions import ForbiddenException
+
+        service, api = self._make_service()
+        api.remove_snapshot.side_effect = ForbiddenException()
+
+        with pytest.raises(DaytonaError):
+            await service.delete("9f0a2b52-6a5f-4bd6-9c1e-1c9a1cf7d3aa")
+
+        api.get_snapshot.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_activate_by_name(self):
+        service, api = self._make_service()
+        api.get_snapshot.return_value = self._make_snapshot_dto()
+        api.activate_snapshot.return_value = self._make_snapshot_dto(name="active-snapshot")
+
+        result = await service.activate("test-snapshot")
+
+        assert result.name == "active-snapshot"
+        api.activate_snapshot.assert_called_once_with("snap-123")
 
     @pytest.mark.asyncio
     async def test_activate(self):

--- a/sdk-ruby/lib/daytona/common/snapshot.rb
+++ b/sdk-ruby/lib/daytona/common/snapshot.rb
@@ -43,6 +43,14 @@ module Daytona
   end
 
   class Snapshot
+    # Matches RFC 4122 UUIDs (versions 1-5) and the nil UUID - the same set the
+    # Daytona API recognizes as snapshot IDs. Anything else is treated as a name.
+    SNAPSHOT_ID_PATTERN = Regexp.new(
+      '\A(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}' \
+      '|00000000-0000-0000-0000-000000000000)\z',
+      Regexp::IGNORECASE
+    ).freeze
+
     # @return [String] Unique identifier for the Snapshot
     attr_reader :id
 
@@ -120,5 +128,11 @@ module Daytona
     # @param dto [DaytonaApiClient::SnapshotDto] The snapshot DTO from the API
     # @return [Daytona::Snapshot] The snapshot instance
     def self.from_dto(dto) = new(dto)
+
+    # Whether the given value looks like a Snapshot ID (a UUID) rather than a name.
+    #
+    # @param value [Object] value to test
+    # @return [Boolean] true when value is a UUID-shaped String
+    def self.id?(value) = value.is_a?(String) && SNAPSHOT_ID_PATTERN.match?(value)
   end
 end

--- a/sdk-ruby/lib/daytona/snapshot_service.rb
+++ b/sdk-ruby/lib/daytona/snapshot_service.rb
@@ -50,7 +50,10 @@ module Daytona
 
     # Delete a Snapshot.
     #
-    # @param snapshot [Daytona::Snapshot] Snapshot to delete
+    # @param snapshot [Daytona::Snapshot, String] Snapshot to delete, or its ID or name.
+    #   Call cost: 1 API call for a Snapshot object or UUID string; 2 for a name
+    #   (resolve, then delete); up to 3 in the worst case for a UUID-formatted name
+    #   (the optimistic delete 404s, then resolve + delete).
     # @return [void]
     #
     # @example
@@ -58,11 +61,13 @@ module Daytona
     #   snapshot = daytona.snapshot.get("demo")
     #   daytona.snapshot.delete(snapshot)
     #   puts "Snapshot deleted"
-    def delete(snapshot) = snapshots_api.remove_snapshot(snapshot.id)
+    def delete(snapshot)
+      call_with_resolved_id(snapshot) { |id| snapshots_api.remove_snapshot(id) }
+    end
 
-    # Get a Snapshot by name.
+    # Get a Snapshot by ID or name.
     #
-    # @param name [String] Name of the Snapshot to get
+    # @param name [String] ID or name of the Snapshot to get
     # @return [Daytona::Snapshot] The Snapshot object
     #
     # @example
@@ -126,11 +131,15 @@ module Daytona
       Snapshot.from_dto(snapshot)
     end
 
-    # Activate a snapshot
+    # Activate a snapshot.
     #
-    # @param snapshot [Daytona::Snapshot] The snapshot instance
+    # @param snapshot [Daytona::Snapshot, String] The Snapshot instance, or its ID or name.
+    #   Call cost matches `delete`: 1 for an object or UUID string, 2 for a name,
+    #   up to 3 for a UUID-formatted name (optimistic 404 then resolve + activate).
     # @return [Daytona::Snapshot]
-    def activate(snapshot) = Snapshot.from_dto(snapshots_api.activate_snapshot(snapshot.id))
+    def activate(snapshot)
+      Snapshot.from_dto(call_with_resolved_id(snapshot) { |id| snapshots_api.activate_snapshot(id) })
+    end
 
     instrument :list, :delete, :get, :create, :activate, component: 'SnapshotService'
 
@@ -174,6 +183,30 @@ module Daytona
 
     # @return [Daytona::OtelState, nil]
     attr_reader :otel_state
+
+    # Invoke an ID-based Snapshot operation, resolving the given identifier with as
+    # few API calls as possible. Snapshot names may themselves be UUID-formatted, so
+    # a UUID-shaped string is first tried directly as an ID (single call) and only
+    # resolved through the API on a 404. Any other string costs one resolution call.
+    #
+    # @param snapshot [Daytona::Snapshot, String] Snapshot instance, ID, or name
+    # @yield [String] resolved Snapshot ID
+    # @yieldreturn [Object] operation result
+    # @return [Object] whatever the block returns
+    def call_with_resolved_id(snapshot)
+      return yield(snapshot.id) unless snapshot.is_a?(String)
+
+      if Snapshot.id?(snapshot)
+        begin
+          return yield(snapshot)
+        rescue DaytonaApiClient::ApiError => e
+          raise unless e.code == 404
+        end
+      end
+
+      resolved = snapshots_api.get_snapshot(snapshot)
+      yield(resolved.id)
+    end
 
     # Wait for snapshot to reach a terminal state (ACTIVE, ERROR, or BUILD_FAILED)
     # Optionally streams logs if on_logs callback is provided

--- a/sdk-ruby/spec/daytona/snapshot_service_spec.rb
+++ b/sdk-ruby/spec/daytona/snapshot_service_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe Daytona::SnapshotService do
   end
 
   describe '#delete' do
+    let(:uuid) { '11111111-2222-4333-8444-555555555555' }
+
     it 'removes snapshot by id' do
       snapshot = Daytona::Snapshot.from_dto(build_snapshot_dto)
       allow(snapshots_api).to receive(:remove_snapshot).with('snap-123')
@@ -65,6 +67,63 @@ RSpec.describe Daytona::SnapshotService do
       service.delete(snapshot)
 
       expect(snapshots_api).to have_received(:remove_snapshot).with('snap-123')
+    end
+
+    it 'resolves a name to an id before deleting' do
+      dto = build_snapshot_dto(id: 'snap-123', name: 'the-name')
+      allow(snapshots_api).to receive(:get_snapshot).with('the-name').and_return(dto)
+      allow(snapshots_api).to receive(:remove_snapshot).with('snap-123')
+
+      service.delete('the-name')
+
+      expect(snapshots_api).to have_received(:get_snapshot).with('the-name').ordered
+      expect(snapshots_api).to have_received(:remove_snapshot).with('snap-123').ordered
+    end
+
+    it 'deletes by uuid string directly without resolving' do
+      allow(snapshots_api).to receive(:remove_snapshot).with(uuid)
+      allow(snapshots_api).to receive(:get_snapshot)
+
+      service.delete(uuid)
+
+      expect(snapshots_api).to have_received(:remove_snapshot).with(uuid)
+      expect(snapshots_api).not_to have_received(:get_snapshot)
+    end
+
+    it 'falls back to name resolution when the optimistic uuid delete returns 404' do
+      resolved_dto = build_snapshot_dto(id: 'snap-real', name: uuid)
+      call_sequence = []
+      allow(snapshots_api).to receive(:remove_snapshot) do |arg|
+        call_sequence << [:remove_snapshot, arg]
+        raise DaytonaApiClient::ApiError.new(code: 404, message: 'not found') if arg == uuid
+
+        nil
+      end
+      allow(snapshots_api).to receive(:get_snapshot).with(uuid) do |arg|
+        call_sequence << [:get_snapshot, arg]
+        resolved_dto
+      end
+
+      service.delete(uuid)
+
+      expect(call_sequence).to eq(
+        [
+          [:remove_snapshot, uuid],
+          [:get_snapshot, uuid],
+          [:remove_snapshot, 'snap-real']
+        ]
+      )
+    end
+
+    it 're-raises non-404 errors from the optimistic uuid delete without resolving' do
+      error = DaytonaApiClient::ApiError.new(code: 403, message: 'forbidden')
+      allow(snapshots_api).to receive(:remove_snapshot).with(uuid).and_raise(error)
+      allow(snapshots_api).to receive(:get_snapshot)
+
+      expect { service.delete(uuid) }.to raise_error(DaytonaApiClient::ApiError) do |e|
+        expect(e.code).to eq(403)
+      end
+      expect(snapshots_api).not_to have_received(:get_snapshot)
     end
   end
 
@@ -78,6 +137,20 @@ RSpec.describe Daytona::SnapshotService do
 
       expect(result).to be_a(Daytona::Snapshot)
       expect(result.state).to eq('active')
+    end
+
+    it 'resolves a name string before activating' do
+      dto = build_snapshot_dto(id: 'snap-123', name: 'my-snap')
+      activated_dto = build_snapshot_dto(id: 'snap-123', name: 'my-snap', state: 'active')
+      allow(snapshots_api).to receive(:get_snapshot).with('my-snap').and_return(dto)
+      allow(snapshots_api).to receive(:activate_snapshot).with('snap-123').and_return(activated_dto)
+
+      result = service.activate('my-snap')
+
+      expect(result).to be_a(Daytona::Snapshot)
+      expect(result.state).to eq('active')
+      expect(snapshots_api).to have_received(:get_snapshot).with('my-snap').ordered
+      expect(snapshots_api).to have_received(:activate_snapshot).with('snap-123').ordered
     end
   end
 

--- a/sdk-typescript/src/Snapshot.ts
+++ b/sdk-typescript/src/Snapshot.ts
@@ -5,7 +5,7 @@
 
 import { ObjectStorageApi, SnapshotsApi, SnapshotState, SandboxClass, Configuration } from '@daytona/api-client'
 import type { SnapshotDto, CreateSnapshot, PaginatedSnapshots as PaginatedSnapshotsDto } from '@daytona/api-client'
-import { DaytonaError } from './errors/DaytonaError'
+import { DaytonaError, DaytonaNotFoundError } from './errors/DaytonaError'
 import { Image } from './Image'
 import type { Resources } from './Daytona'
 import { processStreamingResponse } from './utils/Stream'
@@ -67,6 +67,13 @@ export type CreateSnapshotParams = {
 }
 
 /**
+ * Matches RFC 4122 UUIDs (versions 1-5) and the nil UUID — the same set the
+ * Daytona API recognizes as snapshot IDs. Anything else is treated as a name.
+ */
+const UUID_REGEX =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i
+
+/**
  * Service for managing Daytona Snapshots. Can be used to list, get, create and delete Snapshots.
  *
  * @class
@@ -104,9 +111,9 @@ export class SnapshotService {
   }
 
   /**
-   * Gets a Snapshot by its name.
+   * Gets a Snapshot by its ID or name.
    *
-   * @param {string} name - Name of the Snapshot to retrieve
+   * @param {string} idOrName - ID or name of the Snapshot to retrieve
    * @returns {Promise<Snapshot>} The requested Snapshot
    * @throws {Error} If the Snapshot does not exist or cannot be accessed
    *
@@ -116,27 +123,26 @@ export class SnapshotService {
    * console.log(`Snapshot ${snapshot.name} is in state ${snapshot.state}`);
    */
   @WithInstrumentation()
-  async get(name: string): Promise<Snapshot> {
-    const response = await this.snapshotsApi.getSnapshot(name)
+  async get(idOrName: string): Promise<Snapshot> {
+    const response = await this.snapshotsApi.getSnapshot(idOrName)
     return response.data as Snapshot
   }
 
   /**
    * Deletes a Snapshot.
    *
-   * @param {Snapshot} snapshot - Snapshot to delete
+   * @param {Snapshot | string} snapshot - Snapshot to delete, or its ID or name
    * @returns {Promise<void>}
    * @throws {Error} If the Snapshot does not exist or cannot be deleted
    *
    * @example
    * const daytona = new Daytona();
-   * const snapshot = await daytona.snapshot.get("snapshot-name");
-   * await daytona.snapshot.delete(snapshot);
+   * await daytona.snapshot.delete("snapshot-name");
    * console.log("Snapshot deleted successfully");
    */
   @WithInstrumentation()
-  async delete(snapshot: Snapshot): Promise<void> {
-    await this.snapshotsApi.removeSnapshot(snapshot.id)
+  async delete(snapshot: Snapshot | string): Promise<void> {
+    await this.callWithResolvedId(snapshot, async (id) => this.snapshotsApi.removeSnapshot(id))
   }
 
   /**
@@ -263,12 +269,46 @@ export class SnapshotService {
   /**
    * Activates a snapshot.
    *
-   * @param {Snapshot} snapshot - Snapshot to activate
+   * @param {Snapshot | string} snapshot - Snapshot to activate, or its ID or name
    * @returns {Promise<Snapshot>} The activated Snapshot instance
    */
   @WithInstrumentation()
-  async activate(snapshot: Snapshot): Promise<Snapshot> {
-    return (await this.snapshotsApi.activateSnapshot(snapshot.id)).data as Snapshot
+  async activate(snapshot: Snapshot | string): Promise<Snapshot> {
+    return await this.callWithResolvedId(
+      snapshot,
+      async (id) => (await this.snapshotsApi.activateSnapshot(id)).data as Snapshot,
+    )
+  }
+
+  /**
+   * Invokes an ID-based Snapshot operation, resolving the given identifier with as few
+   * API calls as possible.
+   *
+   * Snapshot names may themselves be UUID-formatted, so a UUID-shaped string is first
+   * tried directly as an ID (single call) and only resolved through the API on a miss.
+   * Everything else is a name and requires one resolution call.
+   *
+   * @param {Snapshot | string} snapshot - Snapshot instance, ID or name
+   * @param {(id: string) => Promise<T>} operation - ID-based operation to invoke
+   */
+  private async callWithResolvedId<T>(snapshot: Snapshot | string, operation: (id: string) => Promise<T>): Promise<T> {
+    if (typeof snapshot !== 'string') {
+      return await operation(snapshot.id)
+    }
+
+    if (UUID_REGEX.test(snapshot)) {
+      try {
+        return await operation(snapshot)
+      } catch (error) {
+        if (!(error instanceof DaytonaNotFoundError)) {
+          throw error
+        }
+        // Not an existing ID — may still be a UUID-formatted name; fall through to resolution.
+      }
+    }
+
+    const resolved = await this.snapshotsApi.getSnapshot(snapshot)
+    return await operation(resolved.data.id)
   }
 
   /**

--- a/sdk-typescript/src/__tests__/Snapshot.test.ts
+++ b/sdk-typescript/src/__tests__/Snapshot.test.ts
@@ -5,6 +5,7 @@ import type { Configuration } from '@daytona/api-client'
 import { createApiResponse } from './helpers'
 import { SnapshotService } from '../Snapshot'
 import { Image } from '../Image'
+import { DaytonaForbiddenError, DaytonaNotFoundError } from '../errors/DaytonaError'
 
 const mockProcessStreamingResponse = jest.fn()
 const mockDynamicImport = jest.fn()
@@ -71,6 +72,52 @@ describe('SnapshotService', () => {
     })
     await expect(service.get('snap1')).resolves.toEqual({ id: 's1', name: 'snap1' })
     await service.delete({ id: 's1' } as never)
+  })
+
+  it('deletes snapshot by name with a single resolution call', async () => {
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ id: 's1', name: 'snap1' }))
+    snapshotsApi.removeSnapshot.mockResolvedValue(createApiResponse(undefined))
+
+    await service.delete('snap1')
+
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledTimes(1)
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledWith('snap1')
+    expect(snapshotsApi.removeSnapshot).toHaveBeenCalledTimes(1)
+    expect(snapshotsApi.removeSnapshot).toHaveBeenCalledWith('s1')
+  })
+
+  it('deletes snapshot by UUID id without resolution', async () => {
+    const id = '9f0a2b52-6a5f-4bd6-9c1e-1c9a1cf7d3aa'
+    snapshotsApi.removeSnapshot.mockResolvedValue(createApiResponse(undefined))
+
+    await service.delete(id)
+
+    expect(snapshotsApi.getSnapshot).not.toHaveBeenCalled()
+    expect(snapshotsApi.removeSnapshot).toHaveBeenCalledTimes(1)
+    expect(snapshotsApi.removeSnapshot).toHaveBeenCalledWith(id)
+  })
+
+  it('falls back to name resolution when UUID-formatted name is not an id', async () => {
+    const uuidName = '9f0a2b52-6a5f-4bd6-9c1e-1c9a1cf7d3aa'
+    snapshotsApi.removeSnapshot
+      .mockRejectedValueOnce(new DaytonaNotFoundError('not found'))
+      .mockResolvedValueOnce(createApiResponse(undefined))
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ id: 'real-id', name: uuidName }))
+
+    await service.delete(uuidName)
+
+    expect(snapshotsApi.removeSnapshot).toHaveBeenNthCalledWith(1, uuidName)
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledWith(uuidName)
+    expect(snapshotsApi.removeSnapshot).toHaveBeenNthCalledWith(2, 'real-id')
+  })
+
+  it('propagates non-404 errors from delete by UUID without resolution', async () => {
+    const id = '9f0a2b52-6a5f-4bd6-9c1e-1c9a1cf7d3aa'
+    snapshotsApi.removeSnapshot.mockRejectedValue(new DaytonaForbiddenError('forbidden'))
+
+    await expect(service.delete(id)).rejects.toThrow('forbidden')
+    expect(snapshotsApi.getSnapshot).not.toHaveBeenCalled()
+    expect(snapshotsApi.removeSnapshot).toHaveBeenCalledTimes(1)
   })
 
   it('creates snapshot from image name with resources and region', async () => {
@@ -181,5 +228,14 @@ describe('SnapshotService', () => {
     snapshotsApi.activateSnapshot.mockResolvedValue(createApiResponse({ id: 's1', name: 'snap1', state: 'active' }))
 
     await expect(service.activate({ id: 's1' } as never)).resolves.toEqual({ id: 's1', name: 'snap1', state: 'active' })
+  })
+
+  it('activates snapshots by name', async () => {
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ id: 's1', name: 'snap1' }))
+    snapshotsApi.activateSnapshot.mockResolvedValue(createApiResponse({ id: 's1', name: 'snap1', state: 'active' }))
+
+    await expect(service.activate('snap1')).resolves.toEqual({ id: 's1', name: 'snap1', state: 'active' })
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledWith('snap1')
+    expect(snapshotsApi.activateSnapshot).toHaveBeenCalledWith('s1')
   })
 })


### PR DESCRIPTION
## Snapshot operations by ID or name (all SDKs + CLI)

Snapshot `delete`/`activate` now accept an **ID or a name** (E2B-style), resolved
client-side with as few API calls as possible. Implemented identically across
TypeScript, Python (sync/async), Go, Ruby, Java SDKs, and the CLI.

### Resolution algorithm

Snapshot names may themselves be UUID-formatted, so a UUID-shaped string is ambiguous:

| Input | Calls |
|---|---|
| `Snapshot` object | 1 — `DELETE/POST {id}` |
| UUID-shaped string | 1 — optimistic direct call; on **404 only**, falls back to `GET` (server resolves ID-or-name) + retry → 3 worst case |
| Any other string (name) | 2 — `GET` resolve + operation (minimum possible; those endpoints are UUID-only) |

Non-404 errors propagate immediately without fallback. The UUID check is a strict
RFC 4122 (v1–5 + nil) regex mirroring the server's `uuid.validate()` — deliberately
not a uuid library, since their validators are looser (dashless/URN forms, v6+) and
drift across versions, which could turn the name-fallback into 400s.

### API changes
- **TS / Python / Ruby**: `delete`/`activate` widened to `Snapshot | string` (backward compatible)
- **Go**: new `Snapshot.DeleteByNameOrID(ctx, nameOrID)` and `Snapshot.Activate(ctx, nameOrID)`; existing `Delete(ctx, *types.Snapshot)` unchanged
- **Java**: `delete(String)` widened to ID-or-name; new `delete(Snapshot)`, `activate(String)`, `activate(Snapshot)`
- **CLI**: `snapshot delete` now does 1 call for UUID args (was always 2); new `snapshot activate [SNAPSHOT_ID | SNAPSHOT_NAME]` command
- `get()` docs corrected everywhere: accepts ID or name (server already supported it)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ID-or-name support for snapshot delete and activate across all SDKs and the CLI with an optimistic client-side resolution to cut extra API calls. Also adds a new `snapshot activate` CLI command, strict UUID matching, and updated docs/tests.

- **New Features**
  - Resolution: UUID-shaped → try ID endpoint; on 404, `GET` resolve then retry. Non-UUID → `GET` resolve then call. Non-404 errors propagate. Uses a strict RFC 4122 UUID regex matching server behavior.
  - SDKs: TypeScript/Python/Ruby `delete`/`activate` accept `Snapshot | string`; `get()` docs now say ID or name. Go adds `DeleteByNameOrID(ctx, string)` and `Activate(ctx, string)` (existing `Delete(ctx, *Snapshot)` kept). Java widens `delete(String)` and adds `delete(Snapshot)`, `activate(String)`, `activate(Snapshot)`.
  - CLI: adds `snapshot activate [SNAPSHOT_ID | SNAPSHOT_NAME]`; optimizes `snapshot delete` to one call for UUID args; shares strict UUID validator.
  - Docs/tests updated across SDKs.

<sup>Written for commit 89880cde547972367645fb0eae76b5957d671416. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

