### PR TITLE
fix(sdk-python): raise typed Daytona errors from VolumeService

### DIFF
--- a/artifacts/sdk-docs/python-sdk/async/async-volume.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-volume.mdx
@@ -55,7 +55,6 @@ async with AsyncDaytona() as daytona:
 #### AsyncVolumeService.get
 
 ```python
-@intercept_errors(message_prefix="Failed to get volume: ")
 @with_instrumentation()
 async def get(name: str, create: bool = False) -> Volume
 ```

--- a/artifacts/sdk-docs/python-sdk/async/async-volume.mdx
+++ b/artifacts/sdk-docs/python-sdk/async/async-volume.mdx
@@ -32,6 +32,7 @@ Service for managing Daytona Volumes. Can be used to list, get, create and delet
 #### AsyncVolumeService.list
 
 ```python
+@intercept_errors(message_prefix="Failed to list volumes: ")
 async def list() -> list[Volume]
 ```
 
@@ -54,6 +55,7 @@ async with AsyncDaytona() as daytona:
 #### AsyncVolumeService.get
 
 ```python
+@intercept_errors(message_prefix="Failed to get volume: ")
 @with_instrumentation()
 async def get(name: str, create: bool = False) -> Volume
 ```
@@ -82,6 +84,7 @@ async with AsyncDaytona() as daytona:
 #### AsyncVolumeService.create
 
 ```python
+@intercept_errors(message_prefix="Failed to create volume: ")
 @with_instrumentation()
 async def create(name: str) -> Volume
 ```
@@ -109,6 +112,7 @@ async with AsyncDaytona() as daytona:
 #### AsyncVolumeService.delete
 
 ```python
+@intercept_errors(message_prefix="Failed to delete volume: ")
 @with_instrumentation()
 async def delete(volume: Volume) -> None
 ```

--- a/artifacts/sdk-docs/python-sdk/sync/volume.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/volume.mdx
@@ -32,6 +32,7 @@ Service for managing Daytona Volumes. Can be used to list, get, create and delet
 #### VolumeService.list
 
 ```python
+@intercept_errors(message_prefix="Failed to list volumes: ")
 def list() -> list[Volume]
 ```
 
@@ -54,6 +55,7 @@ for volume in volumes:
 #### VolumeService.get
 
 ```python
+@intercept_errors(message_prefix="Failed to get volume: ")
 @with_instrumentation()
 def get(name: str, create: bool = False) -> Volume
 ```
@@ -82,6 +84,7 @@ print(f"{volume.name} ({volume.id})")
 #### VolumeService.create
 
 ```python
+@intercept_errors(message_prefix="Failed to create volume: ")
 @with_instrumentation()
 def create(name: str) -> Volume
 ```
@@ -109,6 +112,7 @@ print(f"{volume.name} ({volume.id}); state: {volume.state}")
 #### VolumeService.delete
 
 ```python
+@intercept_errors(message_prefix="Failed to delete volume: ")
 @with_instrumentation()
 def delete(volume: Volume) -> None
 ```

--- a/artifacts/sdk-docs/python-sdk/sync/volume.mdx
+++ b/artifacts/sdk-docs/python-sdk/sync/volume.mdx
@@ -55,7 +55,6 @@ for volume in volumes:
 #### VolumeService.get
 
 ```python
-@intercept_errors(message_prefix="Failed to get volume: ")
 @with_instrumentation()
 def get(name: str, create: bool = False) -> Volume
 ```

--- a/sdk-python/src/daytona/_async/volume.py
+++ b/sdk-python/src/daytona/_async/volume.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from daytona_api_client_async import CreateVolume, VolumesApi
 from daytona_api_client_async.exceptions import NotFoundException
 
+from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from ..common.volume import Volume
 
@@ -16,6 +17,7 @@ class AsyncVolumeService:
     def __init__(self, volumes_api: VolumesApi):
         self.__volumes_api = volumes_api
 
+    @intercept_errors(message_prefix="Failed to list volumes: ")
     async def list(self) -> list[Volume]:
         """List all Volumes.
 
@@ -32,6 +34,7 @@ class AsyncVolumeService:
         """
         return [Volume.from_dto(volume) for volume in await self.__volumes_api.list_volumes()]
 
+    @intercept_errors(message_prefix="Failed to get volume: ")
     @with_instrumentation()
     async def get(self, name: str, create: bool = False) -> Volume:
         """Get a Volume by name.
@@ -57,6 +60,7 @@ class AsyncVolumeService:
                 return await self.create(name)
             raise e
 
+    @intercept_errors(message_prefix="Failed to create volume: ")
     @with_instrumentation()
     async def create(self, name: str) -> Volume:
         """Create a new Volume.
