### PR TITLE
feat: spot gpus

### DIFF
--- a/api-client-go/api/openapi.yaml
+++ b/api-client-go/api/openapi.yaml
@@ -2507,6 +2507,8 @@ paths:
       tags:
       - sandbox
     get:
+      description: Sandboxes destroyed by spot preemption remain retrievable for 24
+        hours so `spotEvictedAt` can be read.
       operationId: getSandbox
       parameters:
       - description: Use with JWT to specify the organization ID
@@ -9718,6 +9720,7 @@ components:
         updatedAt: 2024-10-01T12:00:00Z
         desiredState: destroyed
         networkAllowList: "192.168.1.0/16,10.0.0.0/24"
+        spotEvictedAt: 2026-08-13T12:00:00.000Z
         recoverable: true
         cpu: 2
         gpu: 0
@@ -9727,6 +9730,7 @@ components:
           daytona.io/public: "true"
         disk: 10
         autoDestroyAt: 2026-07-15T12:00:00.000Z
+        spot: false
         name: MySandbox
         backupState: None
         user: daytona
@@ -9809,6 +9813,19 @@ components:
           description: The GPU quota for the sandbox
           example: 0
           type: number
+        spot:
+          default: false
+          description: Whether this is a spot GPU sandbox. Spot sandboxes may be instantly
+            terminated to free capacity for on-demand GPU sandboxes. Absent on APIs
+            that predate this field; treat as false.
+          example: false
+          type: boolean
+        spotEvictedAt:
+          description: "When this sandbox was evicted by spot preemption. Set as soon\
+            \ as the sandbox is marked for eviction, so it is already present while\
+            \ the sandbox is still winding down."
+          example: 2026-08-13T12:00:00.000Z
+          type: string
         gpuType:
           allOf:
           - $ref: "#/components/schemas/GpuType"
@@ -9925,6 +9942,7 @@ components:
           updatedAt: 2024-10-01T12:00:00Z
           desiredState: destroyed
           networkAllowList: "192.168.1.0/16,10.0.0.0/24"
+          spotEvictedAt: 2026-08-13T12:00:00.000Z
           recoverable: true
           cpu: 2
           gpu: 0
@@ -9934,6 +9952,7 @@ components:
             daytona.io/public: "true"
           disk: 10
           autoDestroyAt: 2026-07-15T12:00:00.000Z
+          spot: false
           name: MySandbox
           backupState: None
           user: daytona
@@ -9960,6 +9979,7 @@ components:
           updatedAt: 2024-10-01T12:00:00Z
           desiredState: destroyed
           networkAllowList: "192.168.1.0/16,10.0.0.0/24"
+          spotEvictedAt: 2026-08-13T12:00:00.000Z
           recoverable: true
           cpu: 2
           gpu: 0
@@ -9969,6 +9989,7 @@ components:
             daytona.io/public: "true"
           disk: 10
           autoDestroyAt: 2026-07-15T12:00:00.000Z
+          spot: false
           name: MySandbox
           backupState: None
           user: daytona
@@ -10075,6 +10096,7 @@ components:
         sandboxClass: linux-vm
         desiredState: destroyed
         networkAllowList: "192.168.1.0/16,10.0.0.0/24"
+        spotEvictedAt: 2026-08-13T12:00:00.000Z
         volumes:
         - mountPath: /data
           volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -10094,6 +10116,7 @@ components:
         target: local
         disk: 10
         autoDestroyAt: 2026-07-15T12:00:00.000Z
+        spot: false
         name: MySandbox
         backupState: None
         user: daytona
@@ -10170,6 +10193,19 @@ components:
           description: The GPU quota for the sandbox
           example: 0
           type: number
+        spot:
+          default: false
+          description: Whether this is a spot GPU sandbox. Spot sandboxes may be instantly
+            terminated to free capacity for on-demand GPU sandboxes. Absent on APIs
+            that predate this field; treat as false.
+          example: false
+          type: boolean
+        spotEvictedAt:
+          description: "When this sandbox was destroyed by spot preemption. Set only\
+            \ for spot-evicted sandboxes, which stay retrievable by ID for 24 hours\
+            \ after eviction."
+          example: 2026-08-13T12:00:00.000Z
+          type: string
         gpuType:
           allOf:
           - $ref: "#/components/schemas/GpuType"
@@ -10341,6 +10377,7 @@ components:
           sandboxClass: linux-vm
           desiredState: destroyed
           networkAllowList: "192.168.1.0/16,10.0.0.0/24"
+          spotEvictedAt: 2026-08-13T12:00:00.000Z
           volumes:
           - mountPath: /data
             volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -10360,6 +10397,7 @@ components:
           target: local
           disk: 10
           autoDestroyAt: 2026-07-15T12:00:00.000Z
+          spot: false
           name: MySandbox
           backupState: None
           user: daytona
@@ -10389,6 +10427,7 @@ components:
           sandboxClass: linux-vm
           desiredState: destroyed
           networkAllowList: "192.168.1.0/16,10.0.0.0/24"
+          spotEvictedAt: 2026-08-13T12:00:00.000Z
           volumes:
           - mountPath: /data
             volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -10408,6 +10447,7 @@ components:
           target: local
           disk: 10
           autoDestroyAt: 2026-07-15T12:00:00.000Z
+          spot: false
           name: MySandbox
           backupState: None
           user: daytona
@@ -10486,6 +10526,7 @@ components:
           daytona.io/public: "true"
         target: us
         disk: 3
+        spot: false
         name: MySandbox
         user: daytona
         autoArchiveInterval: 10080
@@ -10567,6 +10608,13 @@ components:
           items:
             $ref: "#/components/schemas/GpuType"
           type: array
+        spot:
+          default: false
+          description: "GPU-only. When true, the sandbox may be instantly terminated\
+            \ without notice to free GPU capacity for an on-demand (non-spot) GPU\
+            \ sandbox. Ignored / rejected when the sandbox requests no GPUs."
+          example: false
+          type: boolean
         memory:
           description: Memory allocated to the sandbox in GB
           example: 1
@@ -13306,6 +13354,7 @@ components:
             - auto_archive
             - auto_delete
             - ttl_expire
+            - spot_evict
             type: string
           type: array
       required:

