### PR TITLE
feat: add otelEndpointOverride to sandbox creation

### DIFF
--- a/api-client-go/api/openapi.yaml
+++ b/api-client-go/api/openapi.yaml
@@ -7604,8 +7604,8 @@ components:
           allOf:
           - $ref: "#/components/schemas/SsoOidcConfig"
           description: OIDC configuration for org-SSO logins (Daytona Auth issuer).
-            Present only when the dual-issuer setup is configured; the dashboard uses
-            it as its authority when entered via an organization SSO link.
+            Present only when the secondary (org-SSO) issuer is configured; the dashboard
+            uses it as its authority when entered via an organization SSO link.
         forcedFeatureFlags:
           description: "Feature flags forced on for this deployment regardless of\
             \ PostHog targeting. Lets environments without PostHog (previews, local\
@@ -9085,6 +9085,7 @@ components:
     Region:
       example:
         organizationId: 123e4567-e89b-12d3-a456-426614174000
+        otelEndpoint: https://otel-collector.example.com:4318
         createdAt: 2023-01-01T00:00:00.000Z
         snapshotManagerUrl: http://snapshot-manager.example.com
         regionType: shared
@@ -9135,6 +9136,14 @@ components:
           example: http://snapshot-manager.example.com
           nullable: true
           type: string
+        otelEndpoint:
+          description: "OTel collector endpoint for sandboxes created in this region.\
+            \ When set, sandbox OTel data is sent to this endpoint instead of the\
+            \ Daytona-hosted collector and will not be available in the Daytona analytics\
+            \ API or dashboard."
+          example: https://otel-collector.example.com:4318
+          nullable: true
+          type: string
       required:
       - createdAt
       - id
@@ -9144,6 +9153,7 @@ components:
       type: object
     CreateRegion:
       example:
+        otelEndpoint: https://otel-collector.example.com:4318
         snapshotManagerUrl: https://snapshot-manager.example.com
         proxyUrl: https://proxy.example.com
         name: us-east-1
@@ -9166,6 +9176,14 @@ components:
         snapshotManagerUrl:
           description: Snapshot Manager URL for the region
           example: https://snapshot-manager.example.com
+          nullable: true
+          type: string
+        otelEndpoint:
+          description: "OTel collector endpoint for sandboxes created in this region.\
+            \ When set, sandbox OTel data is sent to this endpoint instead of the\
+            \ Daytona-hosted collector and will not be available in the Daytona analytics\
+            \ API or dashboard."
+          example: https://otel-collector.example.com:4318
           nullable: true
           type: string
       required:
@@ -9218,6 +9236,7 @@ components:
       type: object
     UpdateRegion:
       example:
+        otelEndpoint: https://otel-collector.example.com:4318
         snapshotManagerUrl: https://snapshot-manager.example.com
         proxyUrl: https://proxy.example.com
         sshGatewayUrl: ssh://ssh-gateway.example.com
@@ -9235,6 +9254,14 @@ components:
         snapshotManagerUrl:
           description: Snapshot Manager URL for the region
           example: https://snapshot-manager.example.com
+          nullable: true
+          type: string
+        otelEndpoint:
+          description: "OTel collector endpoint for sandboxes created in this region.\
+            \ When set, sandbox OTel data is sent to this endpoint instead of the\
+            \ Daytona-hosted collector and will not be available in the Daytona analytics\
+            \ API or dashboard."
+          example: https://otel-collector.example.com:4318
           nullable: true
           type: string
       type: object
@@ -9587,6 +9614,7 @@ components:
           key: key
         - name: name
           key: key
+        pylonEmailHash: pylonEmailHash
         name: name
         id: id
         email: email
@@ -9603,6 +9631,9 @@ components:
         emailVerified:
           description: Whether the user email address has been verified
           type: boolean
+        pylonEmailHash:
+          description: HMAC of the user email for Pylon support-widget identity verification
+          type: string
         publicKeys:
           description: User public keys
           items:
@@ -10080,6 +10111,7 @@ components:
         warmPoolId: warmPoolId
         autoStopInterval: 30
         organizationId: organization123
+        otelEndpointOverride: https://otel-collector.example.com:4318
         autoPauseInterval: 60
         createdAt: 2024-10-01T12:00:00Z
         networkBlockAll: false
@@ -10180,6 +10212,13 @@ components:
             network-layer enforcement applies only when the sandbox also has a domainAllowList.
             Only returned on single-sandbox reads — never on list responses.
           example: http://user:pass@proxy.example.com:3128
+          type: string
+        otelEndpointOverride:
+          description: "OTel collector endpoint override for this sandbox. When set,\
+            \ sandbox OTel data is sent to this endpoint instead of the default collector\
+            \ and is not available in the Daytona analytics API or dashboard. Only\
+            \ returned on single-sandbox reads — never on list responses."
+          example: https://otel-collector.example.com:4318
           type: string
         target:
           description: The target environment for the sandbox
@@ -10361,6 +10400,7 @@ components:
           warmPoolId: warmPoolId
           autoStopInterval: 30
           organizationId: organization123
+          otelEndpointOverride: https://otel-collector.example.com:4318
           autoPauseInterval: 60
           createdAt: 2024-10-01T12:00:00Z
           networkBlockAll: false
@@ -10411,6 +10451,7 @@ components:
           warmPoolId: warmPoolId
           autoStopInterval: 30
           organizationId: organization123
+          otelEndpointOverride: https://otel-collector.example.com:4318
           autoPauseInterval: 60
           createdAt: 2024-10-01T12:00:00Z
           networkBlockAll: false
@@ -10497,6 +10538,7 @@ components:
         memory: 1
         buildInfo: ""
         autoStopInterval: 30
+        otelEndpointOverride: https://otel-collector.example.com:4318
         autoPauseInterval: 60
         networkBlockAll: false
         autoDeleteInterval: 30
@@ -10586,6 +10628,13 @@ components:
             \ redirected through the proxy chain at the network layer, which cannot\
             \ be bypassed from inside the sandbox."
           example: http://user:pass@proxy.example.com:3128
+          type: string
+        otelEndpointOverride:
+          description: "OTel collector endpoint override for this sandbox. When set,\
+            \ sandbox OTel data is sent to this endpoint instead of the default collector\
+            \ (the Daytona-hosted collector or the region-configured endpoint) and\
+            \ will not be available in the Daytona analytics API or dashboard."
+          example: https://otel-collector.example.com:4318
           type: string
         target:
           description: The target (region) where the sandbox will be created

--- a/api-client-go/model_create_region.go
+++ b/api-client-go/model_create_region.go
@@ -29,6 +29,8 @@ type CreateRegion struct {
 	SshGatewayUrl NullableString `json:"sshGatewayUrl,omitempty"`
 	// Snapshot Manager URL for the region
 	SnapshotManagerUrl NullableString `json:"snapshotManagerUrl,omitempty"`
+	// OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+	OtelEndpoint NullableString `json:"otelEndpoint,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -202,6 +204,48 @@ func (o *CreateRegion) UnsetSnapshotManagerUrl() {
 	o.SnapshotManagerUrl.Unset()
 }
 
+// GetOtelEndpoint returns the OtelEndpoint field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *CreateRegion) GetOtelEndpoint() string {
+	if o == nil || IsNil(o.OtelEndpoint.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.OtelEndpoint.Get()
+}
+
+// GetOtelEndpointOk returns a tuple with the OtelEndpoint field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *CreateRegion) GetOtelEndpointOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.OtelEndpoint.Get(), o.OtelEndpoint.IsSet()
+}
+
+// HasOtelEndpoint returns a boolean if a field has been set.
+func (o *CreateRegion) HasOtelEndpoint() bool {
+	if o != nil && o.OtelEndpoint.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetOtelEndpoint gets a reference to the given NullableString and assigns it to the OtelEndpoint field.
+func (o *CreateRegion) SetOtelEndpoint(v string) {
+	o.OtelEndpoint.Set(&v)
+}
+// SetOtelEndpointNil sets the value for OtelEndpoint to be an explicit nil
+func (o *CreateRegion) SetOtelEndpointNil() {
+	o.OtelEndpoint.Set(nil)
+}
+
+// UnsetOtelEndpoint ensures that no value is present for OtelEndpoint, not even an explicit nil
+func (o *CreateRegion) UnsetOtelEndpoint() {
+	o.OtelEndpoint.Unset()
+}
+
 func (o CreateRegion) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -221,6 +265,9 @@ func (o CreateRegion) ToMap() (map[string]interface{}, error) {
 	}
 	if o.SnapshotManagerUrl.IsSet() {
 		toSerialize["snapshotManagerUrl"] = o.SnapshotManagerUrl.Get()
+	}
+	if o.OtelEndpoint.IsSet() {
+		toSerialize["otelEndpoint"] = o.OtelEndpoint.Get()
 	}
 
 	for key, value := range o.AdditionalProperties {
@@ -269,6 +316,7 @@ func (o *CreateRegion) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "proxyUrl")
 		delete(additionalProperties, "sshGatewayUrl")
 		delete(additionalProperties, "snapshotManagerUrl")
+		delete(additionalProperties, "otelEndpoint")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/api-client-go/model_create_sandbox.go
+++ b/api-client-go/model_create_sandbox.go
@@ -40,6 +40,8 @@ type CreateSandbox struct {
 	DomainAllowList *string `json:"domainAllowList,omitempty"`
 	// Outbound proxy URL to route the sandbox HTTP(S) traffic through (http or https; credentials may be included in the URL). On its own this is convenience routing, not a security boundary: it is applied by injecting the standard HTTP(S)_PROXY environment variables at creation, so a process that clears those variables egresses directly. Combine with domainAllowList to have web-port (80/443) egress transparently redirected through the proxy chain at the network layer, which cannot be bypassed from inside the sandbox.
 	OutboundProxyUrl *string `json:"outboundProxyUrl,omitempty"`
+	// OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector (the Daytona-hosted collector or the region-configured endpoint) and will not be available in the Daytona analytics API or dashboard.
+	OtelEndpointOverride *string `json:"otelEndpointOverride,omitempty"`
 	// The target (region) where the sandbox will be created
 	Target *string `json:"target,omitempty"`
 	// CPU cores allocated to the sandbox
@@ -416,6 +418,38 @@ func (o *CreateSandbox) HasOutboundProxyUrl() bool {
 // SetOutboundProxyUrl gets a reference to the given string and assigns it to the OutboundProxyUrl field.
 func (o *CreateSandbox) SetOutboundProxyUrl(v string) {
 	o.OutboundProxyUrl = &v
+}
+
+// GetOtelEndpointOverride returns the OtelEndpointOverride field value if set, zero value otherwise.
+func (o *CreateSandbox) GetOtelEndpointOverride() string {
+	if o == nil || IsNil(o.OtelEndpointOverride) {
+		var ret string
+		return ret
+	}
+	return *o.OtelEndpointOverride
+}
+
+// GetOtelEndpointOverrideOk returns a tuple with the OtelEndpointOverride field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CreateSandbox) GetOtelEndpointOverrideOk() (*string, bool) {
+	if o == nil || IsNil(o.OtelEndpointOverride) {
+		return nil, false
+	}
+	return o.OtelEndpointOverride, true
+}
+
+// HasOtelEndpointOverride returns a boolean if a field has been set.
+func (o *CreateSandbox) HasOtelEndpointOverride() bool {
+	if o != nil && !IsNil(o.OtelEndpointOverride) {
+		return true
+	}
+
+	return false
+}
+
+// SetOtelEndpointOverride gets a reference to the given string and assigns it to the OtelEndpointOverride field.
+func (o *CreateSandbox) SetOtelEndpointOverride(v string) {
+	o.OtelEndpointOverride = &v
 }
 
 // GetTarget returns the Target field value if set, zero value otherwise.
@@ -970,6 +1004,9 @@ func (o CreateSandbox) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.OutboundProxyUrl) {
 		toSerialize["outboundProxyUrl"] = o.OutboundProxyUrl
 	}
+	if !IsNil(o.OtelEndpointOverride) {
+		toSerialize["otelEndpointOverride"] = o.OtelEndpointOverride
+	}
 	if !IsNil(o.Target) {
 		toSerialize["target"] = o.Target
 	}
@@ -1050,6 +1087,7 @@ func (o *CreateSandbox) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "networkAllowList")
 		delete(additionalProperties, "domainAllowList")
 		delete(additionalProperties, "outboundProxyUrl")
+		delete(additionalProperties, "otelEndpointOverride")
 		delete(additionalProperties, "target")
 		delete(additionalProperties, "cpu")
 		delete(additionalProperties, "gpu")