@@ -76,6 +80,7 @@ class AsyncVolumeService:
         """
         return Volume.from_dto(await self.__volumes_api.create_volume(CreateVolume(name=name)))
 
+    @intercept_errors(message_prefix="Failed to delete volume: ")
     @with_instrumentation()
     async def delete(self, volume: Volume) -> None:
         """Delete a Volume.

--- a/sdk-python/src/daytona/_async/volume.py
+++ b/sdk-python/src/daytona/_async/volume.py
@@ -4,10 +4,10 @@
 from __future__ import annotations
 
 from daytona_api_client_async import CreateVolume, VolumesApi
-from daytona_api_client_async.exceptions import NotFoundException
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
+from ..common.errors import DaytonaNotFoundError
 from ..common.volume import Volume
 
 
@@ -35,6 +35,9 @@ class AsyncVolumeService:
         return [Volume.from_dto(volume) for volume in await self.__volumes_api.list_volumes()]
 
     @intercept_errors(message_prefix="Failed to get volume: ")
+    async def __get(self, name: str) -> Volume:
+        return Volume.from_dto(await self.__volumes_api.get_volume_by_name(name))
+
     @with_instrumentation()
     async def get(self, name: str, create: bool = False) -> Volume:
         """Get a Volume by name.
@@ -54,11 +57,11 @@ class AsyncVolumeService:
             ```
         """
         try:
-            return Volume.from_dto(await self.__volumes_api.get_volume_by_name(name))
-        except NotFoundException as e:
+            return await self.__get(name)
+        except DaytonaNotFoundError:
             if create:
                 return await self.create(name)
-            raise e
+            raise
 
     @intercept_errors(message_prefix="Failed to create volume: ")
     @with_instrumentation()

--- a/sdk-python/src/daytona/_sync/volume.py
+++ b/sdk-python/src/daytona/_sync/volume.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from daytona_api_client import CreateVolume, VolumesApi
 from daytona_api_client.exceptions import NotFoundException
 
+from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from ..common.volume import Volume
 
@@ -16,6 +17,7 @@ class VolumeService:
     def __init__(self, volumes_api: VolumesApi):
         self.__volumes_api = volumes_api
 
+    @intercept_errors(message_prefix="Failed to list volumes: ")
     def list(self) -> list[Volume]:
         """List all Volumes.
 
@@ -32,6 +34,7 @@ class VolumeService:
         """
         return [Volume.from_dto(volume) for volume in self.__volumes_api.list_volumes()]
 
+    @intercept_errors(message_prefix="Failed to get volume: ")
     @with_instrumentation()
     def get(self, name: str, create: bool = False) -> Volume:
         """Get a Volume by name.
@@ -57,6 +60,7 @@ class VolumeService:
                 return self.create(name)
             raise e
 
+    @intercept_errors(message_prefix="Failed to create volume: ")
     @with_instrumentation()
     def create(self, name: str) -> Volume:
         """Create a new Volume.
@@ -76,6 +80,7 @@ class VolumeService:
         """
         return Volume.from_dto(self.__volumes_api.create_volume(CreateVolume(name=name)))
 
+    @intercept_errors(message_prefix="Failed to delete volume: ")
     @with_instrumentation()
     def delete(self, volume: Volume) -> None:
         """Delete a Volume.

--- a/sdk-python/src/daytona/_sync/volume.py
+++ b/sdk-python/src/daytona/_sync/volume.py
@@ -4,10 +4,10 @@
 from __future__ import annotations
 
 from daytona_api_client import CreateVolume, VolumesApi
-from daytona_api_client.exceptions import NotFoundException
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
+from ..common.errors import DaytonaNotFoundError
 from ..common.volume import Volume
 
 
@@ -35,6 +35,9 @@ class VolumeService:
         return [Volume.from_dto(volume) for volume in self.__volumes_api.list_volumes()]
 
     @intercept_errors(message_prefix="Failed to get volume: ")
+    def __get(self, name: str) -> Volume:
+        return Volume.from_dto(self.__volumes_api.get_volume_by_name(name))
+
     @with_instrumentation()
     def get(self, name: str, create: bool = False) -> Volume:
         """Get a Volume by name.
@@ -54,11 +57,11 @@ class VolumeService:
             ```
         """
         try:
-            return Volume.from_dto(self.__volumes_api.get_volume_by_name(name))
-        except NotFoundException as e:
+            return self.__get(name)
+        except DaytonaNotFoundError:
             if create:
                 return self.create(name)
-            raise e
+            raise
 
     @intercept_errors(message_prefix="Failed to create volume: ")
     @with_instrumentation()

--- a/sdk-python/tests/test_volume.py
+++ b/sdk-python/tests/test_volume.py
@@ -7,8 +7,23 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from daytona.common.errors import DaytonaNotFoundError, DaytonaRateLimitError
 from daytona.common.volume import Volume
 from daytona_api_client import VolumeDto
