### PR TITLE
fix(cli): shell-quote exec args to preserve argument boundaries

### DIFF
--- a/cli/cmd/sandbox/exec.go
+++ b/cli/cmd/sandbox/exec.go
@@ -48,7 +48,7 @@ var ExecCmd = &cobra.Command{
 
 		toolboxClient := toolbox.NewClient(apiClient)
 
-		command := strings.Join(commandArgs, " ")
+		command := buildCommand(commandArgs)
 
 		executeRequest := toolbox.ExecuteRequest{
 			Command: command,
@@ -83,6 +83,32 @@ var ExecCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+// buildCommand converts the argv captured after "--" into the single command
+// string the toolbox execute API accepts.
+//
+// A lone argument is passed through verbatim so existing shell-snippet usage
+// (e.g. `daytona exec s -- "ls | grep foo"`) keeps working. Multiple arguments
+// are shell-quoted individually before joining, so the sandbox shell
+// reproduces the caller's argument boundaries exactly instead of re-splitting
+// on spaces inside them.
+func buildCommand(commandArgs []string) string {
+	if len(commandArgs) == 1 {
+		return commandArgs[0]
+	}
+
+	quoted := make([]string, len(commandArgs))
+	for i, arg := range commandArgs {
+		quoted[i] = shellQuote(arg)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// shellQuote wraps s in single quotes, escaping any single quotes it contains,
+// so the sandbox shell treats it as a single literal argument.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
 var (

--- a/cli/cmd/sandbox/exec_test.go
+++ b/cli/cmd/sandbox/exec_test.go
@@ -1,0 +1,70 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package sandbox
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestBuildCommandSingleArgumentIsVerbatim(t *testing.T) {
+	cases := []string{
+		"ls",
+		"ls | grep foo",
+		"echo $HOME && ls *.txt",
+		"python3 -c \"print('hi there')\"",
+	}
+
+	for _, arg := range cases {
+		if got := buildCommand([]string{arg}); got != arg {
+			t.Errorf("buildCommand([%q]) = %q, want verbatim", arg, got)
+		}
+	}
+}
+
+// roundTripArgv runs the built command through /bin/sh and returns the argv
+// the shell actually produced, by prepending a printf that echoes each
+// argument on its own line.
+func roundTripArgv(t *testing.T, args []string) []string {
+	t.Helper()
+
+	command := buildCommand(append([]string{"printf", "%s\\n"}, args...))
+	out, err := exec.Command("/bin/sh", "-c", command).Output()
+	if err != nil {
+		t.Fatalf("sh -c %q failed: %v", command, err)
+	}
+	return strings.Split(strings.TrimSuffix(string(out), "\n"), "\n")
+}
+
+func TestBuildCommandPreservesArgumentBoundaries(t *testing.T) {
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not available")
+	}
+
+	cases := [][]string{
+		{"python3", "-c", "print('hi there')"},
+		{"ls", "my file.txt"},
+		{"echo", "$HOME"},
+		{"echo", "a && b", "|", ">out", "*.txt"},
+		{"printf", "%s", "double \" and single ' quotes"},
+		{"grep", "-e", "^foo.*bar$", "file with  double  spaces"},
+		{"echo", ""},
+		{"echo", "back\\slash", "tab\there"},
+	}
+
+	for _, args := range cases {
+		got := roundTripArgv(t, args)
+		if len(got) != len(args) {
+			t.Errorf("argv %q: shell produced %d args %q, want %d", args, len(got), got, len(args))
+			continue
+		}
+		for i := range args {
+			if got[i] != args[i] {
+				t.Errorf("argv %q: arg %d = %q, want %q", args, i, got[i], args[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #202

`daytona exec` joined the argv after `--` with plain spaces, so argument boundaries expressed via quoting were lost and the sandbox shell re-split them (e.g. `python3 -c "print('hi there')"` became a SyntaxError).

## Changes

- `cli/cmd/sandbox/exec.go`: replace `strings.Join(commandArgs, " ")` with `buildCommand()`:
  - a **single** argument after `--` is passed through verbatim, so existing shell-snippet usage (`daytona exec s -- "ls | grep foo"`) is unchanged
  - **multiple** arguments are each single-quoted (same escaping pattern the MCP `execute_command` tool already uses) before joining
- `cli/cmd/sandbox/exec_test.go`: single-arg passthrough tests, plus round-trip tests that run the built command through `/bin/sh` and compare the argv the shell actually produced (spaces, both quote types, `$`, `&&`, pipes, globs, empty string, backslash/tab)

## Compatibility

- The toolbox daemon executes the command string via a POSIX shell (sh/bash/zsh), so single-quote quoting is valid for every shell it can select
- No API change; toolbox `ExecuteRequest.Command` stays a single string

## Verification

- `go build ./cli/...`, `go vet`, `go test ./cli/...` all green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves argument boundaries in `daytona exec` by shell-quoting argv after `--`. Previously we joined args with spaces and the sandbox shell re-split them (e.g., python3 -c "print('hi there')"); now a single arg is passed verbatim and multiple args are individually single-quoted.

- Behavior: Single-string snippets are unchanged; multi-arg calls retain exact argv when executed via a POSIX shell.
- Implementation: Replace strings.Join with buildCommand(...) and shellQuote(...) using single-quote escaping.
- Tests: Add single-arg passthrough and /bin/sh round-trip cases covering spaces, quotes, $, &&, pipes, globs, empty, and backslash/tab.
- Compatibility: Toolbox API remains a single command string; works with sh/bash/zsh. No migration required.

<sup>Written for commit e93d516a19d3f6fddc352a14fad61a9f6ee073af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