--- a/api-client-go/model_daytona_configuration.go
+++ b/api-client-go/model_daytona_configuration.go
@@ -29,7 +29,7 @@ type DaytonaConfiguration struct {
 	Posthog *PosthogConfig `json:"posthog,omitempty"`
 	// OIDC configuration
 	Oidc OidcConfig `json:"oidc"`
-	// OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the dual-issuer setup is configured; the dashboard uses it as its authority when entered via an organization SSO link.
+	// OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the secondary (org-SSO) issuer is configured; the dashboard uses it as its authority when entered via an organization SSO link.
 	SsoOidc *SsoOidcConfig `json:"ssoOidc,omitempty"`
 	// Feature flags forced on for this deployment regardless of PostHog targeting. Lets environments without PostHog (previews, local dev) enable flag-gated dashboard features.
 	ForcedFeatureFlags []string `json:"forcedFeatureFlags,omitempty"`

--- a/api-client-go/model_region.go
+++ b/api-client-go/model_region.go
@@ -39,6 +39,8 @@ type Region struct {
 	SshGatewayUrl NullableString `json:"sshGatewayUrl,omitempty"`
 	// Snapshot Manager URL for the region
 	SnapshotManagerUrl NullableString `json:"snapshotManagerUrl,omitempty"`
+	// OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+	OtelEndpoint NullableString `json:"otelEndpoint,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -354,6 +356,48 @@ func (o *Region) UnsetSnapshotManagerUrl() {
 	o.SnapshotManagerUrl.Unset()
 }
 
+// GetOtelEndpoint returns the OtelEndpoint field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *Region) GetOtelEndpoint() string {
+	if o == nil || IsNil(o.OtelEndpoint.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.OtelEndpoint.Get()
+}
+
+// GetOtelEndpointOk returns a tuple with the OtelEndpoint field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *Region) GetOtelEndpointOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.OtelEndpoint.Get(), o.OtelEndpoint.IsSet()
+}
+
+// HasOtelEndpoint returns a boolean if a field has been set.
+func (o *Region) HasOtelEndpoint() bool {
+	if o != nil && o.OtelEndpoint.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetOtelEndpoint gets a reference to the given NullableString and assigns it to the OtelEndpoint field.
+func (o *Region) SetOtelEndpoint(v string) {
+	o.OtelEndpoint.Set(&v)
+}
+// SetOtelEndpointNil sets the value for OtelEndpoint to be an explicit nil
+func (o *Region) SetOtelEndpointNil() {
+	o.OtelEndpoint.Set(nil)
+}
+
+// UnsetOtelEndpoint ensures that no value is present for OtelEndpoint, not even an explicit nil
+func (o *Region) UnsetOtelEndpoint() {
+	o.OtelEndpoint.Unset()
+}
+
 func (o Region) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -380,6 +424,9 @@ func (o Region) ToMap() (map[string]interface{}, error) {
 	}
 	if o.SnapshotManagerUrl.IsSet() {
 		toSerialize["snapshotManagerUrl"] = o.SnapshotManagerUrl.Get()
+	}
+	if o.OtelEndpoint.IsSet() {
+		toSerialize["otelEndpoint"] = o.OtelEndpoint.Get()
 	}
 
 	for key, value := range o.AdditionalProperties {
@@ -437,6 +484,7 @@ func (o *Region) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "proxyUrl")
 		delete(additionalProperties, "sshGatewayUrl")
 		delete(additionalProperties, "snapshotManagerUrl")
+		delete(additionalProperties, "otelEndpoint")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/api-client-go/model_sandbox.go
+++ b/api-client-go/model_sandbox.go
@@ -45,6 +45,8 @@ type Sandbox struct {
 	DomainAllowList *string `json:"domainAllowList,omitempty"`
 	// Outbound proxy URL the sandbox HTTP(S) traffic is routed through. Applied via the HTTP(S)_PROXY environment variables (convenience routing); network-layer enforcement applies only when the sandbox also has a domainAllowList. Only returned on single-sandbox reads — never on list responses.
 	OutboundProxyUrl *string `json:"outboundProxyUrl,omitempty"`
+	// OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector and is not available in the Daytona analytics API or dashboard. Only returned on single-sandbox reads — never on list responses.
+	OtelEndpointOverride *string `json:"otelEndpointOverride,omitempty"`
 	// The target environment for the sandbox
 	Target string `json:"target"`
 	// The CPU quota for the sandbox
@@ -465,6 +467,38 @@ func (o *Sandbox) HasOutboundProxyUrl() bool {
 // SetOutboundProxyUrl gets a reference to the given string and assigns it to the OutboundProxyUrl field.
 func (o *Sandbox) SetOutboundProxyUrl(v string) {
 	o.OutboundProxyUrl = &v
+}
+
+// GetOtelEndpointOverride returns the OtelEndpointOverride field value if set, zero value otherwise.
+func (o *Sandbox) GetOtelEndpointOverride() string {
+	if o == nil || IsNil(o.OtelEndpointOverride) {
+		var ret string
+		return ret
+	}
+	return *o.OtelEndpointOverride
+}
+
+// GetOtelEndpointOverrideOk returns a tuple with the OtelEndpointOverride field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Sandbox) GetOtelEndpointOverrideOk() (*string, bool) {
+	if o == nil || IsNil(o.OtelEndpointOverride) {
+		return nil, false
+	}
+	return o.OtelEndpointOverride, true
+}
+
+// HasOtelEndpointOverride returns a boolean if a field has been set.
+func (o *Sandbox) HasOtelEndpointOverride() bool {
+	if o != nil && !IsNil(o.OtelEndpointOverride) {
+		return true
+	}
+
+	return false
+}
+
+// SetOtelEndpointOverride gets a reference to the given string and assigns it to the OtelEndpointOverride field.
+func (o *Sandbox) SetOtelEndpointOverride(v string) {
+	o.OtelEndpointOverride = &v
 }
 
 // GetTarget returns the Target field value
@@ -1415,6 +1449,9 @@ func (o Sandbox) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.OutboundProxyUrl) {
 		toSerialize["outboundProxyUrl"] = o.OutboundProxyUrl
 	}
+	if !IsNil(o.OtelEndpointOverride) {
+		toSerialize["otelEndpointOverride"] = o.OtelEndpointOverride
+	}
 	toSerialize["target"] = o.Target
 	toSerialize["cpu"] = o.Cpu
 	toSerialize["gpu"] = o.Gpu
@@ -1561,6 +1598,7 @@ func (o *Sandbox) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "networkAllowList")
 		delete(additionalProperties, "domainAllowList")
 		delete(additionalProperties, "outboundProxyUrl")
+		delete(additionalProperties, "otelEndpointOverride")
 		delete(additionalProperties, "target")
 		delete(additionalProperties, "cpu")
 		delete(additionalProperties, "gpu")

--- a/api-client-go/model_update_region.go
+++ b/api-client-go/model_update_region.go
@@ -26,6 +26,8 @@ type UpdateRegion struct {
 	SshGatewayUrl NullableString `json:"sshGatewayUrl,omitempty"`
 	// Snapshot Manager URL for the region
 	SnapshotManagerUrl NullableString `json:"snapshotManagerUrl,omitempty"`
+	// OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+	OtelEndpoint NullableString `json:"otelEndpoint,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -174,6 +176,48 @@ func (o *UpdateRegion) UnsetSnapshotManagerUrl() {
 	o.SnapshotManagerUrl.Unset()
 }
 