+
+
+def _make_rate_limited_response():
+    """Minimal stand-in for the urllib3/aiohttp response an ApiException wraps."""
+    response = MagicMock()
+    response.status = 429
+    response.reason = "Too Many Requests"
+    response.data = b'{"statusCode":429,"message":"ThrottlerException: Too Many Requests"}'
+    response.headers = {
+        "Retry-After": "10",
+        "X-RateLimit-Limit-failed-auth": "20",
+        "X-RateLimit-Remaining-failed-auth": "0",
+    }
+    return response
 
 
 def _make_volume_dto(name="test-vol", vol_id="vol-123"):
@@ -72,8 +87,31 @@ class TestSyncVolumeService:
 
         service, api = self._make_service()
         api.get_volume_by_name.side_effect = NotFoundException(status=404, reason="Not found")
-        with pytest.raises(NotFoundException):
+        with pytest.raises(DaytonaNotFoundError):
             service.get("nonexistent")
+
+    @pytest.mark.parametrize(
+        ("method", "api_method", "call"),
+        [
+            ("list", "list_volumes", lambda service: service.list()),
+            ("get", "get_volume_by_name", lambda service: service.get("test-vol")),
+            ("create", "create_volume", lambda service: service.create("test-vol")),
+            ("delete", "delete_volume", lambda service: service.delete(_make_volume())),
+        ],
+    )
+    def test_rate_limit_raises_typed_error(self, method, api_method, call):
+        from daytona_api_client.exceptions import ApiException
+
+        service, api = self._make_service()
+        getattr(api, api_method).side_effect = ApiException(
+            status=429, reason="Too Many Requests", http_resp=_make_rate_limited_response()
+        )
+
+        with pytest.raises(DaytonaRateLimitError) as exc_info:
+            call(service)
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.headers["Retry-After"] == "10"
 
     def test_create(self):
         service, api = self._make_service()
@@ -137,3 +175,36 @@ class TestAsyncVolumeService:
 
         assert isinstance(result, Volume)
         api.create_volume.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_not_found_raises(self):
+        from daytona_api_client_async.exceptions import NotFoundException
+
+        service, api = self._make_service()
+        api.get_volume_by_name.side_effect = NotFoundException(status=404, reason="Not found")
+        with pytest.raises(DaytonaNotFoundError):
+            await service.get("nonexistent")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method", "api_method", "call"),
+        [
+            ("list", "list_volumes", lambda service: service.list()),
+            ("get", "get_volume_by_name", lambda service: service.get("test-vol")),
+            ("create", "create_volume", lambda service: service.create("test-vol")),
+            ("delete", "delete_volume", lambda service: service.delete(_make_volume())),
+        ],
+    )
+    async def test_rate_limit_raises_typed_error(self, method, api_method, call):
+        from daytona_api_client_async.exceptions import ApiException
+
+        service, api = self._make_service()
+        getattr(api, api_method).side_effect = ApiException(
+            status=429, reason="Too Many Requests", http_resp=_make_rate_limited_response()
+        )
+
+        with pytest.raises(DaytonaRateLimitError) as exc_info:
+            await call(service)
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.headers["Retry-After"] == "10"

--- a/sdk-python/tests/test_volume.py
+++ b/sdk-python/tests/test_volume.py
@@ -113,6 +113,21 @@ class TestSyncVolumeService:
         assert exc_info.value.status_code == 429
         assert exc_info.value.headers["Retry-After"] == "10"
 
+    def test_get_with_create_failure_is_prefixed_once(self):
+        from daytona_api_client.exceptions import ApiException, NotFoundException
+
+        service, api = self._make_service()
+        api.get_volume_by_name.side_effect = NotFoundException(status=404, reason="Not found")
+        api.create_volume.side_effect = ApiException(
+            status=429, reason="Too Many Requests", http_resp=_make_rate_limited_response()
+        )
+
+        with pytest.raises(DaytonaRateLimitError) as exc_info:
+            service.get("new-vol", create=True)
+
+        assert str(exc_info.value).startswith("Failed to create volume: ")
+        assert "Failed to get volume" not in str(exc_info.value)
+
     def test_create(self):
         service, api = self._make_service()
         api.create_volume.return_value = _make_volume_dto(name="new-vol")
@@ -208,3 +223,19 @@ class TestAsyncVolumeService:
 
         assert exc_info.value.status_code == 429
         assert exc_info.value.headers["Retry-After"] == "10"