--- a/api-client-go/api_sandbox.go
+++ b/api-client-go/api_sandbox.go
@@ -207,6 +207,8 @@ type SandboxAPI interface {
 	/*
 	GetSandbox Get sandbox details
 
+	Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
+
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param sandboxIdOrName ID or name of the sandbox
 	@return SandboxAPIGetSandboxRequest
@@ -2189,6 +2191,8 @@ func (r SandboxAPIGetSandboxRequest) Execute() (*Sandbox, *http.Response, error)
 
 /*
 GetSandbox Get sandbox details
+
+Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param sandboxIdOrName ID or name of the sandbox

--- a/api-client-go/model_create_sandbox.go
+++ b/api-client-go/model_create_sandbox.go
@@ -48,6 +48,8 @@ type CreateSandbox struct {
 	Gpu *int32 `json:"gpu,omitempty"`
 	// Preferred GPU type for the sandbox. Accepts a single value or an ordered preference list — the scheduler tries each in order and pins the sandbox to the first that has capacity.
 	GpuType []GpuType `json:"gpuType,omitempty"`
+	// GPU-only. When true, the sandbox may be instantly terminated without notice to free GPU capacity for an on-demand (non-spot) GPU sandbox. Ignored / rejected when the sandbox requests no GPUs.
+	Spot *bool `json:"spot,omitempty"`
 	// Memory allocated to the sandbox in GB
 	Memory *int32 `json:"memory,omitempty"`
 	// Disk space allocated to the sandbox in GB
@@ -81,6 +83,8 @@ type _CreateSandbox CreateSandbox
 // will change when the set of required properties is changed
 func NewCreateSandbox() *CreateSandbox {
 	this := CreateSandbox{}
+	var spot bool = false
+	this.Spot = &spot
 	return &this
 }
 
@@ -89,6 +93,8 @@ func NewCreateSandbox() *CreateSandbox {
 // but it doesn't guarantee that properties required by API are set
 func NewCreateSandboxWithDefaults() *CreateSandbox {
 	this := CreateSandbox{}
+	var spot bool = false
+	this.Spot = &spot
 	return &this
 }
 
@@ -540,6 +546,38 @@ func (o *CreateSandbox) SetGpuType(v []GpuType) {
 	o.GpuType = v
 }
 
+// GetSpot returns the Spot field value if set, zero value otherwise.
+func (o *CreateSandbox) GetSpot() bool {
+	if o == nil || IsNil(o.Spot) {
+		var ret bool
+		return ret
+	}
+	return *o.Spot
+}
+
+// GetSpotOk returns a tuple with the Spot field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CreateSandbox) GetSpotOk() (*bool, bool) {
+	if o == nil || IsNil(o.Spot) {
+		return nil, false
+	}
+	return o.Spot, true
+}
+
+// HasSpot returns a boolean if a field has been set.
+func (o *CreateSandbox) HasSpot() bool {
+	if o != nil && !IsNil(o.Spot) {
+		return true
+	}
+
+	return false
+}
+
+// SetSpot gets a reference to the given bool and assigns it to the Spot field.
+func (o *CreateSandbox) SetSpot(v bool) {
+	o.Spot = &v
+}
+
 // GetMemory returns the Memory field value if set, zero value otherwise.
 func (o *CreateSandbox) GetMemory() int32 {
 	if o == nil || IsNil(o.Memory) {
@@ -944,6 +982,9 @@ func (o CreateSandbox) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.GpuType) {
 		toSerialize["gpuType"] = o.GpuType
 	}
+	if !IsNil(o.Spot) {
+		toSerialize["spot"] = o.Spot
+	}
 	if !IsNil(o.Memory) {
 		toSerialize["memory"] = o.Memory
 	}
@@ -1013,6 +1054,7 @@ func (o *CreateSandbox) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "cpu")
 		delete(additionalProperties, "gpu")
 		delete(additionalProperties, "gpuType")
+		delete(additionalProperties, "spot")
 		delete(additionalProperties, "memory")
 		delete(additionalProperties, "disk")
 		delete(additionalProperties, "autoStopInterval")

--- a/api-client-go/model_sandbox.go
+++ b/api-client-go/model_sandbox.go
@@ -51,6 +51,10 @@ type Sandbox struct {
 	Cpu float32 `json:"cpu"`
 	// The GPU quota for the sandbox
 	Gpu float32 `json:"gpu"`
+	// Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.
+	Spot *bool `json:"spot,omitempty"`
+	// When this sandbox was destroyed by spot preemption. Set only for spot-evicted sandboxes, which stay retrievable by ID for 24 hours after eviction.
+	SpotEvictedAt *string `json:"spotEvictedAt,omitempty"`
 	// The GPU type assigned to the sandbox
 	GpuType *GpuType `json:"gpuType,omitempty"`
 	// The memory quota for the sandbox
@@ -125,6 +129,8 @@ func NewSandbox(id string, organizationId string, name string, user string, env 
 	this.Target = target
 	this.Cpu = cpu
 	this.Gpu = gpu
+	var spot bool = false
+	this.Spot = &spot
 	this.Memory = memory
 	this.Disk = disk
 	this.ToolboxProxyUrl = toolboxProxyUrl
@@ -136,6 +142,8 @@ func NewSandbox(id string, organizationId string, name string, user string, env 
 // but it doesn't guarantee that properties required by API are set
 func NewSandboxWithDefaults() *Sandbox {
 	this := Sandbox{}
+	var spot bool = false
+	this.Spot = &spot
 	return &this
 }
 
@@ -529,6 +537,70 @@ func (o *Sandbox) GetGpuOk() (*float32, bool) {
 // SetGpu sets field value
 func (o *Sandbox) SetGpu(v float32) {
 	o.Gpu = v
+}
+
+// GetSpot returns the Spot field value if set, zero value otherwise.
+func (o *Sandbox) GetSpot() bool {
+	if o == nil || IsNil(o.Spot) {
+		var ret bool
+		return ret
+	}
+	return *o.Spot
+}
+
+// GetSpotOk returns a tuple with the Spot field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Sandbox) GetSpotOk() (*bool, bool) {
+	if o == nil || IsNil(o.Spot) {
+		return nil, false
+	}
+	return o.Spot, true
+}
+
+// HasSpot returns a boolean if a field has been set.
+func (o *Sandbox) HasSpot() bool {
+	if o != nil && !IsNil(o.Spot) {
+		return true
+	}
+
+	return false
+}
+
+// SetSpot gets a reference to the given bool and assigns it to the Spot field.
+func (o *Sandbox) SetSpot(v bool) {
+	o.Spot = &v
+}
+
+// GetSpotEvictedAt returns the SpotEvictedAt field value if set, zero value otherwise.
+func (o *Sandbox) GetSpotEvictedAt() string {
+	if o == nil || IsNil(o.SpotEvictedAt) {
+		var ret string
+		return ret
+	}
+	return *o.SpotEvictedAt
+}
+
+// GetSpotEvictedAtOk returns a tuple with the SpotEvictedAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Sandbox) GetSpotEvictedAtOk() (*string, bool) {
+	if o == nil || IsNil(o.SpotEvictedAt) {
+		return nil, false
+	}
+	return o.SpotEvictedAt, true
+}
+
+// HasSpotEvictedAt returns a boolean if a field has been set.
+func (o *Sandbox) HasSpotEvictedAt() bool {
+	if o != nil && !IsNil(o.SpotEvictedAt) {
+		return true
+	}
+
+	return false
+}
+
+// SetSpotEvictedAt gets a reference to the given string and assigns it to the SpotEvictedAt field.
+func (o *Sandbox) SetSpotEvictedAt(v string) {
+	o.SpotEvictedAt = &v
 }
 
 // GetGpuType returns the GpuType field value if set, zero value otherwise.
@@ -1346,6 +1418,12 @@ func (o Sandbox) ToMap() (map[string]interface{}, error) {
 	toSerialize["target"] = o.Target
 	toSerialize["cpu"] = o.Cpu
 	toSerialize["gpu"] = o.Gpu
+	if !IsNil(o.Spot) {
+		toSerialize["spot"] = o.Spot
+	}
+	if !IsNil(o.SpotEvictedAt) {
+		toSerialize["spotEvictedAt"] = o.SpotEvictedAt
+	}
 	if !IsNil(o.GpuType) {
 		toSerialize["gpuType"] = o.GpuType
 	}
@@ -1486,6 +1564,8 @@ func (o *Sandbox) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "target")
 		delete(additionalProperties, "cpu")
 		delete(additionalProperties, "gpu")
+		delete(additionalProperties, "spot")
+		delete(additionalProperties, "spotEvictedAt")
 		delete(additionalProperties, "gpuType")
 		delete(additionalProperties, "memory")
 		delete(additionalProperties, "disk")

--- a/api-client-go/model_sandbox_list_item.go
+++ b/api-client-go/model_sandbox_list_item.go
@@ -57,6 +57,10 @@ type SandboxListItem struct {
 	Cpu float32 `json:"cpu"`
 	// The GPU quota for the sandbox
 	Gpu float32 `json:"gpu"`
+	// Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.
+	Spot *bool `json:"spot,omitempty"`
+	// When this sandbox was evicted by spot preemption. Set as soon as the sandbox is marked for eviction, so it is already present while the sandbox is still winding down.
+	SpotEvictedAt *string `json:"spotEvictedAt,omitempty"`
 	// The GPU type assigned to the sandbox
 	GpuType *GpuType `json:"gpuType,omitempty"`
 	// The memory quota for the sandbox
@@ -109,6 +113,8 @@ func NewSandboxListItem(id string, organizationId string, name string, target st
 	this.NetworkBlockAll = networkBlockAll
 	this.Cpu = cpu
 	this.Gpu = gpu
+	var spot bool = false
+	this.Spot = &spot
 	this.Memory = memory
 	this.Disk = disk
 	this.Labels = labels
@@ -121,6 +127,8 @@ func NewSandboxListItem(id string, organizationId string, name string, target st
 // but it doesn't guarantee that properties required by API are set
 func NewSandboxListItemWithDefaults() *SandboxListItem {
 	this := SandboxListItem{}
+	var spot bool = false
+	this.Spot = &spot
 	return &this
 }
 
@@ -626,6 +634,70 @@ func (o *SandboxListItem) GetGpuOk() (*float32, bool) {
 // SetGpu sets field value
 func (o *SandboxListItem) SetGpu(v float32) {
 	o.Gpu = v
+}
+
+// GetSpot returns the Spot field value if set, zero value otherwise.
+func (o *SandboxListItem) GetSpot() bool {
+	if o == nil || IsNil(o.Spot) {
+		var ret bool
+		return ret
+	}
+	return *o.Spot
+}
+
+// GetSpotOk returns a tuple with the Spot field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SandboxListItem) GetSpotOk() (*bool, bool) {
+	if o == nil || IsNil(o.Spot) {
+		return nil, false
+	}
+	return o.Spot, true
+}
+
+// HasSpot returns a boolean if a field has been set.
+func (o *SandboxListItem) HasSpot() bool {
+	if o != nil && !IsNil(o.Spot) {
+		return true
+	}
+
+	return false
+}
+
+// SetSpot gets a reference to the given bool and assigns it to the Spot field.
+func (o *SandboxListItem) SetSpot(v bool) {
+	o.Spot = &v
+}
+
+// GetSpotEvictedAt returns the SpotEvictedAt field value if set, zero value otherwise.
+func (o *SandboxListItem) GetSpotEvictedAt() string {
+	if o == nil || IsNil(o.SpotEvictedAt) {
+		var ret string
+		return ret
+	}
+	return *o.SpotEvictedAt
+}
+
+// GetSpotEvictedAtOk returns a tuple with the SpotEvictedAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SandboxListItem) GetSpotEvictedAtOk() (*string, bool) {
+	if o == nil || IsNil(o.SpotEvictedAt) {
+		return nil, false
+	}
+	return o.SpotEvictedAt, true
+}
+
+// HasSpotEvictedAt returns a boolean if a field has been set.
+func (o *SandboxListItem) HasSpotEvictedAt() bool {
+	if o != nil && !IsNil(o.SpotEvictedAt) {
+		return true
+	}
+
+	return false
+}
+
+// SetSpotEvictedAt gets a reference to the given string and assigns it to the SpotEvictedAt field.
+func (o *SandboxListItem) SetSpotEvictedAt(v string) {
+	o.SpotEvictedAt = &v
 }
 
 // GetGpuType returns the GpuType field value if set, zero value otherwise.
@@ -1154,6 +1226,12 @@ func (o SandboxListItem) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["cpu"] = o.Cpu
 	toSerialize["gpu"] = o.Gpu
+	if !IsNil(o.Spot) {
+		toSerialize["spot"] = o.Spot
+	}
+	if !IsNil(o.SpotEvictedAt) {
+		toSerialize["spotEvictedAt"] = o.SpotEvictedAt
+	}
 	if !IsNil(o.GpuType) {
 		toSerialize["gpuType"] = o.GpuType
 	}
@@ -1267,6 +1345,8 @@ func (o *SandboxListItem) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "domainAllowList")
 		delete(additionalProperties, "cpu")
 		delete(additionalProperties, "gpu")
+		delete(additionalProperties, "spot")
+		delete(additionalProperties, "spotEvictedAt")
 		delete(additionalProperties, "gpuType")
 		delete(additionalProperties, "memory")
 		delete(additionalProperties, "disk")

--- a/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
@@ -2026,7 +2026,7 @@ public class SandboxApi {
 
     /**
      * Get sandbox details
-     * 
+     * Sandboxes destroyed by spot preemption remain retrievable for 24 hours so &#x60;spotEvictedAt&#x60; can be read.
      * @param sandboxIdOrName ID or name of the sandbox (required)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
      * @param verbose Include verbose output (optional)
@@ -2046,7 +2046,7 @@ public class SandboxApi {
 
     /**
      * Get sandbox details
-     * 
+     * Sandboxes destroyed by spot preemption remain retrievable for 24 hours so &#x60;spotEvictedAt&#x60; can be read.
      * @param sandboxIdOrName ID or name of the sandbox (required)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
      * @param verbose Include verbose output (optional)
@@ -2067,7 +2067,7 @@ public class SandboxApi {
 
     /**
      * Get sandbox details (asynchronously)
-     * 
+     * Sandboxes destroyed by spot preemption remain retrievable for 24 hours so &#x60;spotEvictedAt&#x60; can be read.
      * @param sandboxIdOrName ID or name of the sandbox (required)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
      * @param verbose Include verbose output (optional)

--- a/api-client-java/src/main/java/io/daytona/api/client/model/AuditTargetScenario.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/AuditTargetScenario.java
@@ -268,6 +268,8 @@ public class AuditTargetScenario {
     
     TTL_EXPIRE("ttl_expire"),
     
+    SPOT_EVICT("spot_evict"),
+    
     UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 
     private String value;

--- a/api-client-java/src/main/java/io/daytona/api/client/model/CreateSandbox.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/CreateSandbox.java
@@ -127,6 +127,11 @@ public class CreateSandbox {
   @javax.annotation.Nullable
   private List<GpuType> gpuType = new ArrayList<>();
 
+  public static final String SERIALIZED_NAME_SPOT = "spot";
+  @SerializedName(SERIALIZED_NAME_SPOT)
+  @javax.annotation.Nullable
+  private Boolean spot = false;
+
   public static final String SERIALIZED_NAME_MEMORY = "memory";
   @SerializedName(SERIALIZED_NAME_MEMORY)
   @javax.annotation.Nullable
@@ -475,6 +480,25 @@ public class CreateSandbox {
   }
 
 
+  public CreateSandbox spot(@javax.annotation.Nullable Boolean spot) {
+    this.spot = spot;
+    return this;
+  }
+
+  /**
+   * GPU-only. When true, the sandbox may be instantly terminated without notice to free GPU capacity for an on-demand (non-spot) GPU sandbox. Ignored / rejected when the sandbox requests no GPUs.
+   * @return spot
+   */
+  @javax.annotation.Nullable
+  public Boolean getSpot() {
+    return spot;
+  }
+
+  public void setSpot(@javax.annotation.Nullable Boolean spot) {
+    this.spot = spot;
+  }
+
+
   public CreateSandbox memory(@javax.annotation.Nullable Integer memory) {
     this.memory = memory;
     return this;
@@ -768,6 +792,7 @@ public class CreateSandbox {
         Objects.equals(this.cpu, createSandbox.cpu) &&
         Objects.equals(this.gpu, createSandbox.gpu) &&
         Objects.equals(this.gpuType, createSandbox.gpuType) &&
+        Objects.equals(this.spot, createSandbox.spot) &&
         Objects.equals(this.memory, createSandbox.memory) &&
         Objects.equals(this.disk, createSandbox.disk) &&
         Objects.equals(this.autoStopInterval, createSandbox.autoStopInterval) &&
@@ -784,7 +809,7 @@ public class CreateSandbox {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, outboundProxyUrl, target, cpu, gpu, gpuType, memory, disk, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, ttlMinutes, volumes, buildInfo, linkedSandbox, secrets, additionalProperties);
+    return Objects.hash(name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, outboundProxyUrl, target, cpu, gpu, gpuType, spot, memory, disk, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, ttlMinutes, volumes, buildInfo, linkedSandbox, secrets, additionalProperties);
   }
 
   @Override
@@ -805,6 +830,7 @@ public class CreateSandbox {
     sb.append("    cpu: ").append(toIndentedString(cpu)).append("\n");
     sb.append("    gpu: ").append(toIndentedString(gpu)).append("\n");
     sb.append("    gpuType: ").append(toIndentedString(gpuType)).append("\n");
+    sb.append("    spot: ").append(toIndentedString(spot)).append("\n");
     sb.append("    memory: ").append(toIndentedString(memory)).append("\n");
     sb.append("    disk: ").append(toIndentedString(disk)).append("\n");
     sb.append("    autoStopInterval: ").append(toIndentedString(autoStopInterval)).append("\n");
@@ -835,7 +861,7 @@ public class CreateSandbox {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"));
+    openapiFields = new HashSet<String>(Arrays.asList("name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "spot", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(0);

--- a/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
@@ -135,6 +135,16 @@ public class Sandbox {
   @javax.annotation.Nonnull
   private BigDecimal gpu;
 
+  public static final String SERIALIZED_NAME_SPOT = "spot";
+  @SerializedName(SERIALIZED_NAME_SPOT)
+  @javax.annotation.Nullable
+  private Boolean spot = false;
+
+  public static final String SERIALIZED_NAME_SPOT_EVICTED_AT = "spotEvictedAt";
+  @SerializedName(SERIALIZED_NAME_SPOT_EVICTED_AT)
+  @javax.annotation.Nullable
+  private String spotEvictedAt;
+
   public static final String SERIALIZED_NAME_GPU_TYPE = "gpuType";
   @SerializedName(SERIALIZED_NAME_GPU_TYPE)
   @javax.annotation.Nullable
@@ -681,6 +691,44 @@ public class Sandbox {
 
   public void setGpu(@javax.annotation.Nonnull BigDecimal gpu) {
     this.gpu = gpu;
+  }
+
+
+  public Sandbox spot(@javax.annotation.Nullable Boolean spot) {
+    this.spot = spot;
+    return this;
+  }
+
+  /**
+   * Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.
+   * @return spot
+   */
+  @javax.annotation.Nullable
+  public Boolean getSpot() {
+    return spot;
+  }
+
+  public void setSpot(@javax.annotation.Nullable Boolean spot) {
+    this.spot = spot;
+  }
+
+
+  public Sandbox spotEvictedAt(@javax.annotation.Nullable String spotEvictedAt) {
+    this.spotEvictedAt = spotEvictedAt;
+    return this;
+  }
+
+  /**
+   * When this sandbox was destroyed by spot preemption. Set only for spot-evicted sandboxes, which stay retrievable by ID for 24 hours after eviction.
+   * @return spotEvictedAt
+   */
+  @javax.annotation.Nullable
+  public String getSpotEvictedAt() {
+    return spotEvictedAt;
+  }
+
+  public void setSpotEvictedAt(@javax.annotation.Nullable String spotEvictedAt) {
+    this.spotEvictedAt = spotEvictedAt;
   }
 
 
@@ -1244,6 +1292,8 @@ public class Sandbox {
         Objects.equals(this.target, sandbox.target) &&
         Objects.equals(this.cpu, sandbox.cpu) &&
         Objects.equals(this.gpu, sandbox.gpu) &&
+        Objects.equals(this.spot, sandbox.spot) &&
+        Objects.equals(this.spotEvictedAt, sandbox.spotEvictedAt) &&
         Objects.equals(this.gpuType, sandbox.gpuType) &&
         Objects.equals(this.memory, sandbox.memory) &&
         Objects.equals(this.disk, sandbox.disk) &&
@@ -1274,7 +1324,7 @@ public class Sandbox {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, outboundProxyUrl, target, cpu, gpu, gpuType, memory, disk, state, desiredState, errorReason, recoverable, warmPoolId, backupState, backupCreatedAt, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, autoDestroyAt, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, sandboxClass, daemonVersion, runnerId, linkedSandboxId, toolboxProxyUrl, additionalProperties);
+    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, outboundProxyUrl, target, cpu, gpu, spot, spotEvictedAt, gpuType, memory, disk, state, desiredState, errorReason, recoverable, warmPoolId, backupState, backupCreatedAt, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, autoDestroyAt, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, sandboxClass, daemonVersion, runnerId, linkedSandboxId, toolboxProxyUrl, additionalProperties);
   }
 
   @Override
@@ -1296,6 +1346,8 @@ public class Sandbox {
     sb.append("    target: ").append(toIndentedString(target)).append("\n");
     sb.append("    cpu: ").append(toIndentedString(cpu)).append("\n");
     sb.append("    gpu: ").append(toIndentedString(gpu)).append("\n");
+    sb.append("    spot: ").append(toIndentedString(spot)).append("\n");
+    sb.append("    spotEvictedAt: ").append(toIndentedString(spotEvictedAt)).append("\n");
     sb.append("    gpuType: ").append(toIndentedString(gpuType)).append("\n");
     sb.append("    memory: ").append(toIndentedString(memory)).append("\n");
     sb.append("    disk: ").append(toIndentedString(disk)).append("\n");
@@ -1340,7 +1392,7 @@ public class Sandbox {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "user", "env", "labels", "public", "networkBlockAll", "target", "cpu", "gpu", "memory", "disk", "toolboxProxyUrl"));
@@ -1392,6 +1444,9 @@ public class Sandbox {
       }
       if (!jsonObj.get("target").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `target` to be a primitive type in the JSON string but got `%s`", jsonObj.get("target").toString()));
+      }
+      if ((jsonObj.get("spotEvictedAt") != null && !jsonObj.get("spotEvictedAt").isJsonNull()) && !jsonObj.get("spotEvictedAt").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `spotEvictedAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("spotEvictedAt").toString()));
       }
       // validate the optional field `gpuType`
       if (jsonObj.get("gpuType") != null && !jsonObj.get("gpuType").isJsonNull()) {

--- a/api-client-java/src/main/java/io/daytona/api/client/model/SandboxListItem.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/SandboxListItem.java
@@ -147,6 +147,16 @@ public class SandboxListItem {
   @javax.annotation.Nonnull
   private BigDecimal gpu;
 
+  public static final String SERIALIZED_NAME_SPOT = "spot";
+  @SerializedName(SERIALIZED_NAME_SPOT)
+  @javax.annotation.Nullable
+  private Boolean spot = false;
+
+  public static final String SERIALIZED_NAME_SPOT_EVICTED_AT = "spotEvictedAt";
+  @SerializedName(SERIALIZED_NAME_SPOT_EVICTED_AT)
+  @javax.annotation.Nullable
+  private String spotEvictedAt;
+
   public static final String SERIALIZED_NAME_GPU_TYPE = "gpuType";
   @SerializedName(SERIALIZED_NAME_GPU_TYPE)
   @javax.annotation.Nullable
@@ -632,6 +642,44 @@ public class SandboxListItem {
   }
 
 
+  public SandboxListItem spot(@javax.annotation.Nullable Boolean spot) {
+    this.spot = spot;
+    return this;
+  }
+
+  /**
+   * Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.
+   * @return spot
+   */
+  @javax.annotation.Nullable
+  public Boolean getSpot() {
+    return spot;
+  }
+
+  public void setSpot(@javax.annotation.Nullable Boolean spot) {
+    this.spot = spot;
+  }
+
+
+  public SandboxListItem spotEvictedAt(@javax.annotation.Nullable String spotEvictedAt) {
+    this.spotEvictedAt = spotEvictedAt;
+    return this;
+  }
+
+  /**
+   * When this sandbox was evicted by spot preemption. Set as soon as the sandbox is marked for eviction, so it is already present while the sandbox is still winding down.
+   * @return spotEvictedAt
+   */
+  @javax.annotation.Nullable
+  public String getSpotEvictedAt() {
+    return spotEvictedAt;
+  }
+
+  public void setSpotEvictedAt(@javax.annotation.Nullable String spotEvictedAt) {
+    this.spotEvictedAt = spotEvictedAt;
+  }
+
+
   public SandboxListItem gpuType(@javax.annotation.Nullable GpuType gpuType) {
     this.gpuType = gpuType;
     return this;
@@ -1016,6 +1064,8 @@ public class SandboxListItem {
         Objects.equals(this.domainAllowList, sandboxListItem.domainAllowList) &&
         Objects.equals(this.cpu, sandboxListItem.cpu) &&
         Objects.equals(this.gpu, sandboxListItem.gpu) &&
+        Objects.equals(this.spot, sandboxListItem.spot) &&
+        Objects.equals(this.spotEvictedAt, sandboxListItem.spotEvictedAt) &&
         Objects.equals(this.gpuType, sandboxListItem.gpuType) &&
         Objects.equals(this.memory, sandboxListItem.memory) &&
         Objects.equals(this.disk, sandboxListItem.disk) &&
@@ -1037,7 +1087,7 @@ public class SandboxListItem {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, organizationId, name, target, runnerId, sandboxClass, state, desiredState, snapshot, user, errorReason, recoverable, _public, networkBlockAll, networkAllowList, domainAllowList, cpu, gpu, gpuType, memory, disk, labels, backupState, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, autoDestroyAt, createdAt, updatedAt, lastActivityAt, daemonVersion, warmPoolId, toolboxProxyUrl, additionalProperties);
+    return Objects.hash(id, organizationId, name, target, runnerId, sandboxClass, state, desiredState, snapshot, user, errorReason, recoverable, _public, networkBlockAll, networkAllowList, domainAllowList, cpu, gpu, spot, spotEvictedAt, gpuType, memory, disk, labels, backupState, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, autoDestroyAt, createdAt, updatedAt, lastActivityAt, daemonVersion, warmPoolId, toolboxProxyUrl, additionalProperties);
   }
 
   @Override
@@ -1062,6 +1112,8 @@ public class SandboxListItem {
     sb.append("    domainAllowList: ").append(toIndentedString(domainAllowList)).append("\n");
     sb.append("    cpu: ").append(toIndentedString(cpu)).append("\n");
     sb.append("    gpu: ").append(toIndentedString(gpu)).append("\n");
+    sb.append("    spot: ").append(toIndentedString(spot)).append("\n");
+    sb.append("    spotEvictedAt: ").append(toIndentedString(spotEvictedAt)).append("\n");
     sb.append("    gpuType: ").append(toIndentedString(gpuType)).append("\n");
     sb.append("    memory: ").append(toIndentedString(memory)).append("\n");
     sb.append("    disk: ").append(toIndentedString(disk)).append("\n");
@@ -1097,7 +1149,7 @@ public class SandboxListItem {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "warmPoolId", "toolboxProxyUrl"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "warmPoolId", "toolboxProxyUrl"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "target", "user", "public", "networkBlockAll", "cpu", "gpu", "memory", "disk", "labels", "toolboxProxyUrl"));
@@ -1164,6 +1216,9 @@ public class SandboxListItem {
       }
       if ((jsonObj.get("domainAllowList") != null && !jsonObj.get("domainAllowList").isJsonNull()) && !jsonObj.get("domainAllowList").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `domainAllowList` to be a primitive type in the JSON string but got `%s`", jsonObj.get("domainAllowList").toString()));
+      }
+      if ((jsonObj.get("spotEvictedAt") != null && !jsonObj.get("spotEvictedAt").isJsonNull()) && !jsonObj.get("spotEvictedAt").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `spotEvictedAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("spotEvictedAt").toString()));
       }
       // validate the optional field `gpuType`
       if (jsonObj.get("gpuType") != null && !jsonObj.get("gpuType").isJsonNull()) {

--- a/api-client-java/src/test/java/io/daytona/api/client/api/SandboxApiTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/api/SandboxApiTest.java
@@ -244,6 +244,8 @@ public class SandboxApiTest {
     /**
      * Get sandbox details
      *
+     * Sandboxes destroyed by spot preemption remain retrievable for 24 hours so &#x60;spotEvictedAt&#x60; can be read.
+     *
      * @throws ApiException if the Api call fails
      */
     @Test

--- a/api-client-java/src/test/java/io/daytona/api/client/model/CreateSandboxTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/CreateSandboxTest.java
@@ -157,6 +157,14 @@ public class CreateSandboxTest {
     }
 
     /**
+     * Test the property 'spot'
+     */
+    @Test
+    public void spotTest() {
+        // TODO: test spot
+    }
+
+    /**
      * Test the property 'memory'
      */
     @Test

--- a/api-client-java/src/test/java/io/daytona/api/client/model/SandboxListItemTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/SandboxListItemTest.java
@@ -189,6 +189,22 @@ public class SandboxListItemTest {
     }
 
     /**
+     * Test the property 'spot'
+     */
+    @Test
+    public void spotTest() {
+        // TODO: test spot
+    }
+
+    /**
+     * Test the property 'spotEvictedAt'
+     */
+    @Test
+    public void spotEvictedAtTest() {
+        // TODO: test spotEvictedAt
+    }
+
+    /**
      * Test the property 'gpuType'
      */
     @Test

--- a/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
@@ -168,6 +168,22 @@ public class SandboxTest {
     }
 
     /**
+     * Test the property 'spot'
+     */
+    @Test
+    public void spotTest() {
+        // TODO: test spot
+    }
+
+    /**
+     * Test the property 'spotEvictedAt'
+     */
+    @Test
+    public void spotEvictedAtTest() {
+        // TODO: test spotEvictedAt
+    }
+
+    /**
      * Test the property 'gpuType'
      */
     @Test

--- a/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
+++ b/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
@@ -3797,6 +3797,7 @@ class SandboxApi:
     ) -> Sandbox:
         """Get sandbox details
 
+        Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
 
         :param sandbox_id_or_name: ID or name of the sandbox (required)
         :type sandbox_id_or_name: str
@@ -3871,6 +3872,7 @@ class SandboxApi:
     ) -> ApiResponse[Sandbox]:
         """Get sandbox details
 
+        Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
 
         :param sandbox_id_or_name: ID or name of the sandbox (required)
         :type sandbox_id_or_name: str
@@ -3945,6 +3947,7 @@ class SandboxApi:
     ) -> RESTResponseType:
         """Get sandbox details
 
+        Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
 
         :param sandbox_id_or_name: ID or name of the sandbox (required)
         :type sandbox_id_or_name: str

--- a/api-client-python-async/daytona_api_client_async/models/create_sandbox.py
+++ b/api-client-python-async/daytona_api_client_async/models/create_sandbox.py
@@ -47,6 +47,7 @@ class CreateSandbox(BaseModel):
     cpu: Optional[StrictInt] = Field(default=None, description="CPU cores allocated to the sandbox")
     gpu: Optional[StrictInt] = Field(default=None, description="GPU units allocated to the sandbox")
     gpu_type: Optional[List[GpuType]] = Field(default=None, description="Preferred GPU type for the sandbox. Accepts a single value or an ordered preference list — the scheduler tries each in order and pins the sandbox to the first that has capacity.", serialization_alias="gpuType")
+    spot: Optional[StrictBool] = Field(default=False, description="GPU-only. When true, the sandbox may be instantly terminated without notice to free GPU capacity for an on-demand (non-spot) GPU sandbox. Ignored / rejected when the sandbox requests no GPUs.")
     memory: Optional[StrictInt] = Field(default=None, description="Memory allocated to the sandbox in GB")
     disk: Optional[StrictInt] = Field(default=None, description="Disk space allocated to the sandbox in GB")
     auto_stop_interval: Optional[StrictInt] = Field(default=None, description="Auto-stop interval in minutes (0 means disabled)", serialization_alias="autoStopInterval")
@@ -59,7 +60,7 @@ class CreateSandbox(BaseModel):
     linked_sandbox: Optional[StrictStr] = Field(default=None, description="ID or name of an existing sandbox to link the new sandbox to. The new sandbox will be scheduled on the same runner as the linked sandbox so a local network can be established between them. Linked sandboxes must be ephemeral (autoDeleteInterval=0) and cannot themselves be linked to another sandbox. GPU sandboxes cannot participate in links in either direction: a GPU sandbox cannot specify linkedSandbox, and cannot be the link target of another sandbox.", serialization_alias="linkedSandbox")
     secrets: Optional[List[Dict[str, StrictStr]]] = Field(default=None, description="Secrets to mount in this sandbox. Each entry maps an env var name to a vault secret name.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"]
+    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "spot", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -142,6 +143,7 @@ class CreateSandbox(BaseModel):
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),
             "gpu_type": obj.get("gpuType"),
+            "spot": obj.get("spot") if obj.get("spot") is not None else False,
             "memory": obj.get("memory"),
             "disk": obj.get("disk"),
             "auto_stop_interval": obj.get("autoStopInterval"),

--- a/api-client-python-async/daytona_api_client_async/models/sandbox.py
+++ b/api-client-python-async/daytona_api_client_async/models/sandbox.py
@@ -50,6 +50,8 @@ class Sandbox(BaseModel):
     target: StrictStr = Field(description="The target environment for the sandbox")
     cpu: Union[StrictFloat, StrictInt] = Field(description="The CPU quota for the sandbox")
     gpu: Union[StrictFloat, StrictInt] = Field(description="The GPU quota for the sandbox")
+    spot: Optional[StrictBool] = Field(default=False, description="Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.")
+    spot_evicted_at: Optional[StrictStr] = Field(default=None, description="When this sandbox was destroyed by spot preemption. Set only for spot-evicted sandboxes, which stay retrievable by ID for 24 hours after eviction.", serialization_alias="spotEvictedAt")
     gpu_type: Optional[GpuType] = Field(default=None, description="The GPU type assigned to the sandbox", serialization_alias="gpuType")
     memory: Union[StrictFloat, StrictInt] = Field(description="The memory quota for the sandbox")
     disk: Union[StrictFloat, StrictInt] = Field(description="The disk quota for the sandbox")
@@ -76,7 +78,7 @@ class Sandbox(BaseModel):
     linked_sandbox_id: Optional[StrictStr] = Field(default=None, description="ID of the sandbox this sandbox is linked to. When set, the sandbox is co-located on the same runner as the linked sandbox.", serialization_alias="linkedSandboxId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -160,6 +162,8 @@ class Sandbox(BaseModel):
             "target": obj.get("target"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),
+            "spot": obj.get("spot") if obj.get("spot") is not None else False,
+            "spot_evicted_at": obj.get("spotEvictedAt"),
             "gpu_type": obj.get("gpuType"),
             "memory": obj.get("memory"),
             "disk": obj.get("disk"),

--- a/api-client-python-async/daytona_api_client_async/models/sandbox_list_item.py
+++ b/api-client-python-async/daytona_api_client_async/models/sandbox_list_item.py
@@ -52,6 +52,8 @@ class SandboxListItem(BaseModel):
     domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     cpu: Union[StrictFloat, StrictInt] = Field(description="The CPU quota for the sandbox")
     gpu: Union[StrictFloat, StrictInt] = Field(description="The GPU quota for the sandbox")
+    spot: Optional[StrictBool] = Field(default=False, description="Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.")
+    spot_evicted_at: Optional[StrictStr] = Field(default=None, description="When this sandbox was evicted by spot preemption. Set as soon as the sandbox is marked for eviction, so it is already present while the sandbox is still winding down.", serialization_alias="spotEvictedAt")
     gpu_type: Optional[GpuType] = Field(default=None, description="The GPU type assigned to the sandbox", serialization_alias="gpuType")
     memory: Union[StrictFloat, StrictInt] = Field(description="The memory quota for the sandbox")
     disk: Union[StrictFloat, StrictInt] = Field(description="The disk quota for the sandbox")
@@ -69,7 +71,7 @@ class SandboxListItem(BaseModel):
     warm_pool_id: Optional[StrictStr] = Field(default=None, description="Id of the warm pool this sandbox waits in; set only while it is an unclaimed member", serialization_alias="warmPoolId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "warmPoolId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "warmPoolId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -146,6 +148,8 @@ class SandboxListItem(BaseModel):
             "domain_allow_list": obj.get("domainAllowList"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),
+            "spot": obj.get("spot") if obj.get("spot") is not None else False,
+            "spot_evicted_at": obj.get("spotEvictedAt"),
             "gpu_type": obj.get("gpuType"),
             "memory": obj.get("memory"),
             "disk": obj.get("disk"),

--- a/api-client-python/daytona_api_client/api/sandbox_api.py
+++ b/api-client-python/daytona_api_client/api/sandbox_api.py
@@ -3797,6 +3797,7 @@ class SandboxApi:
     ) -> Sandbox:
         """Get sandbox details
 
+        Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
 
         :param sandbox_id_or_name: ID or name of the sandbox (required)
         :type sandbox_id_or_name: str
@@ -3871,6 +3872,7 @@ class SandboxApi:
     ) -> ApiResponse[Sandbox]:
         """Get sandbox details
 
+        Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
 
         :param sandbox_id_or_name: ID or name of the sandbox (required)
         :type sandbox_id_or_name: str
@@ -3945,6 +3947,7 @@ class SandboxApi:
     ) -> RESTResponseType:
         """Get sandbox details
 
+        Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
 
         :param sandbox_id_or_name: ID or name of the sandbox (required)
         :type sandbox_id_or_name: str

--- a/api-client-python/daytona_api_client/models/create_sandbox.py
+++ b/api-client-python/daytona_api_client/models/create_sandbox.py
@@ -47,6 +47,7 @@ class CreateSandbox(BaseModel):
     cpu: Optional[StrictInt] = Field(default=None, description="CPU cores allocated to the sandbox")
     gpu: Optional[StrictInt] = Field(default=None, description="GPU units allocated to the sandbox")
     gpu_type: Optional[List[GpuType]] = Field(default=None, description="Preferred GPU type for the sandbox. Accepts a single value or an ordered preference list — the scheduler tries each in order and pins the sandbox to the first that has capacity.", serialization_alias="gpuType")
+    spot: Optional[StrictBool] = Field(default=False, description="GPU-only. When true, the sandbox may be instantly terminated without notice to free GPU capacity for an on-demand (non-spot) GPU sandbox. Ignored / rejected when the sandbox requests no GPUs.")
     memory: Optional[StrictInt] = Field(default=None, description="Memory allocated to the sandbox in GB")
     disk: Optional[StrictInt] = Field(default=None, description="Disk space allocated to the sandbox in GB")
     auto_stop_interval: Optional[StrictInt] = Field(default=None, description="Auto-stop interval in minutes (0 means disabled)", serialization_alias="autoStopInterval")
@@ -59,7 +60,7 @@ class CreateSandbox(BaseModel):
     linked_sandbox: Optional[StrictStr] = Field(default=None, description="ID or name of an existing sandbox to link the new sandbox to. The new sandbox will be scheduled on the same runner as the linked sandbox so a local network can be established between them. Linked sandboxes must be ephemeral (autoDeleteInterval=0) and cannot themselves be linked to another sandbox. GPU sandboxes cannot participate in links in either direction: a GPU sandbox cannot specify linkedSandbox, and cannot be the link target of another sandbox.", serialization_alias="linkedSandbox")
     secrets: Optional[List[Dict[str, StrictStr]]] = Field(default=None, description="Secrets to mount in this sandbox. Each entry maps an env var name to a vault secret name.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"]
+    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "spot", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -142,6 +143,7 @@ class CreateSandbox(BaseModel):
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),
             "gpu_type": obj.get("gpuType"),
+            "spot": obj.get("spot") if obj.get("spot") is not None else False,
             "memory": obj.get("memory"),
             "disk": obj.get("disk"),
             "auto_stop_interval": obj.get("autoStopInterval"),

--- a/api-client-python/daytona_api_client/models/sandbox.py
+++ b/api-client-python/daytona_api_client/models/sandbox.py
@@ -50,6 +50,8 @@ class Sandbox(BaseModel):
     target: StrictStr = Field(description="The target environment for the sandbox")
     cpu: Union[StrictFloat, StrictInt] = Field(description="The CPU quota for the sandbox")
     gpu: Union[StrictFloat, StrictInt] = Field(description="The GPU quota for the sandbox")
+    spot: Optional[StrictBool] = Field(default=False, description="Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.")
+    spot_evicted_at: Optional[StrictStr] = Field(default=None, description="When this sandbox was destroyed by spot preemption. Set only for spot-evicted sandboxes, which stay retrievable by ID for 24 hours after eviction.", serialization_alias="spotEvictedAt")
     gpu_type: Optional[GpuType] = Field(default=None, description="The GPU type assigned to the sandbox", serialization_alias="gpuType")
     memory: Union[StrictFloat, StrictInt] = Field(description="The memory quota for the sandbox")
     disk: Union[StrictFloat, StrictInt] = Field(description="The disk quota for the sandbox")
@@ -76,7 +78,7 @@ class Sandbox(BaseModel):
     linked_sandbox_id: Optional[StrictStr] = Field(default=None, description="ID of the sandbox this sandbox is linked to. When set, the sandbox is co-located on the same runner as the linked sandbox.", serialization_alias="linkedSandboxId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -160,6 +162,8 @@ class Sandbox(BaseModel):
             "target": obj.get("target"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),
+            "spot": obj.get("spot") if obj.get("spot") is not None else False,
+            "spot_evicted_at": obj.get("spotEvictedAt"),
             "gpu_type": obj.get("gpuType"),
             "memory": obj.get("memory"),
             "disk": obj.get("disk"),

--- a/api-client-python/daytona_api_client/models/sandbox_list_item.py
+++ b/api-client-python/daytona_api_client/models/sandbox_list_item.py
@@ -52,6 +52,8 @@ class SandboxListItem(BaseModel):
     domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     cpu: Union[StrictFloat, StrictInt] = Field(description="The CPU quota for the sandbox")
     gpu: Union[StrictFloat, StrictInt] = Field(description="The GPU quota for the sandbox")
+    spot: Optional[StrictBool] = Field(default=False, description="Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.")
+    spot_evicted_at: Optional[StrictStr] = Field(default=None, description="When this sandbox was evicted by spot preemption. Set as soon as the sandbox is marked for eviction, so it is already present while the sandbox is still winding down.", serialization_alias="spotEvictedAt")
     gpu_type: Optional[GpuType] = Field(default=None, description="The GPU type assigned to the sandbox", serialization_alias="gpuType")
     memory: Union[StrictFloat, StrictInt] = Field(description="The memory quota for the sandbox")
     disk: Union[StrictFloat, StrictInt] = Field(description="The disk quota for the sandbox")
@@ -69,7 +71,7 @@ class SandboxListItem(BaseModel):
     warm_pool_id: Optional[StrictStr] = Field(default=None, description="Id of the warm pool this sandbox waits in; set only while it is an unclaimed member", serialization_alias="warmPoolId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "cpu", "gpu", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "warmPoolId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "target", "runnerId", "sandboxClass", "state", "desiredState", "snapshot", "user", "errorReason", "recoverable", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "labels", "backupState", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "createdAt", "updatedAt", "lastActivityAt", "daemonVersion", "warmPoolId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -146,6 +148,8 @@ class SandboxListItem(BaseModel):
             "domain_allow_list": obj.get("domainAllowList"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),
+            "spot": obj.get("spot") if obj.get("spot") is not None else False,
+            "spot_evicted_at": obj.get("spotEvictedAt"),
             "gpu_type": obj.get("gpuType"),
             "memory": obj.get("memory"),
             "disk": obj.get("disk"),

--- a/api-client-ruby/lib/daytona_api_client/api/sandbox_api.rb
+++ b/api-client-ruby/lib/daytona_api_client/api/sandbox_api.rb
@@ -903,6 +903,7 @@ module DaytonaApiClient
     end
 
     # Get sandbox details
+    # Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
     # @param sandbox_id_or_name [String] ID or name of the sandbox
     # @param [Hash] opts the optional parameters
     # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID
@@ -914,6 +915,7 @@ module DaytonaApiClient
     end
 
     # Get sandbox details
+    # Sandboxes destroyed by spot preemption remain retrievable for 24 hours so &#x60;spotEvictedAt&#x60; can be read.
     # @param sandbox_id_or_name [String] ID or name of the sandbox
     # @param [Hash] opts the optional parameters
     # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID

--- a/api-client-ruby/lib/daytona_api_client/models/create_sandbox.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/create_sandbox.rb
@@ -57,6 +57,9 @@ module DaytonaApiClient
     # Preferred GPU type for the sandbox. Accepts a single value or an ordered preference list — the scheduler tries each in order and pins the sandbox to the first that has capacity.
     attr_accessor :gpu_type
 
+    # GPU-only. When true, the sandbox may be instantly terminated without notice to free GPU capacity for an on-demand (non-spot) GPU sandbox. Ignored / rejected when the sandbox requests no GPUs.
+    attr_accessor :spot
+
     # Memory allocated to the sandbox in GB
     attr_accessor :memory
 
@@ -107,6 +110,7 @@ module DaytonaApiClient
         :'cpu' => :'cpu',
         :'gpu' => :'gpu',
         :'gpu_type' => :'gpuType',
+        :'spot' => :'spot',
         :'memory' => :'memory',
         :'disk' => :'disk',
         :'auto_stop_interval' => :'autoStopInterval',
@@ -148,6 +152,7 @@ module DaytonaApiClient
         :'cpu' => :'Integer',
         :'gpu' => :'Integer',
         :'gpu_type' => :'Array<GpuType>',
+        :'spot' => :'Boolean',
         :'memory' => :'Integer',
         :'disk' => :'Integer',
         :'auto_stop_interval' => :'Integer',
@@ -246,6 +251,12 @@ module DaytonaApiClient
         end
       end
 
+      if attributes.key?(:'spot')
+        self.spot = attributes[:'spot']
+      else
+        self.spot = false
+      end
+
       if attributes.key?(:'memory')
         self.memory = attributes[:'memory']
       end
@@ -329,6 +340,7 @@ module DaytonaApiClient
           cpu == o.cpu &&
           gpu == o.gpu &&
           gpu_type == o.gpu_type &&
+          spot == o.spot &&
           memory == o.memory &&
           disk == o.disk &&
           auto_stop_interval == o.auto_stop_interval &&
@@ -351,7 +363,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, outbound_proxy_url, target, cpu, gpu, gpu_type, memory, disk, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, ttl_minutes, volumes, build_info, linked_sandbox, secrets].hash
+      [name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, outbound_proxy_url, target, cpu, gpu, gpu_type, spot, memory, disk, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, ttl_minutes, volumes, build_info, linked_sandbox, secrets].hash
     end
 
     # Builds the object from hash

--- a/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
@@ -60,6 +60,12 @@ module DaytonaApiClient
     # The GPU quota for the sandbox
     attr_accessor :gpu
 
+    # Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.
+    attr_accessor :spot
+
+    # When this sandbox was destroyed by spot preemption. Set only for spot-evicted sandboxes, which stay retrievable by ID for 24 hours after eviction.
+    attr_accessor :spot_evicted_at
+
     # The GPU type assigned to the sandbox
     attr_accessor :gpu_type
 
@@ -175,6 +181,8 @@ module DaytonaApiClient
         :'target' => :'target',
         :'cpu' => :'cpu',
         :'gpu' => :'gpu',
+        :'spot' => :'spot',
+        :'spot_evicted_at' => :'spotEvictedAt',
         :'gpu_type' => :'gpuType',
         :'memory' => :'memory',
         :'disk' => :'disk',
@@ -231,6 +239,8 @@ module DaytonaApiClient
         :'target' => :'String',
         :'cpu' => :'Float',
         :'gpu' => :'Float',
+        :'spot' => :'Boolean',
+        :'spot_evicted_at' => :'String',
         :'gpu_type' => :'GpuType',
         :'memory' => :'Float',
         :'disk' => :'Float',
@@ -365,6 +375,16 @@ module DaytonaApiClient
         self.gpu = attributes[:'gpu']
       else
         self.gpu = nil
+      end
+
+      if attributes.key?(:'spot')
+        self.spot = attributes[:'spot']
+      else
+        self.spot = false
+      end
+
+      if attributes.key?(:'spot_evicted_at')
+        self.spot_evicted_at = attributes[:'spot_evicted_at']
       end
 
       if attributes.key?(:'gpu_type')
@@ -745,6 +765,8 @@ module DaytonaApiClient
           target == o.target &&
           cpu == o.cpu &&
           gpu == o.gpu &&
+          spot == o.spot &&
+          spot_evicted_at == o.spot_evicted_at &&
           gpu_type == o.gpu_type &&
           memory == o.memory &&
           disk == o.disk &&
@@ -781,7 +803,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, outbound_proxy_url, target, cpu, gpu, gpu_type, memory, disk, state, desired_state, error_reason, recoverable, warm_pool_id, backup_state, backup_created_at, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, auto_destroy_at, volumes, build_info, created_at, updated_at, last_activity_at, sandbox_class, daemon_version, runner_id, linked_sandbox_id, toolbox_proxy_url].hash
+      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, outbound_proxy_url, target, cpu, gpu, spot, spot_evicted_at, gpu_type, memory, disk, state, desired_state, error_reason, recoverable, warm_pool_id, backup_state, backup_created_at, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, auto_destroy_at, volumes, build_info, created_at, updated_at, last_activity_at, sandbox_class, daemon_version, runner_id, linked_sandbox_id, toolbox_proxy_url].hash
     end
 
     # Builds the object from hash

--- a/api-client-ruby/lib/daytona_api_client/models/sandbox_list_item.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/sandbox_list_item.rb
@@ -69,6 +69,12 @@ module DaytonaApiClient
     # The GPU quota for the sandbox
     attr_accessor :gpu
 
+    # Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.
+    attr_accessor :spot
+
+    # When this sandbox was evicted by spot preemption. Set as soon as the sandbox is marked for eviction, so it is already present while the sandbox is still winding down.
+    attr_accessor :spot_evicted_at
+
     # The GPU type assigned to the sandbox
     attr_accessor :gpu_type
 
@@ -160,6 +166,8 @@ module DaytonaApiClient
         :'domain_allow_list' => :'domainAllowList',
         :'cpu' => :'cpu',
         :'gpu' => :'gpu',
+        :'spot' => :'spot',
+        :'spot_evicted_at' => :'spotEvictedAt',
         :'gpu_type' => :'gpuType',
         :'memory' => :'memory',
         :'disk' => :'disk',
@@ -210,6 +218,8 @@ module DaytonaApiClient
         :'domain_allow_list' => :'String',
         :'cpu' => :'Float',
         :'gpu' => :'Float',
+        :'spot' => :'Boolean',
+        :'spot_evicted_at' => :'String',
         :'gpu_type' => :'GpuType',
         :'memory' => :'Float',
         :'disk' => :'Float',
@@ -339,6 +349,16 @@ module DaytonaApiClient
         self.gpu = attributes[:'gpu']
       else
         self.gpu = nil
+      end
+
+      if attributes.key?(:'spot')
+        self.spot = attributes[:'spot']
+      else
+        self.spot = false
+      end
+
+      if attributes.key?(:'spot_evicted_at')
+        self.spot_evicted_at = attributes[:'spot_evicted_at']
       end
 
       if attributes.key?(:'gpu_type')
@@ -661,6 +681,8 @@ module DaytonaApiClient
           domain_allow_list == o.domain_allow_list &&
           cpu == o.cpu &&
           gpu == o.gpu &&
+          spot == o.spot &&
+          spot_evicted_at == o.spot_evicted_at &&
           gpu_type == o.gpu_type &&
           memory == o.memory &&
           disk == o.disk &&
@@ -688,7 +710,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, organization_id, name, target, runner_id, sandbox_class, state, desired_state, snapshot, user, error_reason, recoverable, public, network_block_all, network_allow_list, domain_allow_list, cpu, gpu, gpu_type, memory, disk, labels, backup_state, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, auto_destroy_at, created_at, updated_at, last_activity_at, daemon_version, warm_pool_id, toolbox_proxy_url].hash
+      [id, organization_id, name, target, runner_id, sandbox_class, state, desired_state, snapshot, user, error_reason, recoverable, public, network_block_all, network_allow_list, domain_allow_list, cpu, gpu, spot, spot_evicted_at, gpu_type, memory, disk, labels, backup_state, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, auto_destroy_at, created_at, updated_at, last_activity_at, daemon_version, warm_pool_id, toolbox_proxy_url].hash
     end
 
     # Builds the object from hash

--- a/api-client/src/api/sandbox-api.ts
+++ b/api-client/src/api/sandbox-api.ts
@@ -690,7 +690,7 @@ export const SandboxApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * 
+         * Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
          * @summary Get sandbox details
          * @param {string} sandboxIdOrName ID or name of the sandbox
          * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
@@ -2811,7 +2811,7 @@ export const SandboxApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * 
+         * Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
          * @summary Get sandbox details
          * @param {string} sandboxIdOrName ID or name of the sandbox
          * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
@@ -3527,7 +3527,7 @@ export const SandboxApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getRegionQuotaBySandboxId(sandboxId, xDaytonaOrganizationID, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         * Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
          * @summary Get sandbox details
          * @param {string} sandboxIdOrName ID or name of the sandbox
          * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
@@ -4152,7 +4152,7 @@ export class SandboxApi extends BaseAPI {
     }
 
     /**
-     * 
+     * Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.
      * @summary Get sandbox details
      * @param {string} sandboxIdOrName ID or name of the sandbox
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID

--- a/api-client/src/models/audit-target-scenario.ts
+++ b/api-client/src/models/audit-target-scenario.ts
@@ -109,6 +109,7 @@ export const AuditTargetScenarioActionsEnum = {
     AUTO_ARCHIVE: 'auto_archive',
     AUTO_DELETE: 'auto_delete',
     TTL_EXPIRE: 'ttl_expire',
+    SPOT_EVICT: 'spot_evict',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 

--- a/api-client/src/models/create-sandbox.ts
+++ b/api-client/src/models/create-sandbox.ts
@@ -81,6 +81,10 @@ export interface CreateSandbox {
      */
     'gpuType'?: Array<GpuType>;
     /**
+     * GPU-only. When true, the sandbox may be instantly terminated without notice to free GPU capacity for an on-demand (non-spot) GPU sandbox. Ignored / rejected when the sandbox requests no GPUs.
+     */
+    'spot'?: boolean;
+    /**
      * Memory allocated to the sandbox in GB
      */
     'memory'?: number;

--- a/api-client/src/models/sandbox-list-item.ts
+++ b/api-client/src/models/sandbox-list-item.ts
@@ -100,6 +100,14 @@ export interface SandboxListItem {
      */
     'gpu': number;
     /**
+     * Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.
+     */
+    'spot'?: boolean;
+    /**
+     * When this sandbox was evicted by spot preemption. Set as soon as the sandbox is marked for eviction, so it is already present while the sandbox is still winding down.
+     */
+    'spotEvictedAt'?: string;
+    /**
      * The GPU type assigned to the sandbox
      */
     'gpuType'?: GpuType;

--- a/api-client/src/models/sandbox.ts
+++ b/api-client/src/models/sandbox.ts
@@ -91,6 +91,14 @@ export interface Sandbox {
      */
     'gpu': number;
     /**
+     * Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.
+     */
+    'spot'?: boolean;
+    /**
+     * When this sandbox was destroyed by spot preemption. Set only for spot-evicted sandboxes, which stay retrievable by ID for 24 hours after eviction.
+     */
+    'spotEvictedAt'?: string;
+    /**
      * The GPU type assigned to the sandbox
      */
     'gpuType'?: GpuType;

--- a/artifacts/sdk-docs/go-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/go-sdk/daytona.mdx
@@ -4342,6 +4342,8 @@ type Sandbox struct {
     Target         string                 // Target region/environment where the sandbox runs
     Cpu            float32                // Number of CPUs allocated to the sandbox
     Gpu            float32                // Number of GPUs allocated to the sandbox
+    Spot           bool                   // Whether this is a spot GPU sandbox, which may be instantly terminated to free capacity for on-demand GPU sandboxes
+    SpotEvictedAt  *string                // When the sandbox was evicted by spot preemption
     Memory         float32                // Amount of memory allocated to the sandbox in GiB
     Disk           float32                // Amount of disk space allocated to the sandbox in GiB
     State          apiclient.SandboxState // Current sandbox state

--- a/artifacts/sdk-docs/go-sdk/types.mdx
+++ b/artifacts/sdk-docs/go-sdk/types.mdx
@@ -592,6 +592,10 @@ type SandboxBaseParams struct {
     // combine with DomainAllowList for network-layer enforcement.
     OutboundProxyUrl *string
     Ephemeral        bool
+    // Spot marks the sandbox as a spot GPU sandbox. A spot sandbox may be instantly
+    // terminated without notice to free GPU capacity for an on-demand (non-spot) GPU
+    // sandbox. Rejected when the sandbox requests no GPUs.
+    Spot bool
     // LinkedSandbox is the ID or name of an existing sandbox to link the new sandbox to.
     // The new sandbox will be scheduled on the same runner as the linked sandbox so a local
     // network can be established between them.

--- a/artifacts/sdk-docs/java-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/java-sdk/sandbox.mdx
@@ -834,6 +834,28 @@ public int getGpu()
 
 - `int` - allocated GPU units.
 
+#### isSpot()
+```java
+public boolean isSpot()
+```
+
+Returns whether this is a spot GPU Sandbox.
+
+Spot Sandboxes may be instantly terminated to free capacity for on-demand GPU Sandboxes.
+
+**Returns**:
+
+- `boolean` - `true` when the Sandbox is preemptible.
+
+#### getSpotEvictedAt()
+```java
+public String getSpotEvictedAt()
+```
+
+**Returns**:
+
+- `String` - when the Sandbox was evicted by spot preemption, or `null` when it was not.
+
 #### getMemory()
 ```java
 public int getMemory()

--- a/artifacts/sdk-docs/python-sdk/async/async-daytona.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-daytona.mdx
@@ -518,6 +518,9 @@ Base parameters for creating a new Sandbox.
   combine with domain_allow_list for unbypassable network-layer enforcement.
 - `ephemeral` _bool | None_ - Whether the Sandbox should be ephemeral.
   If True, auto_delete_interval will be set to 0.
+- `spot` _bool | None_ - GPU-only. When True, the Sandbox may be instantly terminated without notice
+  to free GPU capacity for an on-demand (non-spot) GPU Sandbox. Rejected when the Sandbox
+  requests no GPUs.
 - `linked_sandbox` _str | None_ - ID or name of an existing Sandbox to link the new Sandbox to. The new
   Sandbox will be scheduled on the same runner as the linked Sandbox so a local network can be
   established between them. Linked Sandboxes must be

--- a/artifacts/sdk-docs/python-sdk/async/async-sandbox.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-sandbox.mdx
@@ -32,6 +32,9 @@ Represents a Daytona Sandbox.
 - `target` _str_ - Target location of the runner where the Sandbox runs.
 - `cpu` _int_ - Number of CPUs allocated to the Sandbox.
 - `gpu` _int_ - Number of GPUs allocated to the Sandbox.
+- `spot` _bool_ - Whether this is a spot GPU Sandbox. Spot Sandboxes may be instantly terminated
+  to free capacity for on-demand GPU Sandboxes.
+- `spot_evicted_at` _str | None_ - When the Sandbox was evicted by spot preemption.
 - `memory` _int_ - Amount of memory allocated to the Sandbox in GiB.
 - `disk` _int_ - Amount of disk space allocated to the Sandbox in GiB.
 - `state` _SandboxState | None_ - Current state of the Sandbox (e.g., "started", "stopped").

--- a/artifacts/sdk-docs/python-sdk/sync/daytona.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/daytona.mdx
@@ -464,6 +464,9 @@ Base parameters for creating a new Sandbox.
   combine with domain_allow_list for unbypassable network-layer enforcement.
 - `ephemeral` _bool | None_ - Whether the Sandbox should be ephemeral.
   If True, auto_delete_interval will be set to 0.
+- `spot` _bool | None_ - GPU-only. When True, the Sandbox may be instantly terminated without notice
+  to free GPU capacity for an on-demand (non-spot) GPU Sandbox. Rejected when the Sandbox
+  requests no GPUs.
 - `linked_sandbox` _str | None_ - ID or name of an existing Sandbox to link the new Sandbox to. The new
   Sandbox will be scheduled on the same runner as the linked Sandbox so a local network can be
   established between them. Linked Sandboxes must be

--- a/artifacts/sdk-docs/python-sdk/sync/sandbox.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/sandbox.mdx
@@ -32,6 +32,9 @@ Represents a Daytona Sandbox.
 - `target` _str_ - Target location of the runner where the Sandbox runs.
 - `cpu` _int_ - Number of CPUs allocated to the Sandbox.
 - `gpu` _int_ - Number of GPUs allocated to the Sandbox.
+- `spot` _bool_ - Whether this is a spot GPU Sandbox. Spot Sandboxes may be instantly terminated
+  to free capacity for on-demand GPU Sandboxes.
+- `spot_evicted_at` _str | None_ - When the Sandbox was evicted by spot preemption.
 - `memory` _int_ - Amount of memory allocated to the Sandbox in GiB.
 - `disk` _int_ - Amount of disk space allocated to the Sandbox in GiB.
 - `state` _SandboxState | None_ - Current state of the Sandbox (e.g., "started", "stopped").

--- a/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/ruby-sdk/sandbox.mdx
@@ -185,6 +185,29 @@ def gpu()
 
 - `Float` - The GPU quota for the sandbox
 
+#### spot()
+
+```ruby
+def spot()
+
+```
+
+**Returns**:
+
+- `Boolean` - Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated
+to free capacity for on-demand GPU sandboxes.
+
+#### spot_evicted_at()
+
+```ruby
+def spot_evicted_at()
+
+```
+
+**Returns**:
+
+- `String, nil` - When the sandbox was evicted by spot preemption
+
 #### memory()
 
 ```ruby

--- a/artifacts/sdk-docs/typescript-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/daytona.mdx
@@ -410,6 +410,7 @@ Base parameters for creating a new Sandbox.
 - `outboundProxyUrl?` _string_ - Outbound proxy URL to route the Sandbox HTTP(S) traffic through. Applied via the HTTP(S)_PROXY environment variables (convenience routing, not a security boundary on its own); combine with domainAllowList for unbypassable network-layer enforcement.
 - `public?` _boolean_ - Is the Sandbox port preview public
 - `secrets?` _Record\<string, string\>_ - Optional map of environment variable name to the name of an existing organization Secret to mount into the Sandbox. The env var is set to the Secret's opaque placeholder; the real value is substituted transparently on outbound requests to the Secret's allowed hosts. Every referenced Secret name must already exist in the organization.
+- `spot?` _boolean_ - GPU-only. When true, the Sandbox may be instantly terminated without notice to free GPU capacity for an on-demand (non-spot) GPU Sandbox. Rejected when the Sandbox requests no GPUs.
 - `ttlMinutes?` _number_ - Maximum time to live in minutes, counted as wall-clock time since creation regardless of sandbox state (0 means disabled). When it elapses the Sandbox is destroyed, even if it is stopped, paused, or archived.
 - `user?` _string_ - Optional os user to use for the Sandbox
 - `volumes?` _VolumeMount\[\]_ - Optional array of volumes to mount to the Sandbox
@@ -439,6 +440,7 @@ Parameters for creating a new Sandbox.
 - `resources?` _Resources_ - Resource allocation for the Sandbox. If not provided, sandbox will
     have default resources.
 - `secrets?` _Record\<string, string\>_
+- `spot?` _boolean_
 - `ttlMinutes?` _number_
 - `user?` _string_
 - `volumes?` _VolumeMount\[\]_
@@ -465,6 +467,7 @@ Parameters for creating a new Sandbox from a snapshot.
 - `public?` _boolean_
 - `secrets?` _Record\<string, string\>_
 - `snapshot?` _string_ - Name of the snapshot to use for the Sandbox.
+- `spot?` _boolean_
 - `ttlMinutes?` _number_
 - `user?` _string_
 - `volumes?` _VolumeMount\[\]_

--- a/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/sandbox.mdx
@@ -52,6 +52,9 @@ Represents a Daytona Sandbox.
 - `public` _boolean_ - Whether the Sandbox is publicly accessible
 - `recoverable?` _boolean_ - Whether the Sandbox error is recoverable.
 - `snapshot?` _string_ - Daytona snapshot used to create the Sandbox
+- `spot?` _boolean_ - Whether this is a spot GPU Sandbox. Spot Sandboxes may be instantly terminated to free
+    capacity for on-demand GPU Sandboxes
+- `spotEvictedAt?` _string_ - When the Sandbox was evicted by spot preemption
 - `state?` _SandboxState_ - Current state of the Sandbox (e.g., "started", "stopped")
 - `target` _string_ - Target location of the runner where the Sandbox runs
 - `toolboxProxyUrl` _string_

--- a/openapi-specs/api.json
+++ b/openapi-specs/api.json
@@ -3581,6 +3581,7 @@
     },
     "/sandbox/{sandboxIdOrName}": {
       "get": {
+        "description": "Sandboxes destroyed by spot preemption remain retrievable for 24 hours so `spotEvictedAt` can be read.",
         "operationId": "getSandbox",
         "parameters": [
           {
@@ -13407,6 +13408,17 @@
             "description": "The GPU quota for the sandbox",
             "example": 0
           },
+          "spot": {
+            "type": "boolean",
+            "description": "Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.",
+            "example": false,
+            "default": false
+          },
+          "spotEvictedAt": {
+            "type": "string",
+            "description": "When this sandbox was evicted by spot preemption. Set as soon as the sandbox is marked for eviction, so it is already present while the sandbox is still winding down.",
+            "example": "2026-08-13T12:00:00.000Z"
+          },
           "gpuType": {
             "description": "The GPU type assigned to the sandbox",
             "example": "H100",
@@ -13692,6 +13704,17 @@
             "type": "number",
             "description": "The GPU quota for the sandbox",
             "example": 0
+          },
+          "spot": {
+            "type": "boolean",
+            "description": "Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated to free capacity for on-demand GPU sandboxes. Absent on APIs that predate this field; treat as false.",
+            "example": false,
+            "default": false
+          },
+          "spotEvictedAt": {
+            "type": "string",
+            "description": "When this sandbox was destroyed by spot preemption. Set only for spot-evicted sandboxes, which stay retrievable by ID for 24 hours after eviction.",
+            "example": "2026-08-13T12:00:00.000Z"
           },
           "gpuType": {
             "description": "The GPU type assigned to the sandbox",
@@ -14010,6 +14033,12 @@
             "items": {
               "$ref": "#/components/schemas/GpuType"
             }
+          },
+          "spot": {
+            "type": "boolean",
+            "description": "GPU-only. When true, the sandbox may be instantly terminated without notice to free GPU capacity for an on-demand (non-spot) GPU sandbox. Ignored / rejected when the sandbox requests no GPUs.",
+            "example": false,
+            "default": false
           },
           "memory": {
             "type": "integer",
@@ -16795,7 +16824,8 @@
                 "auto_stop",
                 "auto_archive",
                 "auto_delete",
-                "ttl_expire"
+                "ttl_expire",
+                "spot_evict"
               ]
             }
           }

--- a/sdk-go/pkg/daytona/client.go
+++ b/sdk-go/pkg/daytona/client.go
@@ -594,6 +594,9 @@ func (c *Client) doCreate(ctx context.Context, params any, opts ...func(*options
 	if baseParams.LinkedSandbox != "" {
 		createReq.SetLinkedSandbox(baseParams.LinkedSandbox)
 	}
+	if baseParams.Spot {
+		createReq.SetSpot(true)
+	}
 
 	// Handle snapshot
 	if snapshot != "" {

--- a/sdk-go/pkg/daytona/sandbox.go
+++ b/sdk-go/pkg/daytona/sandbox.go
@@ -74,6 +74,8 @@ type Sandbox struct {
 	Target         string                 // Target region/environment where the sandbox runs
 	Cpu            float32                // Number of CPUs allocated to the sandbox
 	Gpu            float32                // Number of GPUs allocated to the sandbox
+	Spot           bool                   // Whether this is a spot GPU sandbox, which may be instantly terminated to free capacity for on-demand GPU sandboxes
+	SpotEvictedAt  *string                // When the sandbox was evicted by spot preemption
 	Memory         float32                // Amount of memory allocated to the sandbox in GiB
 	Disk           float32                // Amount of disk space allocated to the sandbox in GiB
 	State          apiclient.SandboxState // Current sandbox state
@@ -173,6 +175,7 @@ type sandboxDTO interface {
 	GetTarget() string
 	GetCpu() float32
 	GetGpu() float32
+	GetSpot() bool
 	GetMemory() float32
 	GetDisk() float32
 	GetState() apiclient.SandboxState
@@ -202,6 +205,7 @@ type sandboxDTO interface {
 	GetUpdatedAtOk() (*string, bool)
 	GetLastActivityAtOk() (*string, bool)
 	GetAutoDestroyAtOk() (*string, bool)
+	GetSpotEvictedAtOk() (*string, bool)
 }
 
 // ListSandboxesQuery contains query parameters for filtering and sorting when listing sandboxes.
@@ -392,6 +396,10 @@ func (s *Sandbox) populateFromDTO(dto sandboxDTO) {
 	s.Target = dto.GetTarget()
 	s.Cpu = dto.GetCpu()
 	s.Gpu = dto.GetGpu()
+	s.Spot = dto.GetSpot()
+	if v, ok := dto.GetSpotEvictedAtOk(); ok {
+		s.SpotEvictedAt = v
+	}
 	s.Memory = dto.GetMemory()
 	s.Disk = dto.GetDisk()
 	s.ToolboxProxyUrl = dto.GetToolboxProxyUrl()

--- a/sdk-go/pkg/types/types.go
+++ b/sdk-go/pkg/types/types.go
@@ -120,6 +120,10 @@ type SandboxBaseParams struct {
 	// combine with DomainAllowList for network-layer enforcement.
 	OutboundProxyUrl *string
 	Ephemeral        bool
+	// Spot marks the sandbox as a spot GPU sandbox. A spot sandbox may be instantly
+	// terminated without notice to free GPU capacity for an on-demand (non-spot) GPU
+	// sandbox. Rejected when the sandbox requests no GPUs.
+	Spot bool
 	// LinkedSandbox is the ID or name of an existing sandbox to link the new sandbox to.
 	// The new sandbox will be scheduled on the same runner as the linked sandbox so a local
 	// network can be established between them.

--- a/sdk-java/src/main/java/io/daytona/sdk/Daytona.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Daytona.java
@@ -600,6 +600,7 @@ public class Daytona implements AutoCloseable {
         if (params.getDomainAllowList() != null) body.setDomainAllowList(params.getDomainAllowList());
         if (params.getOutboundProxyUrl() != null) body.setOutboundProxyUrl(params.getOutboundProxyUrl());
         if (params.getLinkedSandbox() != null) body.setLinkedSandbox(params.getLinkedSandbox());
+        if (params.getSpot() != null) body.setSpot(params.getSpot());
         if (params.getVolumes() != null) {
             List<SandboxVolume> volumes = new ArrayList<SandboxVolume>();
             for (io.daytona.sdk.model.VolumeMount mount : params.getVolumes()) {

--- a/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
@@ -138,6 +138,8 @@ public class Sandbox {
     private String target;
     private int cpu;
     private int gpu;
+    private boolean spot;
+    private String spotEvictedAt;
     private int memory;
     private int disk;
     private volatile String state;
@@ -854,7 +856,7 @@ public class Sandbox {
         populateCommonFields(
                 d.getId(), d.getName(), d.getOrganizationId(), d.getSnapshot(), d.getUser(),
                 d.getLabels(), d.getPublic(), d.getTarget(),
-                d.getCpu(), d.getGpu(), d.getMemory(), d.getDisk(),
+                d.getCpu(), d.getGpu(), d.getSpot(), d.getSpotEvictedAt(), d.getMemory(), d.getDisk(),
                 d.getErrorReason(), d.getRecoverable(),
                 d.getBackupState() == null ? null : d.getBackupState().getValue(),
                 d.getAutoStopInterval(), d.getAutoPauseInterval(), d.getAutoArchiveInterval(), d.getAutoDeleteInterval(),
@@ -888,7 +890,7 @@ public class Sandbox {
         populateCommonFields(
                 d.getId(), d.getName(), d.getOrganizationId(), d.getSnapshot(), d.getUser(),
                 d.getLabels(), d.getPublic(), d.getTarget(),
-                d.getCpu(), d.getGpu(), d.getMemory(), d.getDisk(),
+                d.getCpu(), d.getGpu(), d.getSpot(), d.getSpotEvictedAt(), d.getMemory(), d.getDisk(),
                 d.getErrorReason(), d.getRecoverable(),
                 d.getBackupState() == null ? null : d.getBackupState().getValue(),
                 d.getAutoStopInterval(), d.getAutoPauseInterval(), d.getAutoArchiveInterval(), d.getAutoDeleteInterval(),
@@ -905,7 +907,7 @@ public class Sandbox {
     private void populateCommonFields(
             String id, String name, String organizationId, String snapshot, String user,
             Map<String, String> labels, Boolean isPublic, String target,
-            BigDecimal cpu, BigDecimal gpu, BigDecimal memory, BigDecimal disk,
+            BigDecimal cpu, BigDecimal gpu, Boolean spot, String spotEvictedAt, BigDecimal memory, BigDecimal disk,
             String errorReason, Boolean recoverable, String backupState,
             BigDecimal autoStopInterval, BigDecimal autoPauseInterval, BigDecimal autoArchiveInterval, BigDecimal autoDeleteInterval,
             String createdAt, String updatedAt, String lastActivityAt, String autoDestroyAt,
@@ -920,6 +922,8 @@ public class Sandbox {
         this.target = asString(target);
         this.cpu = cpu == null ? 0 : cpu.intValue();
         this.gpu = gpu == null ? 0 : gpu.intValue();
+        this.spot = spot != null && spot;
+        this.spotEvictedAt = spotEvictedAt;
         this.memory = memory == null ? 0 : memory.intValue();
         this.disk = disk == null ? 0 : disk.intValue();
         this.errorReason = errorReason;
@@ -1399,6 +1403,18 @@ public class Sandbox {
     public int getCpu() { return cpu; }
     /** @return allocated GPU units. */
     public int getGpu() { return gpu; }
+
+    /**
+     * Returns whether this is a spot GPU Sandbox.
+     *
+     * <p>Spot Sandboxes may be instantly terminated to free capacity for on-demand GPU Sandboxes.
+     *
+     * @return {@code true} when the Sandbox is preemptible.
+     */
+    public boolean isSpot() { return spot; }
+
+    /** @return when the Sandbox was evicted by spot preemption, or {@code null} when it was not. */
+    public String getSpotEvictedAt() { return spotEvictedAt; }
     /** @return allocated memory in GiB. */
     public int getMemory() { return memory; }
     /** @return allocated disk in GiB. */

--- a/sdk-java/src/main/java/io/daytona/sdk/model/CreateSandboxParams.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/model/CreateSandboxParams.java
@@ -33,6 +33,7 @@ public class CreateSandboxParams {
     private String domainAllowList;
     private String outboundProxyUrl;
     private String linkedSandbox;
+    private Boolean spot;
 
     /**
      * Returns Sandbox name.
@@ -293,4 +294,21 @@ public class CreateSandboxParams {
      * @param linkedSandbox linked Sandbox identifier
      */
     public void setLinkedSandbox(String linkedSandbox) { this.linkedSandbox = linkedSandbox; }
+
+    /**
+     * Returns whether the Sandbox is requested as a spot GPU Sandbox.
+     *
+     * @return {@code true} when the Sandbox may be preempted, or {@code null} when unset
+     */
+    public Boolean getSpot() { return spot; }
+
+    /**
+     * Sets whether the Sandbox is requested as a spot GPU Sandbox.
+     *
+     * <p>GPU-only. When {@code true}, the Sandbox may be instantly terminated without notice to free
+     * GPU capacity for an on-demand (non-spot) GPU Sandbox. Rejected when the Sandbox requests no GPUs.
+     *
+     * @param spot whether the Sandbox may be preempted
+     */
+    public void setSpot(Boolean spot) { this.spot = spot; }
 }

--- a/sdk-python/src/daytona/_async/daytona.py
+++ b/sdk-python/src/daytona/_async/daytona.py
@@ -642,6 +642,7 @@ class AsyncDaytona:
             domain_allow_list=params.domain_allow_list,
             outbound_proxy_url=params.outbound_proxy_url,
             linked_sandbox=params.linked_sandbox,
+            spot=params.spot,
         )
 
         if isinstance(params, CreateSandboxFromSnapshotParams) and params.snapshot:

--- a/sdk-python/src/daytona/_async/sandbox.py
+++ b/sdk-python/src/daytona/_async/sandbox.py
@@ -1440,7 +1440,7 @@ class AsyncSandbox(SandboxDto):
         self.target: str = sandbox_dto.target
         self.cpu: float | int = sandbox_dto.cpu
         self.gpu: float | int = sandbox_dto.gpu
-        self.spot: bool = sandbox_dto.spot or False
+        self.spot: bool | None = sandbox_dto.spot or False
         self.spot_evicted_at: str | None = sandbox_dto.spot_evicted_at
         self.memory: float | int = sandbox_dto.memory
         self.disk: float | int = sandbox_dto.disk

--- a/sdk-python/src/daytona/_async/sandbox.py
+++ b/sdk-python/src/daytona/_async/sandbox.py
@@ -130,6 +130,9 @@ class AsyncSandbox(SandboxDto):
         target (str): Target location of the runner where the Sandbox runs.
         cpu (int): Number of CPUs allocated to the Sandbox.
         gpu (int): Number of GPUs allocated to the Sandbox.
+        spot (bool): Whether this is a spot GPU Sandbox. Spot Sandboxes may be instantly terminated
+            to free capacity for on-demand GPU Sandboxes.
+        spot_evicted_at (str | None): When the Sandbox was evicted by spot preemption.
         memory (int): Amount of memory allocated to the Sandbox in GiB.
         disk (int): Amount of disk space allocated to the Sandbox in GiB.
         state (SandboxState | None): Current state of the Sandbox (e.g., "started", "stopped").
@@ -1437,6 +1440,8 @@ class AsyncSandbox(SandboxDto):
         self.target: str = sandbox_dto.target
         self.cpu: float | int = sandbox_dto.cpu
         self.gpu: float | int = sandbox_dto.gpu
+        self.spot: bool = sandbox_dto.spot or False
+        self.spot_evicted_at: str | None = sandbox_dto.spot_evicted_at
         self.memory: float | int = sandbox_dto.memory
         self.disk: float | int = sandbox_dto.disk
         self.error_reason: str | None = sandbox_dto.error_reason

--- a/sdk-python/src/daytona/_sync/daytona.py
+++ b/sdk-python/src/daytona/_sync/daytona.py
@@ -509,6 +509,7 @@ class Daytona:
             domain_allow_list=params.domain_allow_list,
             outbound_proxy_url=params.outbound_proxy_url,
             linked_sandbox=params.linked_sandbox,
+            spot=params.spot,
         )
 
         if isinstance(params, CreateSandboxFromSnapshotParams) and params.snapshot:

--- a/sdk-python/src/daytona/_sync/sandbox.py
+++ b/sdk-python/src/daytona/_sync/sandbox.py
@@ -1416,7 +1416,7 @@ class Sandbox(SandboxDto):
         self.target: str = sandbox_dto.target
         self.cpu: float | int = sandbox_dto.cpu
         self.gpu: float | int = sandbox_dto.gpu
-        self.spot: bool = sandbox_dto.spot or False
+        self.spot: bool | None = sandbox_dto.spot or False
         self.spot_evicted_at: str | None = sandbox_dto.spot_evicted_at
         self.memory: float | int = sandbox_dto.memory
         self.disk: float | int = sandbox_dto.disk

--- a/sdk-python/src/daytona/_sync/sandbox.py
+++ b/sdk-python/src/daytona/_sync/sandbox.py
@@ -111,6 +111,9 @@ class Sandbox(SandboxDto):
         target (str): Target location of the runner where the Sandbox runs.
         cpu (int): Number of CPUs allocated to the Sandbox.
         gpu (int): Number of GPUs allocated to the Sandbox.
+        spot (bool): Whether this is a spot GPU Sandbox. Spot Sandboxes may be instantly terminated
+            to free capacity for on-demand GPU Sandboxes.
+        spot_evicted_at (str | None): When the Sandbox was evicted by spot preemption.
         memory (int): Amount of memory allocated to the Sandbox in GiB.
         disk (int): Amount of disk space allocated to the Sandbox in GiB.
         state (SandboxState | None): Current state of the Sandbox (e.g., "started", "stopped").
@@ -1413,6 +1416,8 @@ class Sandbox(SandboxDto):
         self.target: str = sandbox_dto.target
         self.cpu: float | int = sandbox_dto.cpu
         self.gpu: float | int = sandbox_dto.gpu
+        self.spot: bool = sandbox_dto.spot or False
+        self.spot_evicted_at: str | None = sandbox_dto.spot_evicted_at
         self.memory: float | int = sandbox_dto.memory
         self.disk: float | int = sandbox_dto.disk
         self.error_reason: str | None = sandbox_dto.error_reason

--- a/sdk-python/src/daytona/common/daytona.py
+++ b/sdk-python/src/daytona/common/daytona.py
@@ -174,6 +174,9 @@ class CreateSandboxBaseParams(BaseModel):
             combine with domain_allow_list for unbypassable network-layer enforcement.
         ephemeral (bool | None): Whether the Sandbox should be ephemeral.
             If True, auto_delete_interval will be set to 0.
+        spot (bool | None): GPU-only. When True, the Sandbox may be instantly terminated without notice
+            to free GPU capacity for an on-demand (non-spot) GPU Sandbox. Rejected when the Sandbox
+            requests no GPUs.
         linked_sandbox (str | None): ID or name of an existing Sandbox to link the new Sandbox to. The new
             Sandbox will be scheduled on the same runner as the linked Sandbox so a local network can be
             established between them. Linked Sandboxes must be
@@ -198,6 +201,7 @@ class CreateSandboxBaseParams(BaseModel):
     domain_allow_list: str | None = None
     outbound_proxy_url: str | None = None
     ephemeral: bool | None = None
+    spot: bool | None = None
     linked_sandbox: str | None = None
 
     @model_validator(mode="before")

--- a/sdk-ruby/lib/daytona/common/daytona.rb
+++ b/sdk-ruby/lib/daytona/common/daytona.rb
@@ -65,6 +65,11 @@ module Daytona
     # @return [Boolean, nil] Whether the Sandbox should be ephemeral
     attr_accessor :ephemeral
 
+    # @return [Boolean, nil] GPU-only. When true, the Sandbox may be instantly terminated without notice
+    #   to free GPU capacity for an on-demand (non-spot) GPU Sandbox. Rejected when the Sandbox
+    #   requests no GPUs.
+    attr_accessor :spot
+
     # @return [String, nil] ID or name of an existing Sandbox to link the new Sandbox to. The new
     #   Sandbox will be scheduled on the same runner as the linked Sandbox so a local network can be
     #   established between them. Linked Sandboxes must be
@@ -94,6 +99,8 @@ module Daytona
     #   network-layer enforcement.
     # @param ttl_minutes [Integer, nil] Time to live in minutes (0 to disable)
     # @param ephemeral [Boolean, nil] Whether the Sandbox should be ephemeral
+    # @param spot [Boolean, nil] GPU-only. Whether the Sandbox may be instantly terminated to free GPU
+    #   capacity for an on-demand GPU Sandbox
     # @param linked_sandbox [String, nil] ID or name of an existing Sandbox to link the new Sandbox to
     def initialize( # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
       language: nil,
@@ -114,6 +121,7 @@ module Daytona
       domain_allow_list: nil,
       outbound_proxy_url: nil,
       ephemeral: nil,
+      spot: nil,
       linked_sandbox: nil
     )
       @language = language
@@ -134,6 +142,7 @@ module Daytona
       @domain_allow_list = domain_allow_list
       @outbound_proxy_url = outbound_proxy_url
       @ephemeral = ephemeral
+      @spot = spot
       @linked_sandbox = linked_sandbox
 
       # Handle ephemeral and auto_delete_interval conflict
@@ -163,6 +172,7 @@ module Daytona
         domain_allow_list:,
         outbound_proxy_url:,
         ephemeral:,
+        spot:,
         linked_sandbox:
       }.compact
     end

--- a/sdk-ruby/lib/daytona/daytona.rb
+++ b/sdk-ruby/lib/daytona/daytona.rb
@@ -294,7 +294,8 @@ module Daytona
         network_allow_list: params.network_allow_list,
         domain_allow_list: params.domain_allow_list,
         outbound_proxy_url: params.outbound_proxy_url,
-        linked_sandbox: params.linked_sandbox
+        linked_sandbox: params.linked_sandbox,
+        spot: params.spot
       )
 
       create_sandbox.snapshot = params.snapshot if params.respond_to?(:snapshot)

--- a/sdk-ruby/lib/daytona/sandbox.rb
+++ b/sdk-ruby/lib/daytona/sandbox.rb
@@ -101,6 +101,13 @@ module Daytona
     # @return [Float] The GPU quota for the sandbox
     attr_reader :gpu
 
+    # @return [Boolean] Whether this is a spot GPU sandbox. Spot sandboxes may be instantly terminated
+    #   to free capacity for on-demand GPU sandboxes.
+    attr_reader :spot
+
+    # @return [String, nil] When the sandbox was evicted by spot preemption
+    attr_reader :spot_evicted_at
+
     # @return [Float] The memory quota for the sandbox
     attr_reader :memory
 
@@ -1085,6 +1092,8 @@ module Daytona
       @target = sandbox_dto.target
       @cpu = sandbox_dto.cpu
       @gpu = sandbox_dto.gpu
+      @spot = sandbox_dto.spot || false
+      @spot_evicted_at = sandbox_dto.spot_evicted_at
       @memory = sandbox_dto.memory
       @disk = sandbox_dto.disk
       @desired_state = sandbox_dto.desired_state

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -189,6 +189,7 @@ export interface Resources {
  * @property {string} [domainAllowList] - Comma-separated list of allowed domains for the Sandbox
  * @property {string} [outboundProxyUrl] - Outbound proxy URL to route the Sandbox HTTP(S) traffic through. Applied via the HTTP(S)_PROXY environment variables (convenience routing, not a security boundary on its own); combine with domainAllowList for unbypassable network-layer enforcement.
  * @property {boolean} [ephemeral] - Whether the Sandbox should be ephemeral. If true, autoDeleteInterval will be set to 0.
+ * @property {boolean} [spot] - GPU-only. When true, the Sandbox may be instantly terminated without notice to free GPU capacity for an on-demand (non-spot) GPU Sandbox. Rejected when the Sandbox requests no GPUs.
  * @property {string} [linkedSandbox] - ID or name of an existing sandbox to link the new sandbox to. The new sandbox will be scheduled on the same runner as the linked sandbox so a local network can be established between them. Linked sandboxes must be ephemeral (autoDeleteInterval=0) and cannot themselves be linked to another sandbox.
  * @property {Record<string, string>} [secrets] - Optional map of environment variable name to the name of an existing organization Secret to mount into the Sandbox. The env var is set to the Secret's opaque placeholder; the real value is substituted transparently on outbound requests to the Secret's allowed hosts. Every referenced Secret name must already exist in the organization.
  */
@@ -210,6 +211,7 @@ export type CreateSandboxBaseParams = {
   domainAllowList?: string
   outboundProxyUrl?: string
   ephemeral?: boolean
+  spot?: boolean
   linkedSandbox?: string
   secrets?: Record<string, string>
 }
@@ -687,6 +689,7 @@ export class Daytona implements AsyncDisposable {
               : Array.isArray(resources.gpuType)
                 ? resources.gpuType
                 : [resources.gpuType],
+          spot: params.spot,
           memory: resources?.memory,
           disk: resources?.disk,
           autoStopInterval: params.autoStopInterval,

--- a/sdk-typescript/src/Sandbox.ts
+++ b/sdk-typescript/src/Sandbox.ts
@@ -87,6 +87,9 @@ function withEvents<This, Args extends unknown[], Return>(
  * @property {string} target - Target location of the runner where the Sandbox runs
  * @property {number} cpu - Number of CPUs allocated to the Sandbox
  * @property {number} gpu - Number of GPUs allocated to the Sandbox
+ * @property {boolean} [spot] - Whether this is a spot GPU Sandbox. Spot Sandboxes may be instantly terminated to free
+ * capacity for on-demand GPU Sandboxes
+ * @property {string} [spotEvictedAt] - When the Sandbox was evicted by spot preemption
  * @property {number} memory - Amount of memory allocated to the Sandbox in GiB
  * @property {number} disk - Amount of disk space allocated to the Sandbox in GiB
  * @property {SandboxState} state - Current state of the Sandbox (e.g., "started", "stopped")
@@ -138,6 +141,8 @@ export class Sandbox {
   public target!: string
   public cpu!: number
   public gpu!: number
+  public spot?: boolean
+  public spotEvictedAt?: string
   public memory!: number
   public disk!: number
   public state?: SandboxState
@@ -1449,6 +1454,8 @@ export class Sandbox {
     this.target = sandboxDto.target
     this.cpu = sandboxDto.cpu
     this.gpu = sandboxDto.gpu
+    this.spot = sandboxDto.spot ?? false
+    this.spotEvictedAt = sandboxDto.spotEvictedAt
     this.memory = sandboxDto.memory
     this.disk = sandboxDto.disk
     this.errorReason = sandboxDto.errorReason


### PR DESCRIPTION
## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds spot GPU support and eviction visibility across the Sandbox API and SDKs. Previously, GPU sandboxes were always on‑demand and evicted sandboxes disappeared immediately; now clients can request spot GPU sandboxes and read `spotEvictedAt` for 24 hours after preemption.

- Adds `spot` and `spotEvictedAt` to sandbox models and list items; treat missing `spot` as false for older APIs.
- Create Sandbox accepts `spot` (GPU‑only, default false; ignored/rejected when `gpu=0`).
- `GET /sandbox/{idOrName}`: evicted spot sandboxes remain retrievable for 24 hours to read `spotEvictedAt`; in list responses, `spotEvictedAt` is set as soon as eviction is scheduled.
- Adds audit action `spot_evict`.
- Updates OpenAPI and regenerates clients and docs (`api-client-go`, `api-client-java`, `api-client-python`, `api-client-python-async`, `api-client-ruby`, `api-client`, `openapi-specs/api.json`).

**SDK updates and migration**
- Surfaces `spot` and `spotEvictedAt` and passes `spot` on create in `sdk-go`, `sdk-java`, `sdk-python`, `sdk-ruby`, and `sdk-typescript` (type annotations fixed; default `false`).
- Required actions:
  - To request a spot GPU sandbox, set `spot=true` with `gpu>0` on create.
  - If you display sandbox status or lists, include `spot` and show `spotEvictedAt` when present.
  - If you process audit events, handle `spot_evict`.

<sup>Written for commit 8a94bbce8b68510e695ff98d536ba74a0e6e46f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