+// GetOtelEndpoint returns the OtelEndpoint field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *UpdateRegion) GetOtelEndpoint() string {
+	if o == nil || IsNil(o.OtelEndpoint.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.OtelEndpoint.Get()
+}
+
+// GetOtelEndpointOk returns a tuple with the OtelEndpoint field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateRegion) GetOtelEndpointOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.OtelEndpoint.Get(), o.OtelEndpoint.IsSet()
+}
+
+// HasOtelEndpoint returns a boolean if a field has been set.
+func (o *UpdateRegion) HasOtelEndpoint() bool {
+	if o != nil && o.OtelEndpoint.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetOtelEndpoint gets a reference to the given NullableString and assigns it to the OtelEndpoint field.
+func (o *UpdateRegion) SetOtelEndpoint(v string) {
+	o.OtelEndpoint.Set(&v)
+}
+// SetOtelEndpointNil sets the value for OtelEndpoint to be an explicit nil
+func (o *UpdateRegion) SetOtelEndpointNil() {
+	o.OtelEndpoint.Set(nil)
+}
+
+// UnsetOtelEndpoint ensures that no value is present for OtelEndpoint, not even an explicit nil
+func (o *UpdateRegion) UnsetOtelEndpoint() {
+	o.OtelEndpoint.Unset()
+}
+
 func (o UpdateRegion) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -192,6 +236,9 @@ func (o UpdateRegion) ToMap() (map[string]interface{}, error) {
 	}
 	if o.SnapshotManagerUrl.IsSet() {
 		toSerialize["snapshotManagerUrl"] = o.SnapshotManagerUrl.Get()
+	}
+	if o.OtelEndpoint.IsSet() {
+		toSerialize["otelEndpoint"] = o.OtelEndpoint.Get()
 	}
 
 	for key, value := range o.AdditionalProperties {
@@ -218,6 +265,7 @@ func (o *UpdateRegion) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "proxyUrl")
 		delete(additionalProperties, "sshGatewayUrl")
 		delete(additionalProperties, "snapshotManagerUrl")
+		delete(additionalProperties, "otelEndpoint")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/api-client-go/model_user.go
+++ b/api-client-go/model_user.go
@@ -30,6 +30,8 @@ type User struct {
 	Email string `json:"email"`
 	// Whether the user email address has been verified
 	EmailVerified bool `json:"emailVerified"`
+	// HMAC of the user email for Pylon support-widget identity verification
+	PylonEmailHash *string `json:"pylonEmailHash,omitempty"`
 	// User public keys
 	PublicKeys []UserPublicKey `json:"publicKeys"`
 	// Creation timestamp
@@ -158,6 +160,38 @@ func (o *User) SetEmailVerified(v bool) {
 	o.EmailVerified = v
 }
 
+// GetPylonEmailHash returns the PylonEmailHash field value if set, zero value otherwise.
+func (o *User) GetPylonEmailHash() string {
+	if o == nil || IsNil(o.PylonEmailHash) {
+		var ret string
+		return ret
+	}
+	return *o.PylonEmailHash
+}
+
+// GetPylonEmailHashOk returns a tuple with the PylonEmailHash field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *User) GetPylonEmailHashOk() (*string, bool) {
+	if o == nil || IsNil(o.PylonEmailHash) {
+		return nil, false
+	}
+	return o.PylonEmailHash, true
+}
+
+// HasPylonEmailHash returns a boolean if a field has been set.
+func (o *User) HasPylonEmailHash() bool {
+	if o != nil && !IsNil(o.PylonEmailHash) {
+		return true
+	}
+
+	return false
+}
+
+// SetPylonEmailHash gets a reference to the given string and assigns it to the PylonEmailHash field.
+func (o *User) SetPylonEmailHash(v string) {
+	o.PylonEmailHash = &v
+}
+
 // GetPublicKeys returns the PublicKeys field value
 func (o *User) GetPublicKeys() []UserPublicKey {
 	if o == nil {
@@ -220,6 +254,9 @@ func (o User) ToMap() (map[string]interface{}, error) {
 	toSerialize["name"] = o.Name
 	toSerialize["email"] = o.Email
 	toSerialize["emailVerified"] = o.EmailVerified
+	if !IsNil(o.PylonEmailHash) {
+		toSerialize["pylonEmailHash"] = o.PylonEmailHash
+	}
 	toSerialize["publicKeys"] = o.PublicKeys
 	toSerialize["createdAt"] = o.CreatedAt
 
@@ -274,6 +311,7 @@ func (o *User) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "name")
 		delete(additionalProperties, "email")
 		delete(additionalProperties, "emailVerified")
+		delete(additionalProperties, "pylonEmailHash")
 		delete(additionalProperties, "publicKeys")
 		delete(additionalProperties, "createdAt")
 		o.AdditionalProperties = additionalProperties

--- a/api-client-java/src/main/java/io/daytona/api/client/model/CreateRegion.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/CreateRegion.java
@@ -71,6 +71,11 @@ public class CreateRegion {
   @javax.annotation.Nullable
   private String snapshotManagerUrl;
 
+  public static final String SERIALIZED_NAME_OTEL_ENDPOINT = "otelEndpoint";
+  @SerializedName(SERIALIZED_NAME_OTEL_ENDPOINT)
+  @javax.annotation.Nullable
+  private String otelEndpoint;
+
   public CreateRegion() {
   }
 
@@ -149,6 +154,25 @@ public class CreateRegion {
     this.snapshotManagerUrl = snapshotManagerUrl;
   }
 
+
+  public CreateRegion otelEndpoint(@javax.annotation.Nullable String otelEndpoint) {
+    this.otelEndpoint = otelEndpoint;
+    return this;
+  }
+
+  /**
+   * OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+   * @return otelEndpoint
+   */
+  @javax.annotation.Nullable
+  public String getOtelEndpoint() {
+    return otelEndpoint;
+  }
+
+  public void setOtelEndpoint(@javax.annotation.Nullable String otelEndpoint) {
+    this.otelEndpoint = otelEndpoint;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -207,7 +231,8 @@ public class CreateRegion {
     return Objects.equals(this.name, createRegion.name) &&
         Objects.equals(this.proxyUrl, createRegion.proxyUrl) &&
         Objects.equals(this.sshGatewayUrl, createRegion.sshGatewayUrl) &&
-        Objects.equals(this.snapshotManagerUrl, createRegion.snapshotManagerUrl)&&
+        Objects.equals(this.snapshotManagerUrl, createRegion.snapshotManagerUrl) &&
+        Objects.equals(this.otelEndpoint, createRegion.otelEndpoint)&&
         Objects.equals(this.additionalProperties, createRegion.additionalProperties);
   }
 
@@ -217,7 +242,7 @@ public class CreateRegion {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, proxyUrl, sshGatewayUrl, snapshotManagerUrl, additionalProperties);
+    return Objects.hash(name, proxyUrl, sshGatewayUrl, snapshotManagerUrl, otelEndpoint, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -235,6 +260,7 @@ public class CreateRegion {
     sb.append("    proxyUrl: ").append(toIndentedString(proxyUrl)).append("\n");
     sb.append("    sshGatewayUrl: ").append(toIndentedString(sshGatewayUrl)).append("\n");
     sb.append("    snapshotManagerUrl: ").append(toIndentedString(snapshotManagerUrl)).append("\n");
+    sb.append("    otelEndpoint: ").append(toIndentedString(otelEndpoint)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -254,7 +280,7 @@ public class CreateRegion {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("name", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl"));
+    openapiFields = new HashSet<String>(Arrays.asList("name", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl", "otelEndpoint"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("name"));
@@ -291,6 +317,9 @@ public class CreateRegion {
       }
       if ((jsonObj.get("snapshotManagerUrl") != null && !jsonObj.get("snapshotManagerUrl").isJsonNull()) && !jsonObj.get("snapshotManagerUrl").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `snapshotManagerUrl` to be a primitive type in the JSON string but got `%s`", jsonObj.get("snapshotManagerUrl").toString()));
+      }
+      if ((jsonObj.get("otelEndpoint") != null && !jsonObj.get("otelEndpoint").isJsonNull()) && !jsonObj.get("otelEndpoint").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `otelEndpoint` to be a primitive type in the JSON string but got `%s`", jsonObj.get("otelEndpoint").toString()));
       }
   }
 

--- a/api-client-java/src/main/java/io/daytona/api/client/model/CreateSandbox.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/CreateSandbox.java
@@ -107,6 +107,11 @@ public class CreateSandbox {
   @javax.annotation.Nullable
   private String outboundProxyUrl;
 
+  public static final String SERIALIZED_NAME_OTEL_ENDPOINT_OVERRIDE = "otelEndpointOverride";
+  @SerializedName(SERIALIZED_NAME_OTEL_ENDPOINT_OVERRIDE)
+  @javax.annotation.Nullable
+  private String otelEndpointOverride;
+
   public static final String SERIALIZED_NAME_TARGET = "target";
   @SerializedName(SERIALIZED_NAME_TARGET)
   @javax.annotation.Nullable
@@ -393,6 +398,25 @@ public class CreateSandbox {
 
   public void setOutboundProxyUrl(@javax.annotation.Nullable String outboundProxyUrl) {
     this.outboundProxyUrl = outboundProxyUrl;
+  }
+
+
+  public CreateSandbox otelEndpointOverride(@javax.annotation.Nullable String otelEndpointOverride) {
+    this.otelEndpointOverride = otelEndpointOverride;
+    return this;
+  }
+
+  /**
+   * OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector (the Daytona-hosted collector or the region-configured endpoint) and will not be available in the Daytona analytics API or dashboard.
+   * @return otelEndpointOverride
+   */
+  @javax.annotation.Nullable
+  public String getOtelEndpointOverride() {
+    return otelEndpointOverride;
+  }
+
+  public void setOtelEndpointOverride(@javax.annotation.Nullable String otelEndpointOverride) {
+    this.otelEndpointOverride = otelEndpointOverride;
   }
 
 
@@ -788,6 +812,7 @@ public class CreateSandbox {
         Objects.equals(this.networkAllowList, createSandbox.networkAllowList) &&
         Objects.equals(this.domainAllowList, createSandbox.domainAllowList) &&
         Objects.equals(this.outboundProxyUrl, createSandbox.outboundProxyUrl) &&
+        Objects.equals(this.otelEndpointOverride, createSandbox.otelEndpointOverride) &&
         Objects.equals(this.target, createSandbox.target) &&
         Objects.equals(this.cpu, createSandbox.cpu) &&
         Objects.equals(this.gpu, createSandbox.gpu) &&
@@ -809,7 +834,7 @@ public class CreateSandbox {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, outboundProxyUrl, target, cpu, gpu, gpuType, spot, memory, disk, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, ttlMinutes, volumes, buildInfo, linkedSandbox, secrets, additionalProperties);
+    return Objects.hash(name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, outboundProxyUrl, otelEndpointOverride, target, cpu, gpu, gpuType, spot, memory, disk, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, ttlMinutes, volumes, buildInfo, linkedSandbox, secrets, additionalProperties);
   }
 
   @Override
@@ -826,6 +851,7 @@ public class CreateSandbox {
     sb.append("    networkAllowList: ").append(toIndentedString(networkAllowList)).append("\n");
     sb.append("    domainAllowList: ").append(toIndentedString(domainAllowList)).append("\n");
     sb.append("    outboundProxyUrl: ").append(toIndentedString(outboundProxyUrl)).append("\n");
+    sb.append("    otelEndpointOverride: ").append(toIndentedString(otelEndpointOverride)).append("\n");
     sb.append("    target: ").append(toIndentedString(target)).append("\n");
     sb.append("    cpu: ").append(toIndentedString(cpu)).append("\n");
     sb.append("    gpu: ").append(toIndentedString(gpu)).append("\n");
@@ -861,7 +887,7 @@ public class CreateSandbox {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "spot", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"));
+    openapiFields = new HashSet<String>(Arrays.asList("name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "otelEndpointOverride", "target", "cpu", "gpu", "gpuType", "spot", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(0);
@@ -897,6 +923,9 @@ public class CreateSandbox {
       }
       if ((jsonObj.get("outboundProxyUrl") != null && !jsonObj.get("outboundProxyUrl").isJsonNull()) && !jsonObj.get("outboundProxyUrl").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `outboundProxyUrl` to be a primitive type in the JSON string but got `%s`", jsonObj.get("outboundProxyUrl").toString()));
+      }
+      if ((jsonObj.get("otelEndpointOverride") != null && !jsonObj.get("otelEndpointOverride").isJsonNull()) && !jsonObj.get("otelEndpointOverride").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `otelEndpointOverride` to be a primitive type in the JSON string but got `%s`", jsonObj.get("otelEndpointOverride").toString()));
       }
       if ((jsonObj.get("target") != null && !jsonObj.get("target").isJsonNull()) && !jsonObj.get("target").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `target` to be a primitive type in the JSON string but got `%s`", jsonObj.get("target").toString()));

--- a/api-client-java/src/main/java/io/daytona/api/client/model/DaytonaConfiguration.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/DaytonaConfiguration.java
@@ -255,7 +255,7 @@ public class DaytonaConfiguration {
   }
 
   /**
-   * OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the dual-issuer setup is configured; the dashboard uses it as its authority when entered via an organization SSO link.
+   * OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the secondary (org-SSO) issuer is configured; the dashboard uses it as its authority when entered via an organization SSO link.
    * @return ssoOidc
    */
   @javax.annotation.Nullable

--- a/api-client-java/src/main/java/io/daytona/api/client/model/Region.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/Region.java
@@ -97,6 +97,11 @@ public class Region {
   @javax.annotation.Nullable
   private String snapshotManagerUrl;
 
+  public static final String SERIALIZED_NAME_OTEL_ENDPOINT = "otelEndpoint";
+  @SerializedName(SERIALIZED_NAME_OTEL_ENDPOINT)
+  @javax.annotation.Nullable
+  private String otelEndpoint;
+
   public Region() {
   }
 
@@ -270,6 +275,25 @@ public class Region {
     this.snapshotManagerUrl = snapshotManagerUrl;
   }
 
+
+  public Region otelEndpoint(@javax.annotation.Nullable String otelEndpoint) {
+    this.otelEndpoint = otelEndpoint;
+    return this;
+  }
+
+  /**
+   * OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+   * @return otelEndpoint
+   */
+  @javax.annotation.Nullable
+  public String getOtelEndpoint() {
+    return otelEndpoint;
+  }
+
+  public void setOtelEndpoint(@javax.annotation.Nullable String otelEndpoint) {
+    this.otelEndpoint = otelEndpoint;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -333,7 +357,8 @@ public class Region {
         Objects.equals(this.updatedAt, region.updatedAt) &&
         Objects.equals(this.proxyUrl, region.proxyUrl) &&
         Objects.equals(this.sshGatewayUrl, region.sshGatewayUrl) &&
-        Objects.equals(this.snapshotManagerUrl, region.snapshotManagerUrl)&&
+        Objects.equals(this.snapshotManagerUrl, region.snapshotManagerUrl) &&
+        Objects.equals(this.otelEndpoint, region.otelEndpoint)&&
         Objects.equals(this.additionalProperties, region.additionalProperties);
   }
 
@@ -343,7 +368,7 @@ public class Region {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, organizationId, regionType, createdAt, updatedAt, proxyUrl, sshGatewayUrl, snapshotManagerUrl, additionalProperties);
+    return Objects.hash(id, name, organizationId, regionType, createdAt, updatedAt, proxyUrl, sshGatewayUrl, snapshotManagerUrl, otelEndpoint, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -366,6 +391,7 @@ public class Region {
     sb.append("    proxyUrl: ").append(toIndentedString(proxyUrl)).append("\n");
     sb.append("    sshGatewayUrl: ").append(toIndentedString(sshGatewayUrl)).append("\n");
     sb.append("    snapshotManagerUrl: ").append(toIndentedString(snapshotManagerUrl)).append("\n");
+    sb.append("    otelEndpoint: ").append(toIndentedString(otelEndpoint)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -385,7 +411,7 @@ public class Region {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "name", "organizationId", "regionType", "createdAt", "updatedAt", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "name", "organizationId", "regionType", "createdAt", "updatedAt", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl", "otelEndpoint"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "name", "regionType", "createdAt", "updatedAt"));
@@ -436,6 +462,9 @@ public class Region {
       }
       if ((jsonObj.get("snapshotManagerUrl") != null && !jsonObj.get("snapshotManagerUrl").isJsonNull()) && !jsonObj.get("snapshotManagerUrl").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `snapshotManagerUrl` to be a primitive type in the JSON string but got `%s`", jsonObj.get("snapshotManagerUrl").toString()));
+      }
+      if ((jsonObj.get("otelEndpoint") != null && !jsonObj.get("otelEndpoint").isJsonNull()) && !jsonObj.get("otelEndpoint").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `otelEndpoint` to be a primitive type in the JSON string but got `%s`", jsonObj.get("otelEndpoint").toString()));
       }
   }
 

--- a/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
@@ -120,6 +120,11 @@ public class Sandbox {
   @javax.annotation.Nullable
   private String outboundProxyUrl;
 
+  public static final String SERIALIZED_NAME_OTEL_ENDPOINT_OVERRIDE = "otelEndpointOverride";
+  @SerializedName(SERIALIZED_NAME_OTEL_ENDPOINT_OVERRIDE)
+  @javax.annotation.Nullable
+  private String otelEndpointOverride;
+
   public static final String SERIALIZED_NAME_TARGET = "target";
   @SerializedName(SERIALIZED_NAME_TARGET)
   @javax.annotation.Nonnull
@@ -634,6 +639,25 @@ public class Sandbox {
 
   public void setOutboundProxyUrl(@javax.annotation.Nullable String outboundProxyUrl) {
     this.outboundProxyUrl = outboundProxyUrl;
+  }
+
+
+  public Sandbox otelEndpointOverride(@javax.annotation.Nullable String otelEndpointOverride) {
+    this.otelEndpointOverride = otelEndpointOverride;
+    return this;
+  }
+
+  /**
+   * OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector and is not available in the Daytona analytics API or dashboard. Only returned on single-sandbox reads — never on list responses.
+   * @return otelEndpointOverride
+   */
+  @javax.annotation.Nullable
+  public String getOtelEndpointOverride() {
+    return otelEndpointOverride;
+  }
+
+  public void setOtelEndpointOverride(@javax.annotation.Nullable String otelEndpointOverride) {
+    this.otelEndpointOverride = otelEndpointOverride;
   }
 
 
@@ -1289,6 +1313,7 @@ public class Sandbox {
         Objects.equals(this.networkAllowList, sandbox.networkAllowList) &&
         Objects.equals(this.domainAllowList, sandbox.domainAllowList) &&
         Objects.equals(this.outboundProxyUrl, sandbox.outboundProxyUrl) &&
+        Objects.equals(this.otelEndpointOverride, sandbox.otelEndpointOverride) &&
         Objects.equals(this.target, sandbox.target) &&
         Objects.equals(this.cpu, sandbox.cpu) &&
         Objects.equals(this.gpu, sandbox.gpu) &&
@@ -1324,7 +1349,7 @@ public class Sandbox {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, outboundProxyUrl, target, cpu, gpu, spot, spotEvictedAt, gpuType, memory, disk, state, desiredState, errorReason, recoverable, warmPoolId, backupState, backupCreatedAt, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, autoDestroyAt, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, sandboxClass, daemonVersion, runnerId, linkedSandboxId, toolboxProxyUrl, additionalProperties);
+    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, outboundProxyUrl, otelEndpointOverride, target, cpu, gpu, spot, spotEvictedAt, gpuType, memory, disk, state, desiredState, errorReason, recoverable, warmPoolId, backupState, backupCreatedAt, autoStopInterval, autoPauseInterval, autoArchiveInterval, autoDeleteInterval, autoDestroyAt, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, sandboxClass, daemonVersion, runnerId, linkedSandboxId, toolboxProxyUrl, additionalProperties);
   }
 
   @Override
@@ -1343,6 +1368,7 @@ public class Sandbox {
     sb.append("    networkAllowList: ").append(toIndentedString(networkAllowList)).append("\n");
     sb.append("    domainAllowList: ").append(toIndentedString(domainAllowList)).append("\n");
     sb.append("    outboundProxyUrl: ").append(toIndentedString(outboundProxyUrl)).append("\n");
+    sb.append("    otelEndpointOverride: ").append(toIndentedString(otelEndpointOverride)).append("\n");
     sb.append("    target: ").append(toIndentedString(target)).append("\n");
     sb.append("    cpu: ").append(toIndentedString(cpu)).append("\n");
     sb.append("    gpu: ").append(toIndentedString(gpu)).append("\n");
@@ -1392,7 +1418,7 @@ public class Sandbox {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "otelEndpointOverride", "target", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "user", "env", "labels", "public", "networkBlockAll", "target", "cpu", "gpu", "memory", "disk", "toolboxProxyUrl"));
@@ -1441,6 +1467,9 @@ public class Sandbox {
       }
       if ((jsonObj.get("outboundProxyUrl") != null && !jsonObj.get("outboundProxyUrl").isJsonNull()) && !jsonObj.get("outboundProxyUrl").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `outboundProxyUrl` to be a primitive type in the JSON string but got `%s`", jsonObj.get("outboundProxyUrl").toString()));
+      }
+      if ((jsonObj.get("otelEndpointOverride") != null && !jsonObj.get("otelEndpointOverride").isJsonNull()) && !jsonObj.get("otelEndpointOverride").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `otelEndpointOverride` to be a primitive type in the JSON string but got `%s`", jsonObj.get("otelEndpointOverride").toString()));
       }
       if (!jsonObj.get("target").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `target` to be a primitive type in the JSON string but got `%s`", jsonObj.get("target").toString()));

--- a/api-client-java/src/main/java/io/daytona/api/client/model/UpdateRegion.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/UpdateRegion.java
@@ -66,6 +66,11 @@ public class UpdateRegion {
   @javax.annotation.Nullable
   private String snapshotManagerUrl;
 
+  public static final String SERIALIZED_NAME_OTEL_ENDPOINT = "otelEndpoint";
+  @SerializedName(SERIALIZED_NAME_OTEL_ENDPOINT)
+  @javax.annotation.Nullable
+  private String otelEndpoint;
+
   public UpdateRegion() {
   }
 
@@ -125,6 +130,25 @@ public class UpdateRegion {
     this.snapshotManagerUrl = snapshotManagerUrl;
   }
 
+
+  public UpdateRegion otelEndpoint(@javax.annotation.Nullable String otelEndpoint) {
+    this.otelEndpoint = otelEndpoint;
+    return this;
+  }
+
+  /**
+   * OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+   * @return otelEndpoint
+   */
+  @javax.annotation.Nullable
+  public String getOtelEndpoint() {
+    return otelEndpoint;
+  }
+
+  public void setOtelEndpoint(@javax.annotation.Nullable String otelEndpoint) {
+    this.otelEndpoint = otelEndpoint;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -182,7 +206,8 @@ public class UpdateRegion {
     UpdateRegion updateRegion = (UpdateRegion) o;
     return Objects.equals(this.proxyUrl, updateRegion.proxyUrl) &&
         Objects.equals(this.sshGatewayUrl, updateRegion.sshGatewayUrl) &&
-        Objects.equals(this.snapshotManagerUrl, updateRegion.snapshotManagerUrl)&&
+        Objects.equals(this.snapshotManagerUrl, updateRegion.snapshotManagerUrl) &&
+        Objects.equals(this.otelEndpoint, updateRegion.otelEndpoint)&&
         Objects.equals(this.additionalProperties, updateRegion.additionalProperties);
   }
 
@@ -192,7 +217,7 @@ public class UpdateRegion {
 
   @Override
   public int hashCode() {
-    return Objects.hash(proxyUrl, sshGatewayUrl, snapshotManagerUrl, additionalProperties);
+    return Objects.hash(proxyUrl, sshGatewayUrl, snapshotManagerUrl, otelEndpoint, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -209,6 +234,7 @@ public class UpdateRegion {
     sb.append("    proxyUrl: ").append(toIndentedString(proxyUrl)).append("\n");
     sb.append("    sshGatewayUrl: ").append(toIndentedString(sshGatewayUrl)).append("\n");
     sb.append("    snapshotManagerUrl: ").append(toIndentedString(snapshotManagerUrl)).append("\n");
+    sb.append("    otelEndpoint: ").append(toIndentedString(otelEndpoint)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -228,7 +254,7 @@ public class UpdateRegion {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("proxyUrl", "sshGatewayUrl", "snapshotManagerUrl"));
+    openapiFields = new HashSet<String>(Arrays.asList("proxyUrl", "sshGatewayUrl", "snapshotManagerUrl", "otelEndpoint"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(0);
@@ -255,6 +281,9 @@ public class UpdateRegion {
       }
       if ((jsonObj.get("snapshotManagerUrl") != null && !jsonObj.get("snapshotManagerUrl").isJsonNull()) && !jsonObj.get("snapshotManagerUrl").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `snapshotManagerUrl` to be a primitive type in the JSON string but got `%s`", jsonObj.get("snapshotManagerUrl").toString()));
+      }
+      if ((jsonObj.get("otelEndpoint") != null && !jsonObj.get("otelEndpoint").isJsonNull()) && !jsonObj.get("otelEndpoint").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `otelEndpoint` to be a primitive type in the JSON string but got `%s`", jsonObj.get("otelEndpoint").toString()));
       }
   }
 

--- a/api-client-java/src/main/java/io/daytona/api/client/model/User.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/User.java
@@ -74,6 +74,11 @@ public class User {
   @javax.annotation.Nonnull
   private Boolean emailVerified;
 
+  public static final String SERIALIZED_NAME_PYLON_EMAIL_HASH = "pylonEmailHash";
+  @SerializedName(SERIALIZED_NAME_PYLON_EMAIL_HASH)
+  @javax.annotation.Nullable
+  private String pylonEmailHash;
+
   public static final String SERIALIZED_NAME_PUBLIC_KEYS = "publicKeys";
   @SerializedName(SERIALIZED_NAME_PUBLIC_KEYS)
   @javax.annotation.Nonnull
@@ -160,6 +165,25 @@ public class User {
 
   public void setEmailVerified(@javax.annotation.Nonnull Boolean emailVerified) {
     this.emailVerified = emailVerified;
+  }
+
+
+  public User pylonEmailHash(@javax.annotation.Nullable String pylonEmailHash) {
+    this.pylonEmailHash = pylonEmailHash;
+    return this;
+  }
+
+  /**
+   * HMAC of the user email for Pylon support-widget identity verification
+   * @return pylonEmailHash
+   */
+  @javax.annotation.Nullable
+  public String getPylonEmailHash() {
+    return pylonEmailHash;
+  }
+
+  public void setPylonEmailHash(@javax.annotation.Nullable String pylonEmailHash) {
+    this.pylonEmailHash = pylonEmailHash;
   }
 
 
@@ -267,6 +291,7 @@ public class User {
         Objects.equals(this.name, user.name) &&
         Objects.equals(this.email, user.email) &&
         Objects.equals(this.emailVerified, user.emailVerified) &&
+        Objects.equals(this.pylonEmailHash, user.pylonEmailHash) &&
         Objects.equals(this.publicKeys, user.publicKeys) &&
         Objects.equals(this.createdAt, user.createdAt)&&
         Objects.equals(this.additionalProperties, user.additionalProperties);
@@ -274,7 +299,7 @@ public class User {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, email, emailVerified, publicKeys, createdAt, additionalProperties);
+    return Objects.hash(id, name, email, emailVerified, pylonEmailHash, publicKeys, createdAt, additionalProperties);
   }
 
   @Override
@@ -285,6 +310,7 @@ public class User {
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    email: ").append(toIndentedString(email)).append("\n");
     sb.append("    emailVerified: ").append(toIndentedString(emailVerified)).append("\n");
+    sb.append("    pylonEmailHash: ").append(toIndentedString(pylonEmailHash)).append("\n");
     sb.append("    publicKeys: ").append(toIndentedString(publicKeys)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
@@ -306,7 +332,7 @@ public class User {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "name", "email", "emailVerified", "publicKeys", "createdAt"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "name", "email", "emailVerified", "pylonEmailHash", "publicKeys", "createdAt"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "name", "email", "emailVerified", "publicKeys", "createdAt"));
@@ -340,6 +366,9 @@ public class User {
       }
       if (!jsonObj.get("email").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `email` to be a primitive type in the JSON string but got `%s`", jsonObj.get("email").toString()));
+      }
+      if ((jsonObj.get("pylonEmailHash") != null && !jsonObj.get("pylonEmailHash").isJsonNull()) && !jsonObj.get("pylonEmailHash").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `pylonEmailHash` to be a primitive type in the JSON string but got `%s`", jsonObj.get("pylonEmailHash").toString()));
       }
       if (jsonObj.get("publicKeys") != null) {
         if (!jsonObj.get("publicKeys").isJsonArray()) {

--- a/api-client-java/src/test/java/io/daytona/api/client/model/CreateRegionTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/CreateRegionTest.java
@@ -70,4 +70,12 @@ public class CreateRegionTest {
         // TODO: test snapshotManagerUrl
     }
 
+    /**
+     * Test the property 'otelEndpoint'
+     */
+    @Test
+    public void otelEndpointTest() {
+        // TODO: test otelEndpoint
+    }
+
 }

--- a/api-client-java/src/test/java/io/daytona/api/client/model/CreateSandboxTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/CreateSandboxTest.java
@@ -125,6 +125,14 @@ public class CreateSandboxTest {
     }
 
     /**
+     * Test the property 'otelEndpointOverride'
+     */
+    @Test
+    public void otelEndpointOverrideTest() {
+        // TODO: test otelEndpointOverride
+    }
+
+    /**
      * Test the property 'target'
      */
     @Test

--- a/api-client-java/src/test/java/io/daytona/api/client/model/RegionTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/RegionTest.java
@@ -111,4 +111,12 @@ public class RegionTest {
         // TODO: test snapshotManagerUrl
     }
 
+    /**
+     * Test the property 'otelEndpoint'
+     */
+    @Test
+    public void otelEndpointTest() {
+        // TODO: test otelEndpoint
+    }
+
 }

--- a/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
@@ -144,6 +144,14 @@ public class SandboxTest {
     }
 
     /**
+     * Test the property 'otelEndpointOverride'
+     */
+    @Test
+    public void otelEndpointOverrideTest() {
+        // TODO: test otelEndpointOverride
+    }
+
+    /**
      * Test the property 'target'
      */
     @Test

--- a/api-client-java/src/test/java/io/daytona/api/client/model/UpdateRegionTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/UpdateRegionTest.java
@@ -62,4 +62,12 @@ public class UpdateRegionTest {
         // TODO: test snapshotManagerUrl
     }
 
+    /**
+     * Test the property 'otelEndpoint'
+     */
+    @Test
+    public void otelEndpointTest() {
+        // TODO: test otelEndpoint
+    }
+
 }

--- a/api-client-java/src/test/java/io/daytona/api/client/model/UserTest.java
+++ b/api-client-java/src/test/java/io/daytona/api/client/model/UserTest.java
@@ -74,6 +74,14 @@ public class UserTest {
     }
 
     /**
+     * Test the property 'pylonEmailHash'
+     */
+    @Test
+    public void pylonEmailHashTest() {
+        // TODO: test pylonEmailHash
+    }
+
+    /**
      * Test the property 'publicKeys'
      */
     @Test

--- a/api-client-python-async/daytona_api_client_async/models/create_region.py
+++ b/api-client-python-async/daytona_api_client_async/models/create_region.py
@@ -34,8 +34,9 @@ class CreateRegion(BaseModel):
     proxy_url: Optional[StrictStr] = Field(default=None, description="Proxy URL for the region", serialization_alias="proxyUrl")
     ssh_gateway_url: Optional[StrictStr] = Field(default=None, description="SSH Gateway URL for the region", serialization_alias="sshGatewayUrl")
     snapshot_manager_url: Optional[StrictStr] = Field(default=None, description="Snapshot Manager URL for the region", serialization_alias="snapshotManagerUrl")
+    otel_endpoint: Optional[StrictStr] = Field(default=None, description="OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.", serialization_alias="otelEndpoint")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl"]
+    __properties: ClassVar[List[str]] = ["name", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl", "otelEndpoint"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -97,6 +98,11 @@ class CreateRegion(BaseModel):
         if self.snapshot_manager_url is None and "snapshot_manager_url" in self.model_fields_set:
             _dict['snapshotManagerUrl'] = None
 
+        # set to None if otel_endpoint (nullable) is None
+        # and model_fields_set contains the field
+        if self.otel_endpoint is None and "otel_endpoint" in self.model_fields_set:
+            _dict['otelEndpoint'] = None
+
         return _dict
 
     @classmethod
@@ -112,7 +118,8 @@ class CreateRegion(BaseModel):
             "name": obj.get("name"),
             "proxy_url": obj.get("proxyUrl"),
             "ssh_gateway_url": obj.get("sshGatewayUrl"),
-            "snapshot_manager_url": obj.get("snapshotManagerUrl")
+            "snapshot_manager_url": obj.get("snapshotManagerUrl"),
+            "otel_endpoint": obj.get("otelEndpoint")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/api-client-python-async/daytona_api_client_async/models/create_sandbox.py
+++ b/api-client-python-async/daytona_api_client_async/models/create_sandbox.py
@@ -43,6 +43,7 @@ class CreateSandbox(BaseModel):
     network_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed CIDR network addresses for the sandbox", serialization_alias="networkAllowList")
     domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     outbound_proxy_url: Optional[StrictStr] = Field(default=None, description="Outbound proxy URL to route the sandbox HTTP(S) traffic through (http or https; credentials may be included in the URL). On its own this is convenience routing, not a security boundary: it is applied by injecting the standard HTTP(S)_PROXY environment variables at creation, so a process that clears those variables egresses directly. Combine with domainAllowList to have web-port (80/443) egress transparently redirected through the proxy chain at the network layer, which cannot be bypassed from inside the sandbox.", serialization_alias="outboundProxyUrl")
+    otel_endpoint_override: Optional[StrictStr] = Field(default=None, description="OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector (the Daytona-hosted collector or the region-configured endpoint) and will not be available in the Daytona analytics API or dashboard.", serialization_alias="otelEndpointOverride")
     target: Optional[StrictStr] = Field(default=None, description="The target (region) where the sandbox will be created")
     cpu: Optional[StrictInt] = Field(default=None, description="CPU cores allocated to the sandbox")
     gpu: Optional[StrictInt] = Field(default=None, description="GPU units allocated to the sandbox")
@@ -60,7 +61,7 @@ class CreateSandbox(BaseModel):
     linked_sandbox: Optional[StrictStr] = Field(default=None, description="ID or name of an existing sandbox to link the new sandbox to. The new sandbox will be scheduled on the same runner as the linked sandbox so a local network can be established between them. Linked sandboxes must be ephemeral (autoDeleteInterval=0) and cannot themselves be linked to another sandbox. GPU sandboxes cannot participate in links in either direction: a GPU sandbox cannot specify linkedSandbox, and cannot be the link target of another sandbox.", serialization_alias="linkedSandbox")
     secrets: Optional[List[Dict[str, StrictStr]]] = Field(default=None, description="Secrets to mount in this sandbox. Each entry maps an env var name to a vault secret name.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "spot", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"]
+    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "otelEndpointOverride", "target", "cpu", "gpu", "gpuType", "spot", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -139,6 +140,7 @@ class CreateSandbox(BaseModel):
             "network_allow_list": obj.get("networkAllowList"),
             "domain_allow_list": obj.get("domainAllowList"),
             "outbound_proxy_url": obj.get("outboundProxyUrl"),
+            "otel_endpoint_override": obj.get("otelEndpointOverride"),
             "target": obj.get("target"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),

--- a/api-client-python-async/daytona_api_client_async/models/daytona_configuration.py
+++ b/api-client-python-async/daytona_api_client_async/models/daytona_configuration.py
@@ -39,7 +39,7 @@ class DaytonaConfiguration(BaseModel):
     build_sha: Optional[StrictStr] = Field(default=None, description="Commit sha of the source the app was built from", serialization_alias="buildSha")
     posthog: Optional[PosthogConfig] = Field(default=None, description="PostHog configuration")
     oidc: OidcConfig = Field(description="OIDC configuration")
-    sso_oidc: Optional[SsoOidcConfig] = Field(default=None, description="OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the dual-issuer setup is configured; the dashboard uses it as its authority when entered via an organization SSO link.", serialization_alias="ssoOidc")
+    sso_oidc: Optional[SsoOidcConfig] = Field(default=None, description="OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the secondary (org-SSO) issuer is configured; the dashboard uses it as its authority when entered via an organization SSO link.", serialization_alias="ssoOidc")
     forced_feature_flags: Optional[List[StrictStr]] = Field(default=None, description="Feature flags forced on for this deployment regardless of PostHog targeting. Lets environments without PostHog (previews, local dev) enable flag-gated dashboard features.", serialization_alias="forcedFeatureFlags")
     linked_accounts_enabled: StrictBool = Field(description="Whether linked accounts are enabled", serialization_alias="linkedAccountsEnabled")
     announcements: Dict[str, Announcement] = Field(description="System announcements")

--- a/api-client-python-async/daytona_api_client_async/models/region.py
+++ b/api-client-python-async/daytona_api_client_async/models/region.py
@@ -40,8 +40,9 @@ class Region(BaseModel):
     proxy_url: Optional[StrictStr] = Field(default=None, description="Proxy URL for the region", serialization_alias="proxyUrl")
     ssh_gateway_url: Optional[StrictStr] = Field(default=None, description="SSH Gateway URL for the region", serialization_alias="sshGatewayUrl")
     snapshot_manager_url: Optional[StrictStr] = Field(default=None, description="Snapshot Manager URL for the region", serialization_alias="snapshotManagerUrl")
+    otel_endpoint: Optional[StrictStr] = Field(default=None, description="OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.", serialization_alias="otelEndpoint")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "name", "organizationId", "regionType", "createdAt", "updatedAt", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl"]
+    __properties: ClassVar[List[str]] = ["id", "name", "organizationId", "regionType", "createdAt", "updatedAt", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl", "otelEndpoint"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -108,6 +109,11 @@ class Region(BaseModel):
         if self.snapshot_manager_url is None and "snapshot_manager_url" in self.model_fields_set:
             _dict['snapshotManagerUrl'] = None
 
+        # set to None if otel_endpoint (nullable) is None
+        # and model_fields_set contains the field
+        if self.otel_endpoint is None and "otel_endpoint" in self.model_fields_set:
+            _dict['otelEndpoint'] = None
+
         return _dict
 
     @classmethod
@@ -128,7 +134,8 @@ class Region(BaseModel):
             "updated_at": obj.get("updatedAt"),
             "proxy_url": obj.get("proxyUrl"),
             "ssh_gateway_url": obj.get("sshGatewayUrl"),
-            "snapshot_manager_url": obj.get("snapshotManagerUrl")
+            "snapshot_manager_url": obj.get("snapshotManagerUrl"),
+            "otel_endpoint": obj.get("otelEndpoint")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/api-client-python-async/daytona_api_client_async/models/sandbox.py
+++ b/api-client-python-async/daytona_api_client_async/models/sandbox.py
@@ -47,6 +47,7 @@ class Sandbox(BaseModel):
     network_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed CIDR network addresses for the sandbox", serialization_alias="networkAllowList")
     domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     outbound_proxy_url: Optional[StrictStr] = Field(default=None, description="Outbound proxy URL the sandbox HTTP(S) traffic is routed through. Applied via the HTTP(S)_PROXY environment variables (convenience routing); network-layer enforcement applies only when the sandbox also has a domainAllowList. Only returned on single-sandbox reads — never on list responses.", serialization_alias="outboundProxyUrl")
+    otel_endpoint_override: Optional[StrictStr] = Field(default=None, description="OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector and is not available in the Daytona analytics API or dashboard. Only returned on single-sandbox reads — never on list responses.", serialization_alias="otelEndpointOverride")
     target: StrictStr = Field(description="The target environment for the sandbox")
     cpu: Union[StrictFloat, StrictInt] = Field(description="The CPU quota for the sandbox")
     gpu: Union[StrictFloat, StrictInt] = Field(description="The GPU quota for the sandbox")
@@ -78,7 +79,7 @@ class Sandbox(BaseModel):
     linked_sandbox_id: Optional[StrictStr] = Field(default=None, description="ID of the sandbox this sandbox is linked to. When set, the sandbox is co-located on the same runner as the linked sandbox.", serialization_alias="linkedSandboxId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "otelEndpointOverride", "target", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -159,6 +160,7 @@ class Sandbox(BaseModel):
             "network_allow_list": obj.get("networkAllowList"),
             "domain_allow_list": obj.get("domainAllowList"),
             "outbound_proxy_url": obj.get("outboundProxyUrl"),
+            "otel_endpoint_override": obj.get("otelEndpointOverride"),
             "target": obj.get("target"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),

--- a/api-client-python-async/daytona_api_client_async/models/update_region.py
+++ b/api-client-python-async/daytona_api_client_async/models/update_region.py
@@ -33,8 +33,9 @@ class UpdateRegion(BaseModel):
     proxy_url: Optional[StrictStr] = Field(default=None, description="Proxy URL for the region", serialization_alias="proxyUrl")
     ssh_gateway_url: Optional[StrictStr] = Field(default=None, description="SSH Gateway URL for the region", serialization_alias="sshGatewayUrl")
     snapshot_manager_url: Optional[StrictStr] = Field(default=None, description="Snapshot Manager URL for the region", serialization_alias="snapshotManagerUrl")
+    otel_endpoint: Optional[StrictStr] = Field(default=None, description="OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.", serialization_alias="otelEndpoint")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["proxyUrl", "sshGatewayUrl", "snapshotManagerUrl"]
+    __properties: ClassVar[List[str]] = ["proxyUrl", "sshGatewayUrl", "snapshotManagerUrl", "otelEndpoint"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -96,6 +97,11 @@ class UpdateRegion(BaseModel):
         if self.snapshot_manager_url is None and "snapshot_manager_url" in self.model_fields_set:
             _dict['snapshotManagerUrl'] = None
 
+        # set to None if otel_endpoint (nullable) is None
+        # and model_fields_set contains the field
+        if self.otel_endpoint is None and "otel_endpoint" in self.model_fields_set:
+            _dict['otelEndpoint'] = None
+
         return _dict
 
     @classmethod
@@ -110,7 +116,8 @@ class UpdateRegion(BaseModel):
         _obj = cls.model_validate({
             "proxy_url": obj.get("proxyUrl"),
             "ssh_gateway_url": obj.get("sshGatewayUrl"),
-            "snapshot_manager_url": obj.get("snapshotManagerUrl")
+            "snapshot_manager_url": obj.get("snapshotManagerUrl"),
+            "otel_endpoint": obj.get("otelEndpoint")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/api-client-python-async/daytona_api_client_async/models/user.py
+++ b/api-client-python-async/daytona_api_client_async/models/user.py
@@ -20,7 +20,7 @@ import json
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from daytona_api_client_async.models.user_public_key import UserPublicKey
 from pydantic import TypeAdapter
 from typing import Optional, Set
@@ -36,10 +36,11 @@ class User(BaseModel):
     name: StrictStr = Field(description="User name")
     email: StrictStr = Field(description="User email")
     email_verified: StrictBool = Field(description="Whether the user email address has been verified", serialization_alias="emailVerified")
+    pylon_email_hash: Optional[StrictStr] = Field(default=None, description="HMAC of the user email for Pylon support-widget identity verification", serialization_alias="pylonEmailHash")
     public_keys: List[UserPublicKey] = Field(description="User public keys", serialization_alias="publicKeys")
     created_at: datetime = Field(description="Creation timestamp", serialization_alias="createdAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "name", "email", "emailVerified", "publicKeys", "createdAt"]
+    __properties: ClassVar[List[str]] = ["id", "name", "email", "emailVerified", "pylonEmailHash", "publicKeys", "createdAt"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -109,6 +110,7 @@ class User(BaseModel):
             "name": obj.get("name"),
             "email": obj.get("email"),
             "email_verified": obj.get("emailVerified"),
+            "pylon_email_hash": obj.get("pylonEmailHash"),
             "public_keys": [UserPublicKey.from_dict(_item) for _item in obj["publicKeys"]] if obj.get("publicKeys") is not None else None,
             "created_at": obj.get("createdAt")
         })

--- a/api-client-python/daytona_api_client/models/create_region.py
+++ b/api-client-python/daytona_api_client/models/create_region.py
@@ -34,8 +34,9 @@ class CreateRegion(BaseModel):
     proxy_url: Optional[StrictStr] = Field(default=None, description="Proxy URL for the region", serialization_alias="proxyUrl")
     ssh_gateway_url: Optional[StrictStr] = Field(default=None, description="SSH Gateway URL for the region", serialization_alias="sshGatewayUrl")
     snapshot_manager_url: Optional[StrictStr] = Field(default=None, description="Snapshot Manager URL for the region", serialization_alias="snapshotManagerUrl")
+    otel_endpoint: Optional[StrictStr] = Field(default=None, description="OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.", serialization_alias="otelEndpoint")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl"]
+    __properties: ClassVar[List[str]] = ["name", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl", "otelEndpoint"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -97,6 +98,11 @@ class CreateRegion(BaseModel):
         if self.snapshot_manager_url is None and "snapshot_manager_url" in self.model_fields_set:
             _dict['snapshotManagerUrl'] = None
 
+        # set to None if otel_endpoint (nullable) is None
+        # and model_fields_set contains the field
+        if self.otel_endpoint is None and "otel_endpoint" in self.model_fields_set:
+            _dict['otelEndpoint'] = None
+
         return _dict
 
     @classmethod
@@ -112,7 +118,8 @@ class CreateRegion(BaseModel):
             "name": obj.get("name"),
             "proxy_url": obj.get("proxyUrl"),
             "ssh_gateway_url": obj.get("sshGatewayUrl"),
-            "snapshot_manager_url": obj.get("snapshotManagerUrl")
+            "snapshot_manager_url": obj.get("snapshotManagerUrl"),
+            "otel_endpoint": obj.get("otelEndpoint")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/api-client-python/daytona_api_client/models/create_sandbox.py
+++ b/api-client-python/daytona_api_client/models/create_sandbox.py
@@ -43,6 +43,7 @@ class CreateSandbox(BaseModel):
     network_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed CIDR network addresses for the sandbox", serialization_alias="networkAllowList")
     domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     outbound_proxy_url: Optional[StrictStr] = Field(default=None, description="Outbound proxy URL to route the sandbox HTTP(S) traffic through (http or https; credentials may be included in the URL). On its own this is convenience routing, not a security boundary: it is applied by injecting the standard HTTP(S)_PROXY environment variables at creation, so a process that clears those variables egresses directly. Combine with domainAllowList to have web-port (80/443) egress transparently redirected through the proxy chain at the network layer, which cannot be bypassed from inside the sandbox.", serialization_alias="outboundProxyUrl")
+    otel_endpoint_override: Optional[StrictStr] = Field(default=None, description="OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector (the Daytona-hosted collector or the region-configured endpoint) and will not be available in the Daytona analytics API or dashboard.", serialization_alias="otelEndpointOverride")
     target: Optional[StrictStr] = Field(default=None, description="The target (region) where the sandbox will be created")
     cpu: Optional[StrictInt] = Field(default=None, description="CPU cores allocated to the sandbox")
     gpu: Optional[StrictInt] = Field(default=None, description="GPU units allocated to the sandbox")
@@ -60,7 +61,7 @@ class CreateSandbox(BaseModel):
     linked_sandbox: Optional[StrictStr] = Field(default=None, description="ID or name of an existing sandbox to link the new sandbox to. The new sandbox will be scheduled on the same runner as the linked sandbox so a local network can be established between them. Linked sandboxes must be ephemeral (autoDeleteInterval=0) and cannot themselves be linked to another sandbox. GPU sandboxes cannot participate in links in either direction: a GPU sandbox cannot specify linkedSandbox, and cannot be the link target of another sandbox.", serialization_alias="linkedSandbox")
     secrets: Optional[List[Dict[str, StrictStr]]] = Field(default=None, description="Secrets to mount in this sandbox. Each entry maps an env var name to a vault secret name.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "gpuType", "spot", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"]
+    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "otelEndpointOverride", "target", "cpu", "gpu", "gpuType", "spot", "memory", "disk", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "ttlMinutes", "volumes", "buildInfo", "linkedSandbox", "secrets"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -139,6 +140,7 @@ class CreateSandbox(BaseModel):
             "network_allow_list": obj.get("networkAllowList"),
             "domain_allow_list": obj.get("domainAllowList"),
             "outbound_proxy_url": obj.get("outboundProxyUrl"),
+            "otel_endpoint_override": obj.get("otelEndpointOverride"),
             "target": obj.get("target"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),

--- a/api-client-python/daytona_api_client/models/daytona_configuration.py
+++ b/api-client-python/daytona_api_client/models/daytona_configuration.py
@@ -39,7 +39,7 @@ class DaytonaConfiguration(BaseModel):
     build_sha: Optional[StrictStr] = Field(default=None, description="Commit sha of the source the app was built from", serialization_alias="buildSha")
     posthog: Optional[PosthogConfig] = Field(default=None, description="PostHog configuration")
     oidc: OidcConfig = Field(description="OIDC configuration")
-    sso_oidc: Optional[SsoOidcConfig] = Field(default=None, description="OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the dual-issuer setup is configured; the dashboard uses it as its authority when entered via an organization SSO link.", serialization_alias="ssoOidc")
+    sso_oidc: Optional[SsoOidcConfig] = Field(default=None, description="OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the secondary (org-SSO) issuer is configured; the dashboard uses it as its authority when entered via an organization SSO link.", serialization_alias="ssoOidc")
     forced_feature_flags: Optional[List[StrictStr]] = Field(default=None, description="Feature flags forced on for this deployment regardless of PostHog targeting. Lets environments without PostHog (previews, local dev) enable flag-gated dashboard features.", serialization_alias="forcedFeatureFlags")
     linked_accounts_enabled: StrictBool = Field(description="Whether linked accounts are enabled", serialization_alias="linkedAccountsEnabled")
     announcements: Dict[str, Announcement] = Field(description="System announcements")

--- a/api-client-python/daytona_api_client/models/region.py
+++ b/api-client-python/daytona_api_client/models/region.py
@@ -40,8 +40,9 @@ class Region(BaseModel):
     proxy_url: Optional[StrictStr] = Field(default=None, description="Proxy URL for the region", serialization_alias="proxyUrl")
     ssh_gateway_url: Optional[StrictStr] = Field(default=None, description="SSH Gateway URL for the region", serialization_alias="sshGatewayUrl")
     snapshot_manager_url: Optional[StrictStr] = Field(default=None, description="Snapshot Manager URL for the region", serialization_alias="snapshotManagerUrl")
+    otel_endpoint: Optional[StrictStr] = Field(default=None, description="OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.", serialization_alias="otelEndpoint")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "name", "organizationId", "regionType", "createdAt", "updatedAt", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl"]
+    __properties: ClassVar[List[str]] = ["id", "name", "organizationId", "regionType", "createdAt", "updatedAt", "proxyUrl", "sshGatewayUrl", "snapshotManagerUrl", "otelEndpoint"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -108,6 +109,11 @@ class Region(BaseModel):
         if self.snapshot_manager_url is None and "snapshot_manager_url" in self.model_fields_set:
             _dict['snapshotManagerUrl'] = None
 
+        # set to None if otel_endpoint (nullable) is None
+        # and model_fields_set contains the field
+        if self.otel_endpoint is None and "otel_endpoint" in self.model_fields_set:
+            _dict['otelEndpoint'] = None
+
         return _dict
 
     @classmethod
@@ -128,7 +134,8 @@ class Region(BaseModel):
             "updated_at": obj.get("updatedAt"),
             "proxy_url": obj.get("proxyUrl"),
             "ssh_gateway_url": obj.get("sshGatewayUrl"),
-            "snapshot_manager_url": obj.get("snapshotManagerUrl")
+            "snapshot_manager_url": obj.get("snapshotManagerUrl"),
+            "otel_endpoint": obj.get("otelEndpoint")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/api-client-python/daytona_api_client/models/sandbox.py
+++ b/api-client-python/daytona_api_client/models/sandbox.py
@@ -47,6 +47,7 @@ class Sandbox(BaseModel):
     network_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed CIDR network addresses for the sandbox", serialization_alias="networkAllowList")
     domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     outbound_proxy_url: Optional[StrictStr] = Field(default=None, description="Outbound proxy URL the sandbox HTTP(S) traffic is routed through. Applied via the HTTP(S)_PROXY environment variables (convenience routing); network-layer enforcement applies only when the sandbox also has a domainAllowList. Only returned on single-sandbox reads — never on list responses.", serialization_alias="outboundProxyUrl")
+    otel_endpoint_override: Optional[StrictStr] = Field(default=None, description="OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector and is not available in the Daytona analytics API or dashboard. Only returned on single-sandbox reads — never on list responses.", serialization_alias="otelEndpointOverride")
     target: StrictStr = Field(description="The target environment for the sandbox")
     cpu: Union[StrictFloat, StrictInt] = Field(description="The CPU quota for the sandbox")
     gpu: Union[StrictFloat, StrictInt] = Field(description="The GPU quota for the sandbox")
@@ -78,7 +79,7 @@ class Sandbox(BaseModel):
     linked_sandbox_id: Optional[StrictStr] = Field(default=None, description="ID of the sandbox this sandbox is linked to. When set, the sandbox is co-located on the same runner as the linked sandbox.", serialization_alias="linkedSandboxId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "target", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "outboundProxyUrl", "otelEndpointOverride", "target", "cpu", "gpu", "spot", "spotEvictedAt", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "warmPoolId", "backupState", "backupCreatedAt", "autoStopInterval", "autoPauseInterval", "autoArchiveInterval", "autoDeleteInterval", "autoDestroyAt", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -159,6 +160,7 @@ class Sandbox(BaseModel):
             "network_allow_list": obj.get("networkAllowList"),
             "domain_allow_list": obj.get("domainAllowList"),
             "outbound_proxy_url": obj.get("outboundProxyUrl"),
+            "otel_endpoint_override": obj.get("otelEndpointOverride"),
             "target": obj.get("target"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),

--- a/api-client-python/daytona_api_client/models/update_region.py
+++ b/api-client-python/daytona_api_client/models/update_region.py
@@ -33,8 +33,9 @@ class UpdateRegion(BaseModel):
     proxy_url: Optional[StrictStr] = Field(default=None, description="Proxy URL for the region", serialization_alias="proxyUrl")
     ssh_gateway_url: Optional[StrictStr] = Field(default=None, description="SSH Gateway URL for the region", serialization_alias="sshGatewayUrl")
     snapshot_manager_url: Optional[StrictStr] = Field(default=None, description="Snapshot Manager URL for the region", serialization_alias="snapshotManagerUrl")
+    otel_endpoint: Optional[StrictStr] = Field(default=None, description="OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.", serialization_alias="otelEndpoint")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["proxyUrl", "sshGatewayUrl", "snapshotManagerUrl"]
+    __properties: ClassVar[List[str]] = ["proxyUrl", "sshGatewayUrl", "snapshotManagerUrl", "otelEndpoint"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -96,6 +97,11 @@ class UpdateRegion(BaseModel):
         if self.snapshot_manager_url is None and "snapshot_manager_url" in self.model_fields_set:
             _dict['snapshotManagerUrl'] = None
 
+        # set to None if otel_endpoint (nullable) is None
+        # and model_fields_set contains the field
+        if self.otel_endpoint is None and "otel_endpoint" in self.model_fields_set:
+            _dict['otelEndpoint'] = None
+
         return _dict
 
     @classmethod
@@ -110,7 +116,8 @@ class UpdateRegion(BaseModel):
         _obj = cls.model_validate({
             "proxy_url": obj.get("proxyUrl"),
             "ssh_gateway_url": obj.get("sshGatewayUrl"),
-            "snapshot_manager_url": obj.get("snapshotManagerUrl")
+            "snapshot_manager_url": obj.get("snapshotManagerUrl"),
+            "otel_endpoint": obj.get("otelEndpoint")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/api-client-python/daytona_api_client/models/user.py
+++ b/api-client-python/daytona_api_client/models/user.py
@@ -20,7 +20,7 @@ import json
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from daytona_api_client.models.user_public_key import UserPublicKey
 from pydantic import TypeAdapter
 from typing import Optional, Set
@@ -36,10 +36,11 @@ class User(BaseModel):
     name: StrictStr = Field(description="User name")
     email: StrictStr = Field(description="User email")
     email_verified: StrictBool = Field(description="Whether the user email address has been verified", serialization_alias="emailVerified")
+    pylon_email_hash: Optional[StrictStr] = Field(default=None, description="HMAC of the user email for Pylon support-widget identity verification", serialization_alias="pylonEmailHash")
     public_keys: List[UserPublicKey] = Field(description="User public keys", serialization_alias="publicKeys")
     created_at: datetime = Field(description="Creation timestamp", serialization_alias="createdAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "name", "email", "emailVerified", "publicKeys", "createdAt"]
+    __properties: ClassVar[List[str]] = ["id", "name", "email", "emailVerified", "pylonEmailHash", "publicKeys", "createdAt"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -109,6 +110,7 @@ class User(BaseModel):
             "name": obj.get("name"),
             "email": obj.get("email"),
             "email_verified": obj.get("emailVerified"),
+            "pylon_email_hash": obj.get("pylonEmailHash"),
             "public_keys": [UserPublicKey.from_dict(_item) for _item in obj["publicKeys"]] if obj.get("publicKeys") is not None else None,
             "created_at": obj.get("createdAt")
         })

--- a/api-client-ruby/lib/daytona_api_client/models/create_region.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/create_region.rb
@@ -27,13 +27,17 @@ module DaytonaApiClient
     # Snapshot Manager URL for the region
     attr_accessor :snapshot_manager_url
 
+    # OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+    attr_accessor :otel_endpoint
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         :'name' => :'name',
         :'proxy_url' => :'proxyUrl',
         :'ssh_gateway_url' => :'sshGatewayUrl',
-        :'snapshot_manager_url' => :'snapshotManagerUrl'
+        :'snapshot_manager_url' => :'snapshotManagerUrl',
+        :'otel_endpoint' => :'otelEndpoint'
       }
     end
 
@@ -53,7 +57,8 @@ module DaytonaApiClient
         :'name' => :'String',
         :'proxy_url' => :'String',
         :'ssh_gateway_url' => :'String',
-        :'snapshot_manager_url' => :'String'
+        :'snapshot_manager_url' => :'String',
+        :'otel_endpoint' => :'String'
       }
     end
 
@@ -62,7 +67,8 @@ module DaytonaApiClient
       Set.new([
         :'proxy_url',
         :'ssh_gateway_url',
-        :'snapshot_manager_url'
+        :'snapshot_manager_url',
+        :'otel_endpoint'
       ])
     end
 
@@ -98,6 +104,10 @@ module DaytonaApiClient
 
       if attributes.key?(:'snapshot_manager_url')
         self.snapshot_manager_url = attributes[:'snapshot_manager_url']
+      end
+
+      if attributes.key?(:'otel_endpoint')
+        self.otel_endpoint = attributes[:'otel_endpoint']
       end
     end
 
@@ -139,7 +149,8 @@ module DaytonaApiClient
           name == o.name &&
           proxy_url == o.proxy_url &&
           ssh_gateway_url == o.ssh_gateway_url &&
-          snapshot_manager_url == o.snapshot_manager_url
+          snapshot_manager_url == o.snapshot_manager_url &&
+          otel_endpoint == o.otel_endpoint
     end
 
     # @see the `==` method
@@ -151,7 +162,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [name, proxy_url, ssh_gateway_url, snapshot_manager_url].hash
+      [name, proxy_url, ssh_gateway_url, snapshot_manager_url, otel_endpoint].hash
     end
 
     # Builds the object from hash

--- a/api-client-ruby/lib/daytona_api_client/models/create_sandbox.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/create_sandbox.rb
@@ -45,6 +45,9 @@ module DaytonaApiClient
     # Outbound proxy URL to route the sandbox HTTP(S) traffic through (http or https; credentials may be included in the URL). On its own this is convenience routing, not a security boundary: it is applied by injecting the standard HTTP(S)_PROXY environment variables at creation, so a process that clears those variables egresses directly. Combine with domainAllowList to have web-port (80/443) egress transparently redirected through the proxy chain at the network layer, which cannot be bypassed from inside the sandbox.
     attr_accessor :outbound_proxy_url
 
+    # OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector (the Daytona-hosted collector or the region-configured endpoint) and will not be available in the Daytona analytics API or dashboard.
+    attr_accessor :otel_endpoint_override
+
     # The target (region) where the sandbox will be created
     attr_accessor :target
 
@@ -106,6 +109,7 @@ module DaytonaApiClient
         :'network_allow_list' => :'networkAllowList',
         :'domain_allow_list' => :'domainAllowList',
         :'outbound_proxy_url' => :'outboundProxyUrl',
+        :'otel_endpoint_override' => :'otelEndpointOverride',
         :'target' => :'target',
         :'cpu' => :'cpu',
         :'gpu' => :'gpu',
@@ -148,6 +152,7 @@ module DaytonaApiClient
         :'network_allow_list' => :'String',
         :'domain_allow_list' => :'String',
         :'outbound_proxy_url' => :'String',
+        :'otel_endpoint_override' => :'String',
         :'target' => :'String',
         :'cpu' => :'Integer',
         :'gpu' => :'Integer',
@@ -231,6 +236,10 @@ module DaytonaApiClient
 
       if attributes.key?(:'outbound_proxy_url')
         self.outbound_proxy_url = attributes[:'outbound_proxy_url']
+      end
+
+      if attributes.key?(:'otel_endpoint_override')
+        self.otel_endpoint_override = attributes[:'otel_endpoint_override']
       end
 
       if attributes.key?(:'target')
@@ -336,6 +345,7 @@ module DaytonaApiClient
           network_allow_list == o.network_allow_list &&
           domain_allow_list == o.domain_allow_list &&
           outbound_proxy_url == o.outbound_proxy_url &&
+          otel_endpoint_override == o.otel_endpoint_override &&
           target == o.target &&
           cpu == o.cpu &&
           gpu == o.gpu &&
@@ -363,7 +373,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, outbound_proxy_url, target, cpu, gpu, gpu_type, spot, memory, disk, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, ttl_minutes, volumes, build_info, linked_sandbox, secrets].hash
+      [name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, outbound_proxy_url, otel_endpoint_override, target, cpu, gpu, gpu_type, spot, memory, disk, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, ttl_minutes, volumes, build_info, linked_sandbox, secrets].hash
     end
 
     # Builds the object from hash

--- a/api-client-ruby/lib/daytona_api_client/models/daytona_configuration.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/daytona_configuration.rb
@@ -27,7 +27,7 @@ module DaytonaApiClient
     # OIDC configuration
     attr_accessor :oidc
 
-    # OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the dual-issuer setup is configured; the dashboard uses it as its authority when entered via an organization SSO link.
+    # OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the secondary (org-SSO) issuer is configured; the dashboard uses it as its authority when entered via an organization SSO link.
     attr_accessor :sso_oidc
 
     # Feature flags forced on for this deployment regardless of PostHog targeting. Lets environments without PostHog (previews, local dev) enable flag-gated dashboard features.

--- a/api-client-ruby/lib/daytona_api_client/models/region.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/region.rb
@@ -42,6 +42,9 @@ module DaytonaApiClient
     # Snapshot Manager URL for the region
     attr_accessor :snapshot_manager_url
 
+    # OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+    attr_accessor :otel_endpoint
+
     class EnumAttributeValidator
       attr_reader :datatype
       attr_reader :allowable_values
@@ -75,7 +78,8 @@ module DaytonaApiClient
         :'updated_at' => :'updatedAt',
         :'proxy_url' => :'proxyUrl',
         :'ssh_gateway_url' => :'sshGatewayUrl',
-        :'snapshot_manager_url' => :'snapshotManagerUrl'
+        :'snapshot_manager_url' => :'snapshotManagerUrl',
+        :'otel_endpoint' => :'otelEndpoint'
       }
     end
 
@@ -100,7 +104,8 @@ module DaytonaApiClient
         :'updated_at' => :'String',
         :'proxy_url' => :'String',
         :'ssh_gateway_url' => :'String',
-        :'snapshot_manager_url' => :'String'
+        :'snapshot_manager_url' => :'String',
+        :'otel_endpoint' => :'String'
       }
     end
 
@@ -110,7 +115,8 @@ module DaytonaApiClient
         :'organization_id',
         :'proxy_url',
         :'ssh_gateway_url',
-        :'snapshot_manager_url'
+        :'snapshot_manager_url',
+        :'otel_endpoint'
       ])
     end
 
@@ -174,6 +180,10 @@ module DaytonaApiClient
 
       if attributes.key?(:'snapshot_manager_url')
         self.snapshot_manager_url = attributes[:'snapshot_manager_url']
+      end
+
+      if attributes.key?(:'otel_endpoint')
+        self.otel_endpoint = attributes[:'otel_endpoint']
       end
     end
 
@@ -280,7 +290,8 @@ module DaytonaApiClient
           updated_at == o.updated_at &&
           proxy_url == o.proxy_url &&
           ssh_gateway_url == o.ssh_gateway_url &&
-          snapshot_manager_url == o.snapshot_manager_url
+          snapshot_manager_url == o.snapshot_manager_url &&
+          otel_endpoint == o.otel_endpoint
     end
 
     # @see the `==` method
@@ -292,7 +303,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, name, organization_id, region_type, created_at, updated_at, proxy_url, ssh_gateway_url, snapshot_manager_url].hash
+      [id, name, organization_id, region_type, created_at, updated_at, proxy_url, ssh_gateway_url, snapshot_manager_url, otel_endpoint].hash
     end
 
     # Builds the object from hash

--- a/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
@@ -51,6 +51,9 @@ module DaytonaApiClient
     # Outbound proxy URL the sandbox HTTP(S) traffic is routed through. Applied via the HTTP(S)_PROXY environment variables (convenience routing); network-layer enforcement applies only when the sandbox also has a domainAllowList. Only returned on single-sandbox reads — never on list responses.
     attr_accessor :outbound_proxy_url
 
+    # OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector and is not available in the Daytona analytics API or dashboard. Only returned on single-sandbox reads — never on list responses.
+    attr_accessor :otel_endpoint_override
+
     # The target environment for the sandbox
     attr_accessor :target
 
@@ -178,6 +181,7 @@ module DaytonaApiClient
         :'network_allow_list' => :'networkAllowList',
         :'domain_allow_list' => :'domainAllowList',
         :'outbound_proxy_url' => :'outboundProxyUrl',
+        :'otel_endpoint_override' => :'otelEndpointOverride',
         :'target' => :'target',
         :'cpu' => :'cpu',
         :'gpu' => :'gpu',
@@ -236,6 +240,7 @@ module DaytonaApiClient
         :'network_allow_list' => :'String',
         :'domain_allow_list' => :'String',
         :'outbound_proxy_url' => :'String',
+        :'otel_endpoint_override' => :'String',
         :'target' => :'String',
         :'cpu' => :'Float',
         :'gpu' => :'Float',
@@ -357,6 +362,10 @@ module DaytonaApiClient
 
       if attributes.key?(:'outbound_proxy_url')
         self.outbound_proxy_url = attributes[:'outbound_proxy_url']
+      end
+
+      if attributes.key?(:'otel_endpoint_override')
+        self.otel_endpoint_override = attributes[:'otel_endpoint_override']
       end
 
       if attributes.key?(:'target')
@@ -762,6 +771,7 @@ module DaytonaApiClient
           network_allow_list == o.network_allow_list &&
           domain_allow_list == o.domain_allow_list &&
           outbound_proxy_url == o.outbound_proxy_url &&
+          otel_endpoint_override == o.otel_endpoint_override &&
           target == o.target &&
           cpu == o.cpu &&
           gpu == o.gpu &&
@@ -803,7 +813,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, outbound_proxy_url, target, cpu, gpu, spot, spot_evicted_at, gpu_type, memory, disk, state, desired_state, error_reason, recoverable, warm_pool_id, backup_state, backup_created_at, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, auto_destroy_at, volumes, build_info, created_at, updated_at, last_activity_at, sandbox_class, daemon_version, runner_id, linked_sandbox_id, toolbox_proxy_url].hash
+      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, outbound_proxy_url, otel_endpoint_override, target, cpu, gpu, spot, spot_evicted_at, gpu_type, memory, disk, state, desired_state, error_reason, recoverable, warm_pool_id, backup_state, backup_created_at, auto_stop_interval, auto_pause_interval, auto_archive_interval, auto_delete_interval, auto_destroy_at, volumes, build_info, created_at, updated_at, last_activity_at, sandbox_class, daemon_version, runner_id, linked_sandbox_id, toolbox_proxy_url].hash
     end
 
     # Builds the object from hash

--- a/api-client-ruby/lib/daytona_api_client/models/update_region.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/update_region.rb
@@ -24,12 +24,16 @@ module DaytonaApiClient
     # Snapshot Manager URL for the region
     attr_accessor :snapshot_manager_url
 
+    # OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+    attr_accessor :otel_endpoint
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         :'proxy_url' => :'proxyUrl',
         :'ssh_gateway_url' => :'sshGatewayUrl',
-        :'snapshot_manager_url' => :'snapshotManagerUrl'
+        :'snapshot_manager_url' => :'snapshotManagerUrl',
+        :'otel_endpoint' => :'otelEndpoint'
       }
     end
 
@@ -48,7 +52,8 @@ module DaytonaApiClient
       {
         :'proxy_url' => :'String',
         :'ssh_gateway_url' => :'String',
-        :'snapshot_manager_url' => :'String'
+        :'snapshot_manager_url' => :'String',
+        :'otel_endpoint' => :'String'
       }
     end
 
@@ -57,7 +62,8 @@ module DaytonaApiClient
       Set.new([
         :'proxy_url',
         :'ssh_gateway_url',
-        :'snapshot_manager_url'
+        :'snapshot_manager_url',
+        :'otel_endpoint'
       ])
     end
 
@@ -88,6 +94,10 @@ module DaytonaApiClient
       if attributes.key?(:'snapshot_manager_url')
         self.snapshot_manager_url = attributes[:'snapshot_manager_url']
       end
+
+      if attributes.key?(:'otel_endpoint')
+        self.otel_endpoint = attributes[:'otel_endpoint']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -112,7 +122,8 @@ module DaytonaApiClient
       self.class == o.class &&
           proxy_url == o.proxy_url &&
           ssh_gateway_url == o.ssh_gateway_url &&
-          snapshot_manager_url == o.snapshot_manager_url
+          snapshot_manager_url == o.snapshot_manager_url &&
+          otel_endpoint == o.otel_endpoint
     end
 
     # @see the `==` method
@@ -124,7 +135,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [proxy_url, ssh_gateway_url, snapshot_manager_url].hash
+      [proxy_url, ssh_gateway_url, snapshot_manager_url, otel_endpoint].hash
     end
 
     # Builds the object from hash

--- a/api-client-ruby/lib/daytona_api_client/models/user.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/user.rb
@@ -27,6 +27,9 @@ module DaytonaApiClient
     # Whether the user email address has been verified
     attr_accessor :email_verified
 
+    # HMAC of the user email for Pylon support-widget identity verification
+    attr_accessor :pylon_email_hash
+
     # User public keys
     attr_accessor :public_keys
 
@@ -40,6 +43,7 @@ module DaytonaApiClient
         :'name' => :'name',
         :'email' => :'email',
         :'email_verified' => :'emailVerified',
+        :'pylon_email_hash' => :'pylonEmailHash',
         :'public_keys' => :'publicKeys',
         :'created_at' => :'createdAt'
       }
@@ -62,6 +66,7 @@ module DaytonaApiClient
         :'name' => :'String',
         :'email' => :'String',
         :'email_verified' => :'Boolean',
+        :'pylon_email_hash' => :'String',
         :'public_keys' => :'Array<UserPublicKey>',
         :'created_at' => :'Time'
       }
@@ -111,6 +116,10 @@ module DaytonaApiClient
         self.email_verified = attributes[:'email_verified']
       else
         self.email_verified = nil
+      end
+
+      if attributes.key?(:'pylon_email_hash')
+        self.pylon_email_hash = attributes[:'pylon_email_hash']
       end
 
       if attributes.key?(:'public_keys')
@@ -242,6 +251,7 @@ module DaytonaApiClient
           name == o.name &&
           email == o.email &&
           email_verified == o.email_verified &&
+          pylon_email_hash == o.pylon_email_hash &&
           public_keys == o.public_keys &&
           created_at == o.created_at
     end
@@ -255,7 +265,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, name, email, email_verified, public_keys, created_at].hash
+      [id, name, email, email_verified, pylon_email_hash, public_keys, created_at].hash
     end
 
     # Builds the object from hash

--- a/api-client/src/models/create-region.ts
+++ b/api-client/src/models/create-region.ts
@@ -31,5 +31,9 @@ export interface CreateRegion {
      * Snapshot Manager URL for the region
      */
     'snapshotManagerUrl'?: string | null;
+    /**
+     * OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+     */
+    'otelEndpoint'?: string | null;
 }
 

--- a/api-client/src/models/create-sandbox.ts
+++ b/api-client/src/models/create-sandbox.ts
@@ -65,6 +65,10 @@ export interface CreateSandbox {
      */
     'outboundProxyUrl'?: string;
     /**
+     * OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector (the Daytona-hosted collector or the region-configured endpoint) and will not be available in the Daytona analytics API or dashboard.
+     */
+    'otelEndpointOverride'?: string;
+    /**
      * The target (region) where the sandbox will be created
      */
     'target'?: string;

--- a/api-client/src/models/daytona-configuration.ts
+++ b/api-client/src/models/daytona-configuration.ts
@@ -47,7 +47,7 @@ export interface DaytonaConfiguration {
      */
     'oidc': OidcConfig;
     /**
-     * OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the dual-issuer setup is configured; the dashboard uses it as its authority when entered via an organization SSO link.
+     * OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the secondary (org-SSO) issuer is configured; the dashboard uses it as its authority when entered via an organization SSO link.
      */
     'ssoOidc'?: SsoOidcConfig;
     /**

--- a/api-client/src/models/region.ts
+++ b/api-client/src/models/region.ts
@@ -54,6 +54,10 @@ export interface Region {
      * Snapshot Manager URL for the region
      */
     'snapshotManagerUrl'?: string | null;
+    /**
+     * OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+     */
+    'otelEndpoint'?: string | null;
 }
 
 

--- a/api-client/src/models/sandbox.ts
+++ b/api-client/src/models/sandbox.ts
@@ -79,6 +79,10 @@ export interface Sandbox {
      */
     'outboundProxyUrl'?: string;
     /**
+     * OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector and is not available in the Daytona analytics API or dashboard. Only returned on single-sandbox reads — never on list responses.
+     */
+    'otelEndpointOverride'?: string;
+    /**
      * The target environment for the sandbox
      */
     'target': string;

--- a/api-client/src/models/update-region.ts
+++ b/api-client/src/models/update-region.ts
@@ -27,5 +27,9 @@ export interface UpdateRegion {
      * Snapshot Manager URL for the region
      */
     'snapshotManagerUrl'?: string | null;
+    /**
+     * OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.
+     */
+    'otelEndpoint'?: string | null;
 }
 

--- a/api-client/src/models/user.ts
+++ b/api-client/src/models/user.ts
@@ -35,6 +35,10 @@ export interface User {
      */
     'emailVerified': boolean;
     /**
+     * HMAC of the user email for Pylon support-widget identity verification
+     */
+    'pylonEmailHash'?: string;
+    /**
      * User public keys
      */
     'publicKeys': Array<UserPublicKey>;

--- a/artifacts/sdk-docs/go-sdk/types.mdx
+++ b/artifacts/sdk-docs/go-sdk/types.mdx
@@ -591,7 +591,11 @@ type SandboxBaseParams struct {
     // routed through. Applied via the HTTP(S)_PROXY environment variables;
     // combine with DomainAllowList for network-layer enforcement.
     OutboundProxyUrl *string
-    Ephemeral        bool
+    // OtelEndpointOverride is the OTel collector endpoint override for the sandbox.
+    // When set, sandbox OTel data is sent to this endpoint instead of the default
+    // collector and will not be available in the Daytona analytics API or dashboard.
+    OtelEndpointOverride *string
+    Ephemeral            bool
     // Spot marks the sandbox as a spot GPU sandbox. A spot sandbox may be instantly
     // terminated without notice to free GPU capacity for an on-demand (non-spot) GPU
     // sandbox. Rejected when the sandbox requests no GPUs.

--- a/artifacts/sdk-docs/python-sdk/async/async-daytona.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-daytona.mdx
@@ -516,6 +516,9 @@ Base parameters for creating a new Sandbox.
 - `outbound_proxy_url` _str | None_ - Outbound proxy URL to route the Sandbox HTTP(S) traffic through. Applied
   via the HTTP(S)_PROXY environment variables (convenience routing, not a security boundary on its own);
   combine with domain_allow_list for unbypassable network-layer enforcement.
+- `otel_endpoint_override` _str | None_ - OTel collector endpoint override for the Sandbox. When set,
+  sandbox OTel data is sent to this endpoint instead of the default collector and will not be
+  available in the Daytona analytics API or dashboard.
 - `ephemeral` _bool | None_ - Whether the Sandbox should be ephemeral.
   If True, auto_delete_interval will be set to 0.
 - `spot` _bool | None_ - GPU-only. When True, the Sandbox may be instantly terminated without notice

--- a/artifacts/sdk-docs/python-sdk/sync/daytona.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/daytona.mdx
@@ -462,6 +462,9 @@ Base parameters for creating a new Sandbox.
 - `outbound_proxy_url` _str | None_ - Outbound proxy URL to route the Sandbox HTTP(S) traffic through. Applied
   via the HTTP(S)_PROXY environment variables (convenience routing, not a security boundary on its own);
   combine with domain_allow_list for unbypassable network-layer enforcement.
+- `otel_endpoint_override` _str | None_ - OTel collector endpoint override for the Sandbox. When set,
+  sandbox OTel data is sent to this endpoint instead of the default collector and will not be
+  available in the Daytona analytics API or dashboard.
 - `ephemeral` _bool | None_ - Whether the Sandbox should be ephemeral.
   If True, auto_delete_interval will be set to 0.
 - `spot` _bool | None_ - GPU-only. When True, the Sandbox may be instantly terminated without notice

--- a/artifacts/sdk-docs/typescript-sdk/daytona.mdx
+++ b/artifacts/sdk-docs/typescript-sdk/daytona.mdx
@@ -407,6 +407,7 @@ Base parameters for creating a new Sandbox.
 - `name?` _string_
 - `networkAllowList?` _string_ - Comma-separated list of allowed CIDR network addresses for the Sandbox
 - `networkBlockAll?` _boolean_ - Whether to block all network access for the Sandbox
+- `otelEndpointOverride?` _string_ - OTel collector endpoint override for the Sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector and will not be available in the Daytona analytics API or dashboard.
 - `outboundProxyUrl?` _string_ - Outbound proxy URL to route the Sandbox HTTP(S) traffic through. Applied via the HTTP(S)_PROXY environment variables (convenience routing, not a security boundary on its own); combine with domainAllowList for unbypassable network-layer enforcement.
 - `public?` _boolean_ - Is the Sandbox port preview public
 - `secrets?` _Record\<string, string\>_ - Optional map of environment variable name to the name of an existing organization Secret to mount into the Sandbox. The env var is set to the Secret's opaque placeholder; the real value is substituted transparently on outbound requests to the Secret's allowed hosts. Every referenced Secret name must already exist in the organization.
@@ -435,6 +436,7 @@ Parameters for creating a new Sandbox.
 - `name?` _string_
 - `networkAllowList?` _string_
 - `networkBlockAll?` _boolean_
+- `otelEndpointOverride?` _string_
 - `outboundProxyUrl?` _string_
 - `public?` _boolean_
 - `resources?` _Resources_ - Resource allocation for the Sandbox. If not provided, sandbox will
@@ -463,6 +465,7 @@ Parameters for creating a new Sandbox from a snapshot.
 - `name?` _string_
 - `networkAllowList?` _string_
 - `networkBlockAll?` _boolean_
+- `otelEndpointOverride?` _string_
 - `outboundProxyUrl?` _string_
 - `public?` _boolean_
 - `secrets?` _Record\<string, string\>_

--- a/openapi-specs/api.json
+++ b/openapi-specs/api.json
@@ -11147,7 +11147,7 @@
             ]
           },
           "ssoOidc": {
-            "description": "OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the dual-issuer setup is configured; the dashboard uses it as its authority when entered via an organization SSO link.",
+            "description": "OIDC configuration for org-SSO logins (Daytona Auth issuer). Present only when the secondary (org-SSO) issuer is configured; the dashboard uses it as its authority when entered via an organization SSO link.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/SsoOidcConfig"
@@ -12704,6 +12704,12 @@
             "description": "Snapshot Manager URL for the region",
             "example": "http://snapshot-manager.example.com",
             "nullable": true
+          },
+          "otelEndpoint": {
+            "type": "string",
+            "description": "OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.",
+            "example": "https://otel-collector.example.com:4318",
+            "nullable": true
           }
         },
         "required": [
@@ -12738,6 +12744,12 @@
             "type": "string",
             "description": "Snapshot Manager URL for the region",
             "example": "https://snapshot-manager.example.com",
+            "nullable": true
+          },
+          "otelEndpoint": {
+            "type": "string",
+            "description": "OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.",
+            "example": "https://otel-collector.example.com:4318",
             "nullable": true
           }
         },
@@ -12813,6 +12825,12 @@
             "type": "string",
             "description": "Snapshot Manager URL for the region",
             "example": "https://snapshot-manager.example.com",
+            "nullable": true
+          },
+          "otelEndpoint": {
+            "type": "string",
+            "description": "OTel collector endpoint for sandboxes created in this region. When set, sandbox OTel data is sent to this endpoint instead of the Daytona-hosted collector and will not be available in the Daytona analytics API or dashboard.",
+            "example": "https://otel-collector.example.com:4318",
             "nullable": true
           }
         }
@@ -13191,6 +13209,10 @@
           "emailVerified": {
             "type": "boolean",
             "description": "Whether the user email address has been verified"
+          },
+          "pylonEmailHash": {
+            "type": "string",
+            "description": "HMAC of the user email for Pylon support-widget identity verification"
           },
           "publicKeys": {
             "description": "User public keys",
@@ -13690,6 +13712,11 @@
             "description": "Outbound proxy URL the sandbox HTTP(S) traffic is routed through. Applied via the HTTP(S)_PROXY environment variables (convenience routing); network-layer enforcement applies only when the sandbox also has a domainAllowList. Only returned on single-sandbox reads — never on list responses.",
             "example": "http://user:pass@proxy.example.com:3128"
           },
+          "otelEndpointOverride": {
+            "type": "string",
+            "description": "OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector and is not available in the Daytona analytics API or dashboard. Only returned on single-sandbox reads — never on list responses.",
+            "example": "https://otel-collector.example.com:4318"
+          },
           "target": {
             "type": "string",
             "description": "The target environment for the sandbox",
@@ -14008,6 +14035,11 @@
             "type": "string",
             "description": "Outbound proxy URL to route the sandbox HTTP(S) traffic through (http or https; credentials may be included in the URL). On its own this is convenience routing, not a security boundary: it is applied by injecting the standard HTTP(S)_PROXY environment variables at creation, so a process that clears those variables egresses directly. Combine with domainAllowList to have web-port (80/443) egress transparently redirected through the proxy chain at the network layer, which cannot be bypassed from inside the sandbox.",
             "example": "http://user:pass@proxy.example.com:3128"
+          },
+          "otelEndpointOverride": {
+            "type": "string",
+            "description": "OTel collector endpoint override for this sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector (the Daytona-hosted collector or the region-configured endpoint) and will not be available in the Daytona analytics API or dashboard.",
+            "example": "https://otel-collector.example.com:4318"
           },
           "target": {
             "type": "string",

--- a/sdk-go/pkg/daytona/client.go
+++ b/sdk-go/pkg/daytona/client.go
@@ -591,6 +591,9 @@ func (c *Client) doCreate(ctx context.Context, params any, opts ...func(*options
 	if baseParams.OutboundProxyUrl != nil {
 		createReq.SetOutboundProxyUrl(*baseParams.OutboundProxyUrl)
 	}
+	if baseParams.OtelEndpointOverride != nil {
+		createReq.SetOtelEndpointOverride(*baseParams.OtelEndpointOverride)
+	}
 	if baseParams.LinkedSandbox != "" {
 		createReq.SetLinkedSandbox(baseParams.LinkedSandbox)
 	}

--- a/sdk-go/pkg/types/types.go
+++ b/sdk-go/pkg/types/types.go
@@ -119,7 +119,11 @@ type SandboxBaseParams struct {
 	// routed through. Applied via the HTTP(S)_PROXY environment variables;
 	// combine with DomainAllowList for network-layer enforcement.
 	OutboundProxyUrl *string
-	Ephemeral        bool
+	// OtelEndpointOverride is the OTel collector endpoint override for the sandbox.
+	// When set, sandbox OTel data is sent to this endpoint instead of the default
+	// collector and will not be available in the Daytona analytics API or dashboard.
+	OtelEndpointOverride *string
+	Ephemeral            bool
 	// Spot marks the sandbox as a spot GPU sandbox. A spot sandbox may be instantly
 	// terminated without notice to free GPU capacity for an on-demand (non-spot) GPU
 	// sandbox. Rejected when the sandbox requests no GPUs.

--- a/sdk-java/src/main/java/io/daytona/sdk/Daytona.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Daytona.java
@@ -599,6 +599,7 @@ public class Daytona implements AutoCloseable {
         if (params.getNetworkBlockAll() != null) body.setNetworkBlockAll(params.getNetworkBlockAll());
         if (params.getDomainAllowList() != null) body.setDomainAllowList(params.getDomainAllowList());
         if (params.getOutboundProxyUrl() != null) body.setOutboundProxyUrl(params.getOutboundProxyUrl());
+        if (params.getOtelEndpointOverride() != null) body.setOtelEndpointOverride(params.getOtelEndpointOverride());
         if (params.getLinkedSandbox() != null) body.setLinkedSandbox(params.getLinkedSandbox());
         if (params.getSpot() != null) body.setSpot(params.getSpot());
         if (params.getVolumes() != null) {

--- a/sdk-java/src/main/java/io/daytona/sdk/model/CreateSandboxParams.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/model/CreateSandboxParams.java
@@ -32,6 +32,7 @@ public class CreateSandboxParams {
     private Boolean networkBlockAll;
     private String domainAllowList;
     private String outboundProxyUrl;
+    private String otelEndpointOverride;
     private String linkedSandbox;
     private Boolean spot;
 
@@ -275,6 +276,26 @@ public class CreateSandboxParams {
      * @param outboundProxyUrl outbound proxy URL
      */
     public void setOutboundProxyUrl(String outboundProxyUrl) { this.outboundProxyUrl = outboundProxyUrl; }
+
+    /**
+     * Returns the OTel collector endpoint override for the Sandbox.
+     *
+     * <p>When set, sandbox OTel data is sent to this endpoint instead of the default collector and
+     * will not be available in the Daytona analytics API or dashboard.
+     *
+     * @return OTel collector endpoint override, or {@code null}
+     */
+    public String getOtelEndpointOverride() { return otelEndpointOverride; }
+
+    /**
+     * Sets the OTel collector endpoint override for the Sandbox.
+     *
+     * <p>When set, sandbox OTel data is sent to this endpoint instead of the default collector and
+     * will not be available in the Daytona analytics API or dashboard.
+     *
+     * @param otelEndpointOverride OTel collector endpoint override
+     */
+    public void setOtelEndpointOverride(String otelEndpointOverride) { this.otelEndpointOverride = otelEndpointOverride; }
 
     /**
      * Returns the ID or name of an existing Sandbox to link the new Sandbox to.

--- a/sdk-python/src/daytona/_async/daytona.py
+++ b/sdk-python/src/daytona/_async/daytona.py
@@ -641,6 +641,7 @@ class AsyncDaytona:
             network_allow_list=params.network_allow_list,
             domain_allow_list=params.domain_allow_list,
             outbound_proxy_url=params.outbound_proxy_url,
+            otel_endpoint_override=params.otel_endpoint_override,
             linked_sandbox=params.linked_sandbox,
             spot=params.spot,
         )

--- a/sdk-python/src/daytona/_sync/daytona.py
+++ b/sdk-python/src/daytona/_sync/daytona.py
@@ -508,6 +508,7 @@ class Daytona:
             network_allow_list=params.network_allow_list,
             domain_allow_list=params.domain_allow_list,
             outbound_proxy_url=params.outbound_proxy_url,
+            otel_endpoint_override=params.otel_endpoint_override,
             linked_sandbox=params.linked_sandbox,
             spot=params.spot,
         )

--- a/sdk-python/src/daytona/common/daytona.py
+++ b/sdk-python/src/daytona/common/daytona.py
@@ -172,6 +172,9 @@ class CreateSandboxBaseParams(BaseModel):
         outbound_proxy_url (str | None): Outbound proxy URL to route the Sandbox HTTP(S) traffic through. Applied
             via the HTTP(S)_PROXY environment variables (convenience routing, not a security boundary on its own);
             combine with domain_allow_list for unbypassable network-layer enforcement.
+        otel_endpoint_override (str | None): OTel collector endpoint override for the Sandbox. When set,
+            sandbox OTel data is sent to this endpoint instead of the default collector and will not be
+            available in the Daytona analytics API or dashboard.
         ephemeral (bool | None): Whether the Sandbox should be ephemeral.
             If True, auto_delete_interval will be set to 0.
         spot (bool | None): GPU-only. When True, the Sandbox may be instantly terminated without notice
@@ -200,6 +203,7 @@ class CreateSandboxBaseParams(BaseModel):
     network_allow_list: str | None = None
     domain_allow_list: str | None = None
     outbound_proxy_url: str | None = None
+    otel_endpoint_override: str | None = None
     ephemeral: bool | None = None
     spot: bool | None = None
     linked_sandbox: str | None = None

--- a/sdk-ruby/lib/daytona/common/daytona.rb
+++ b/sdk-ruby/lib/daytona/common/daytona.rb
@@ -59,6 +59,9 @@ module Daytona
     # @return [String, nil] Outbound proxy URL to route the Sandbox HTTP(S) traffic through
     attr_accessor :outbound_proxy_url
 
+    # @return [String, nil] OTel collector endpoint override for the Sandbox
+    attr_accessor :otel_endpoint_override
+
     # @return [Integer, nil] Time to live in minutes (0 to disable)
     attr_accessor :ttl_minutes
 
@@ -97,6 +100,9 @@ module Daytona
     # @param outbound_proxy_url [String, nil] Outbound proxy URL to route the Sandbox HTTP(S) traffic through.
     #   Applied via the HTTP(S)_PROXY environment variables; combine with domain_allow_list for
     #   network-layer enforcement.
+    # @param otel_endpoint_override [String, nil] OTel collector endpoint override for the Sandbox. When set,
+    #   sandbox OTel data is sent to this endpoint instead of the default collector and will not be
+    #   available in the Daytona analytics API or dashboard.
     # @param ttl_minutes [Integer, nil] Time to live in minutes (0 to disable)
     # @param ephemeral [Boolean, nil] Whether the Sandbox should be ephemeral
     # @param spot [Boolean, nil] GPU-only. Whether the Sandbox may be instantly terminated to free GPU
@@ -120,6 +126,7 @@ module Daytona
       network_allow_list: nil,
       domain_allow_list: nil,
       outbound_proxy_url: nil,
+      otel_endpoint_override: nil,
       ephemeral: nil,
       spot: nil,
       linked_sandbox: nil
@@ -141,6 +148,7 @@ module Daytona
       @network_allow_list = network_allow_list
       @domain_allow_list = domain_allow_list
       @outbound_proxy_url = outbound_proxy_url
+      @otel_endpoint_override = otel_endpoint_override
       @ephemeral = ephemeral
       @spot = spot
       @linked_sandbox = linked_sandbox
@@ -171,6 +179,7 @@ module Daytona
         network_allow_list:,
         domain_allow_list:,
         outbound_proxy_url:,
+        otel_endpoint_override:,
         ephemeral:,
         spot:,
         linked_sandbox:
@@ -229,6 +238,9 @@ module Daytona
     # @param outbound_proxy_url [String, nil] Outbound proxy URL to route the Sandbox HTTP(S) traffic through.
     #   Applied via the HTTP(S)_PROXY environment variables; combine with domain_allow_list for
     #   network-layer enforcement.
+    # @param otel_endpoint_override [String, nil] OTel collector endpoint override for the Sandbox. When set,
+    #   sandbox OTel data is sent to this endpoint instead of the default collector and will not be
+    #   available in the Daytona analytics API or dashboard.
     # @param ephemeral [Boolean, nil] Whether the Sandbox should be ephemeral
     def initialize(image:, resources: nil, **args)
       @image = image
@@ -275,6 +287,9 @@ module Daytona
     # @param outbound_proxy_url [String, nil] Outbound proxy URL to route the Sandbox HTTP(S) traffic through.
     #   Applied via the HTTP(S)_PROXY environment variables; combine with domain_allow_list for
     #   network-layer enforcement.
+    # @param otel_endpoint_override [String, nil] OTel collector endpoint override for the Sandbox. When set,
+    #   sandbox OTel data is sent to this endpoint instead of the default collector and will not be
+    #   available in the Daytona analytics API or dashboard.
     # @param ephemeral [Boolean, nil] Whether the Sandbox should be ephemeral
     def initialize(snapshot: nil, **args)
       @snapshot = snapshot

--- a/sdk-ruby/lib/daytona/daytona.rb
+++ b/sdk-ruby/lib/daytona/daytona.rb
@@ -294,6 +294,7 @@ module Daytona
         network_allow_list: params.network_allow_list,
         domain_allow_list: params.domain_allow_list,
         outbound_proxy_url: params.outbound_proxy_url,
+        otel_endpoint_override: params.otel_endpoint_override,
         linked_sandbox: params.linked_sandbox,
         spot: params.spot
       )

--- a/sdk-ruby/spec/daytona/daytona_spec.rb
+++ b/sdk-ruby/spec/daytona/daytona_spec.rb
@@ -230,6 +230,20 @@ RSpec.describe Daytona::Daytona do
       end
     end
 
+    it 'passes otel_endpoint_override through to create_sandbox' do
+      params = Daytona::CreateSandboxFromSnapshotParams.new(
+        snapshot: 'snap-1',
+        otel_endpoint_override: 'https://otel-collector.example.com:4318'
+      )
+      allow(sandbox_api).to receive(:create_sandbox).and_return(sandbox_dto)
+
+      described_class.new(config).create(params)
+
+      expect(sandbox_api).to have_received(:create_sandbox) do |request|
+        expect(request.otel_endpoint_override).to eq('https://otel-collector.example.com:4318')
+      end
+    end
+
     it 'leaves secrets nil when none are provided' do
       params = Daytona::CreateSandboxFromSnapshotParams.new(snapshot: 'snap-1')
       allow(sandbox_api).to receive(:create_sandbox).and_return(sandbox_dto)

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -188,6 +188,7 @@ export interface Resources {
  * @property {string} [networkAllowList] - Comma-separated list of allowed CIDR network addresses for the Sandbox
  * @property {string} [domainAllowList] - Comma-separated list of allowed domains for the Sandbox
  * @property {string} [outboundProxyUrl] - Outbound proxy URL to route the Sandbox HTTP(S) traffic through. Applied via the HTTP(S)_PROXY environment variables (convenience routing, not a security boundary on its own); combine with domainAllowList for unbypassable network-layer enforcement.
+ * @property {string} [otelEndpointOverride] - OTel collector endpoint override for the Sandbox. When set, sandbox OTel data is sent to this endpoint instead of the default collector and will not be available in the Daytona analytics API or dashboard.
  * @property {boolean} [ephemeral] - Whether the Sandbox should be ephemeral. If true, autoDeleteInterval will be set to 0.
  * @property {boolean} [spot] - GPU-only. When true, the Sandbox may be instantly terminated without notice to free GPU capacity for an on-demand (non-spot) GPU Sandbox. Rejected when the Sandbox requests no GPUs.
  * @property {string} [linkedSandbox] - ID or name of an existing sandbox to link the new sandbox to. The new sandbox will be scheduled on the same runner as the linked sandbox so a local network can be established between them. Linked sandboxes must be ephemeral (autoDeleteInterval=0) and cannot themselves be linked to another sandbox.
@@ -210,6 +211,7 @@ export type CreateSandboxBaseParams = {
   networkAllowList?: string
   domainAllowList?: string
   outboundProxyUrl?: string
+  otelEndpointOverride?: string
   ephemeral?: boolean
   spot?: boolean
   linkedSandbox?: string
@@ -702,6 +704,7 @@ export class Daytona implements AsyncDisposable {
           networkAllowList: params.networkAllowList,
           domainAllowList: params.domainAllowList,
           outboundProxyUrl: params.outboundProxyUrl,
+          otelEndpointOverride: params.otelEndpointOverride,
           linkedSandbox: params.linkedSandbox,
           secrets: params.secrets
             ? Object.entries(params.secrets).map(([envVar, secretName]) => ({ [envVar]: secretName }))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds optional OTel collector endpoint routing for sandboxes and regions. Previously all sandbox telemetry was sent to the Daytona-hosted collector; now regions can set `otelEndpoint` and sandboxes can override with `otelEndpointOverride`. When set, telemetry is not available in the Daytona analytics API or dashboard.

- **Review focus**
  - OpenAPI adds `Region.otelEndpoint`, `CreateRegion.otelEndpoint`, `UpdateRegion.otelEndpoint`, and `Sandbox/CreateSandbox.otelEndpointOverride`; docs updated accordingly.
  - Client models and SDKs pass through `otelEndpointOverride` in `sdk-go`, `sdk-java`, `sdk-python`, `sdk-ruby`, and `sdk-typescript`; tests and SDK docs updated.
  - `Sandbox` returns `otelEndpointOverride` only on single-sandbox reads, not in list responses.
  - Minor OIDC description wording change; behavior unchanged.
  - Adds optional `User.pylonEmailHash` for Pylon support-widget identity verification.

- **Rollout**
  - No migration required; fields are optional and preserve existing behavior when unset.
  - Consumers can set `otelEndpointOverride` when creating sandboxes or `otelEndpoint` on regions to redirect telemetry.
  - Telemetry routed to custom endpoints will not appear in Daytona analytics or the dashboard.

<sup>Written for commit 153664515d3bdc0e513f7a39e425f99c5def856f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

