### PR TITLE
fix(sdk-go): remove unsupported android sandbox class

### DIFF
--- a/artifacts/sdk-docs/go-sdk/types.mdx
+++ b/artifacts/sdk-docs/go-sdk/types.mdx
@@ -624,7 +624,6 @@ type SandboxClass = apiclient.SandboxClass
 const (
     SandboxClassLinuxVM   SandboxClass = apiclient.SANDBOXCLASS_LINUX_VM
     SandboxClassContainer SandboxClass = apiclient.SANDBOXCLASS_CONTAINER
-    SandboxClassAndroid   SandboxClass = apiclient.SANDBOXCLASS_ANDROID
 )
 ```
 

--- a/cli/cmd/snapshot/create.go
+++ b/cli/cmd/snapshot/create.go
@@ -61,10 +61,8 @@ var CreateCmd = &cobra.Command{
 				sc = apiclient.SANDBOXCLASS_CONTAINER
 			case "linux-vm":
 				sc = apiclient.SANDBOXCLASS_LINUX_VM
-			case "android":
-				sc = apiclient.SANDBOXCLASS_ANDROID
 			default:
-				return fmt.Errorf("invalid --sandbox-class %q: must be 'container', 'linux-vm' or 'android'", sandboxClassFlag)
+				return fmt.Errorf("invalid --sandbox-class %q: must be 'container' or 'linux-vm'", sandboxClassFlag)
 			}
 			createSnapshot.SetSandboxClass(sc)
 		}
@@ -168,7 +166,7 @@ func init() {
 	CreateCmd.Flags().Int32Var(&memoryFlag, "memory", 0, "Memory that will be allocated to the underlying sandboxes in GB (default: 1)")
 	CreateCmd.Flags().Int32Var(&diskFlag, "disk", 0, "Disk space that will be allocated to the underlying sandboxes in GB (default: 3)")
 	CreateCmd.Flags().StringVar(&regionIdFlag, "region", "", "ID of the region where the snapshot will be available (defaults to organization default region)")
-	CreateCmd.Flags().StringVar(&sandboxClassFlag, "sandbox-class", "", "Target sandbox class for the snapshot. One of: 'container', 'linux-vm' or 'android' (defaults to organization/server default)")
+	CreateCmd.Flags().StringVar(&sandboxClassFlag, "sandbox-class", "", "Target sandbox class for the snapshot. One of: 'container' or 'linux-vm' (defaults to organization/server default)")
 
 	CreateCmd.MarkFlagsMutuallyExclusive("image", "dockerfile")
 	CreateCmd.MarkFlagsMutuallyExclusive("image", "context")

--- a/sdk-go/pkg/types/types.go
+++ b/sdk-go/pkg/types/types.go
@@ -40,7 +40,6 @@ type SandboxClass = apiclient.SandboxClass
 const (
 	SandboxClassLinuxVM   SandboxClass = apiclient.SANDBOXCLASS_LINUX_VM
 	SandboxClassContainer SandboxClass = apiclient.SANDBOXCLASS_CONTAINER
-	SandboxClassAndroid   SandboxClass = apiclient.SANDBOXCLASS_ANDROID
 )
 
 // ExperimentalConfig holds experimental feature flags for the Daytona client.


### PR DESCRIPTION
## Summary

The Go SDK still declared a `SandboxClassAndroid` constant even though the android sandbox class is not supported. Since the Go SDK reference docs (`artifacts/sdk-docs/go-sdk/types.mdx`) are generated from this source, the android class was showing up on the docs site and in docs search results. The CLI also advertised `android` as a valid `--sandbox-class` value.

## Changes

- Removed the unused `SandboxClassAndroid` constant from `sdk-go/pkg/types/types.go` (declared but never referenced anywhere in the SDK)
- Regenerated `artifacts/sdk-docs/go-sdk/types.mdx` via gomarkdoc
- Removed `android` from the CLI `snapshot create --sandbox-class` accepted values and help text

## Verification

- `go build ./...` / `go vet ./...` clean for `sdk-go` and `cli`; `go test ./sdk-go/...` passes
- `grep -i android artifacts/sdk-docs/go-sdk/types.mdx` → no matches
- Built the CLI and ran it: help text shows only 'container' or 'linux-vm'; `--sandbox-class android` is rejected with a clear error

## Note (out of scope)

The generated API clients still carry `SANDBOXCLASS_ANDROID` from the vendored OpenAPI spec — intentionally left, since the API itself still models the android class (support-gated), and regeneration would bring it back. Other SDKs (TS/Python/Ruby/Java) never exposed android in their source or docs, so no changes needed there.