### PR TITLE
fix(sdk-typescript): export Snapshot and PaginatedSnapshots types

### DIFF
--- a/sdk-typescript/src/index.ts
+++ b/sdk-typescript/src/index.ts
@@ -86,7 +86,7 @@ export { Image } from './Image'
 export { Sandbox } from './Sandbox'
 export type { ListSandboxesQuery, SandboxMetrics } from './Sandbox'
 export type { Secret, CreateSecretParams, UpdateSecretParams, ListSecretsQuery, ListSecretsResponse } from './Secret'
-export type { CreateSnapshotParams, ListSnapshotsQuery } from './Snapshot'
+export type { CreateSnapshotParams, ListSnapshotsQuery, PaginatedSnapshots, Snapshot } from './Snapshot'
 export type { WarmPool } from './WarmPool'
 export { ComputerUse, Mouse, Keyboard, Screenshot, Display, Accessibility } from './ComputerUse'
 export type {
@@ -111,6 +111,7 @@ export type { ExecutionError, ExecutionResult, OutputMessage, RunCodeOptions } f
 export {
   GpuType,
   SandboxState,
+  SnapshotState,
   SandboxListSortField,
   SandboxListSortDirection,
   SandboxClass,


### PR DESCRIPTION
## Summary

The TypeScript SDK does not export the `Snapshot` type — `snapshot.get(name)` returns `Promise<Snapshot>`, but `Snapshot` cannot be imported from `@daytona/sdk`.

This was an oversight in the package entry point: `sdk-typescript/src/index.ts` only exported `CreateSnapshotParams` and `ListSnapshotsQuery` from `./Snapshot`.

## Changes

- Export `Snapshot` and `PaginatedSnapshots` types from `./Snapshot` (`PaginatedSnapshots` is returned by `snapshot.list()` and had the same problem)
- Export the `SnapshotState` enum from `@daytona/api-client` (referenced by `Snapshot.state`), alongside the already-exported `SandboxState`

## Verification

- `yarn nx build sdk-typescript` — pass
- `yarn nx test sdk-typescript` — 295/295 tests pass
- Consumer-style compile check against the built package (strict tsc, nodenext):

```ts
import { Daytona, SnapshotState } from '@daytona/sdk'
import type { Snapshot, PaginatedSnapshots } from '@daytona/sdk'

const s: Snapshot = await daytona.snapshot.get('my-snapshot')
const p: PaginatedSnapshots = await daytona.snapshot.list()
if (s.state === SnapshotState.ACTIVE) { /* ... */ }
```

Type-only additions to the public surface — no runtime behavior change (`SnapshotState` is a re-exported enum value from the generated api-client).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export `Snapshot` and `PaginatedSnapshots` from the SDK entry point and re-export `SnapshotState` from `@daytona/api-client` so consumers can import the types returned by `snapshot.get()` and `snapshot.list()`. Previously these types were not importable from `@daytona/sdk`; now they are. No runtime behavior change.

**Review notes**
- Change is limited to `sdk-typescript/src/index.ts`: adds `Snapshot`, `PaginatedSnapshots`, and `SnapshotState` to exports.
- Consumers can now import `Snapshot`, `PaginatedSnapshots`, and `SnapshotState` from `@daytona/sdk`; no migration required.

<sup>Written for commit 65decf01a59b4ebad7defd125ba631f3ce3246e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

