### PR TITLE
fix(sdk-typescript): set a Workers-compatible fetch cache mode, bump wrangler fixture

### DIFF
--- a/sdk-typescript/runtime-tests/cloudflare-workers/package.json
+++ b/sdk-typescript/runtime-tests/cloudflare-workers/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "wrangler": "^3.78.0"
+    "wrangler": "^4.127.1"
   }
 }

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -1013,6 +1013,10 @@ export class Daytona implements AsyncDisposable {
   public static createAxiosInstance(requestTimeoutMs?: number): AxiosInstance {
     const axiosInstance = axios.create({
       timeout: requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      // Cloudflare Workers' runtime rejects the `cache: 'default'` that axios'
+      // fetch adapter would otherwise apply, so set a mode workerd accepts.
+      // Ignored by the Node http adapter. API responses are not cacheable anyway.
+      fetchOptions: { cache: 'no-store' },
     })
 
     // Request interceptor: Inject trace context into headers


### PR DESCRIPTION
## Summary

Fixes the `TypeScript SDK runtime compatibility` job, which has been failing on
`main` since roughly 2026-08-24. There were **two stacked problems**, and the
second one affects real SDK consumers today.

## 1. axios 1.20.0 breaks Cloudflare Workers (user-facing)

axios 1.20.0 added a `DEFAULT_REQUEST_OPTIONS` constant that applies
`cache: 'default'` to the `Request` its fetch adapter builds. workerd rejects
that value, so **every SDK API call from a Worker fails**:

```
DaytonaError: Unsupported cache mode: default
  at createAxiosDaytonaError (sdk-typescript/src/errors/DaytonaError.ts:371)
  at Daytona.ts:1044
  at async Axios.request (axios/lib/core/Axios.js:42)
```

axios 1.19.0 had no such constant. The published `@daytona/sdk` declares
`axios: ^1.19.0`, so anyone installing after 1.20.0 shipped resolves it and is
broken on any API call.

axios only applies those defaults when the value is `undefined`, so passing an
explicit mode is sufficient:

```ts
fetchOptions: { cache: 'no-store' }
```

This is set once, on the single `axios.create` in `Daytona.createAxiosInstance`,
so it covers every SDK call. It deliberately avoids constraining the axios range:
no upper bound is added, future 1.20.x fixes flow through normally, and the
publish pipeline is untouched. The option is ignored by the Node http adapter,
and `no-store` is the correct semantic for these requests regardless — they are
authenticated, dynamic API calls that must not be served from a cache.

## 2. wrangler 3 can no longer bundle the fixture

The `cloudflare-workers` fixture pinned `wrangler: ^3.78.0`, which resolves to
3.114.17 (published 2026-01-13). That version exact-pins
`@cloudflare/unenv-preset 2.0.2`, whose `/node/console` and `/node/process`
subpaths no longer resolve, so `wrangler dev` never became ready and the fixture
timed out after 30s. The only thing CI surfaced was a bare `Killed` line from the
cleanup trap — the real error goes to `/tmp/wrangler-runtime.log`, which is never
uploaded. That is why this looked opaque, and it had been masking the axios
problem above.

Bumped to `wrangler: ^4.127.1`. `--local` is still supported in v4, so `run.sh`
needs no change.

## Verification

Verified with axios resolving to **1.20.0** — the broken version, with no pin and
no npm overrides — so this proves the fix rather than sidestepping it:

- `cloudflare-workers`: `{"imageOk":true,"listOk":true}`, passes in 9s
- `node-esm`, `node-cjs`, `vite-browser` pass, covering the http, fetch and
  browser adapter paths
- sdk-typescript unit 296/296; `lint:ts` 0 errors
- Confirmed pre-existing on `main`: the identical failure reproduces on an
  unmodified `origin/main` worktree, so it was not introduced by #218
- Diagnosis confirmed by bisection: wrangler 4 + axios 1.20.0 fails with the
  cache error; wrangler 4 + axios 1.19.0 passes; wrangler 4 + axios 1.20.0 + this
  fix passes

The full 14-fixture sweep needs `bun`/`deno`/`func`, which are not installed on
the dev box — CI covers those.

## Note on unrelated CI failures

Earlier runs on this branch failed `Unit tests`, `Go lint (cli)` and
`Format, lint, generate clients and docs` because Go's module infrastructure was
returning HTTP/2 `INTERNAL_ERROR`:

```
reading https://sum.golang.org/tile/8/0/x229/305: stream error: INTERNAL_ERROR
read "https://proxy.golang.org/.../gomarkdoc/@v/v1.1.0.zip": stream error: INTERNAL_ERROR
```

This PR touches no Go files. Two of the three recovered on re-run; the Format job
may need another re-run once the upstream outage clears.

## Follow-up worth considering separately

`run.sh` deletes `package-lock.json` and installs fresh on every run, so the
fixtures have no reproducibility guard and drift silently with upstream
publishes. That is the underlying reason this broke unnoticed for a week, and it
applies to all 14 fixtures. Committing lockfiles would trade "always test against
latest" for "test reproducibly" — a deliberate decision rather than something to
fold into this fix.