+
+    @pytest.mark.asyncio
+    async def test_get_with_create_failure_is_prefixed_once(self):
+        from daytona_api_client_async.exceptions import ApiException, NotFoundException
+
+        service, api = self._make_service()
+        api.get_volume_by_name.side_effect = NotFoundException(status=404, reason="Not found")
+        api.create_volume.side_effect = ApiException(
+            status=429, reason="Too Many Requests", http_resp=_make_rate_limited_response()
+        )
+
+        with pytest.raises(DaytonaRateLimitError) as exc_info:
+            await service.get("new-vol", create=True)
+
+        assert str(exc_info.value).startswith("Failed to create volume: ")
+        assert "Failed to get volume" not in str(exc_info.value)


### PR DESCRIPTION
## Problem

A customer reported that on Python SDK `0.201.0`, `volume.get()` surfaces HTTP 429 as a raw `daytona_api_client.exceptions.ApiException` instead of `DaytonaRateLimitError`, so their retry path — which catches the typed error — never engaged.

Confirmed, and it is not limited to `0.201.0`: `VolumeService` is the **only** top-level service missing the `@intercept_errors()` decorator, which is the sole mechanism that maps generated-client exceptions onto the `DaytonaError` hierarchy. Every `volume.*` method has leaked `ApiException` since `volume.py` was created.

Sweep of published wheels — `intercept_errors` occurrences:

| version | `_sync/volume.py` | `_async/volume.py` | `_sync/snapshot.py` |
| --- | --- | --- | --- |
| 0.196.0 → 0.207.0 (all) | 0 | 0 | 5 |

## Evidence (live API, SDK 0.207.0)

Both calls made against the same active rate-limit block:

```
volume.get()    : daytona_api_client.exceptions.ApiException   status=429  isDaytonaRateLimitError=False
snapshot.list() : daytona.common.errors.DaytonaRateLimitError  status=429  isDaytonaRateLimitError=True
```

The TypeScript SDK is **not** affected — verified the same way on `@daytona/sdk@0.207.0`, where `volume.get()`, `volume.list()` and `snapshot.list()` all raise `DaytonaRateLimitError` with `Retry-After` preserved. TS maps errors once in a shared axios response interceptor (`Daytona.createAxiosInstance`) rather than per method, so a service cannot be missed.

Worth noting for triage: this is easy to miss in the wild because the SDK sets `RemoteDisconnectedRetry(total=3, raise_on_status=False)` and urllib3 honours `Retry-After` on 429 for idempotent methods. Short blocks are silently retried and succeed; the raw `ApiException` only escapes once the retry budget is exhausted.

## Change

Add `@intercept_errors()` to `list` / `get` / `create` / `delete` on both `VolumeService` and `AsyncVolumeService`, with message prefixes matching `SnapshotService`.

## Behaviour change

`volume.get("missing")` (with `create=False`) now raises `DaytonaNotFoundError` instead of the generated `NotFoundException`, which aligns it with `SnapshotService` and the rest of the SDK. The `create=True` auto-create fallback is unchanged — it is handled inside the method body, before the decorator sees the error.

## Tests

- `test_get_not_found_raises` (sync + async, async one is new) now assert `DaytonaNotFoundError`.
- New parametrized `test_rate_limit_raises_typed_error` over all four methods, sync + async: asserts `DaytonaRateLimitError`, `status_code == 429`, and that `Retry-After` survives on `.headers`.
- All 10 new/updated tests fail on `main` and pass with this change.
- Full suite: `614 passed`. `isort` / `black` / `pylint` / `basedpyright` clean via the pre-commit hooks.

## Out of scope (follow-ups)

- The Ruby SDK has the same shape of gap: it maps errors via per-call-site `Sdk.wrap_error`, and `volume_service.rb`, `snapshot_service.rb`, `secret_service.rb` and `object_storage.rb` have zero call sites, so they leak `DaytonaApiClient::ApiError`. Broader than volumes, so not fixed here.
- Longer term, Python would be better served by mapping errors once at the ApiClient proxy layer (as TypeScript does) instead of relying on a decorator being remembered on every new method.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@intercept_errors()` to all four methods on `VolumeService` and `AsyncVolumeService` so volume calls raise typed `DaytonaError` subclasses instead of the generated client's raw `ApiException`. Previously every `volume.*` method leaked `ApiException` — most visibly, HTTP 429 surfaced raw instead of `DaytonaRateLimitError`, so retry paths keyed on the typed error never engaged.

Behavior change: `volume.get()` on a missing volume now raises `DaytonaNotFoundError` instead of the generated `NotFoundException`, matching `SnapshotService`. The `create=True` auto-create fallback is preserved; its raw fetch moved to a private `__get` method so fallback failures keep only create's single error prefix.

**Tests**
- Added sync and async tests asserting `DaytonaRateLimitError` on 429 with `Retry-After` preserved, `DaytonaNotFoundError` on missing volumes, and single-prefix fallback errors.

**Docs**
- Regenerated the sync and async Python SDK volume reference with the new decorators.

<sup>Written for commit 61094442386ce19bcf4cfeb7b07c14692f73a39b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

