### PR TITLE
fix(sdk-python): improve S3 upload reliability

### DIFF
--- a/sdk-python/src/daytona/_async/object_storage.py
+++ b/sdk-python/src/daytona/_async/object_storage.py
@@ -7,6 +7,7 @@ import hashlib
 import os
 import tarfile
 import threading
+from datetime import timedelta
 
 import aiofiles
 import aiofiles.os
@@ -49,6 +50,8 @@ class AsyncObjectStorage:
                 access_key_id=aws_access_key_id,
                 secret_access_key=aws_secret_access_key,
                 session_token=aws_session_token,
+                client_options={"timeout": timedelta(minutes=2)},
+                retry_config={"retry_timeout": timedelta(minutes=4)},
             )
 
     @with_instrumentation()
@@ -188,7 +191,7 @@ class AsyncObjectStorage:
             finally:
                 read_file.close()
 
-        _ = await self.store.put_async(s3_key, reader_iter())
+        _ = await self.store.put_async(s3_key, reader_iter(), max_concurrency=4)
         await asyncio.to_thread(thread.join)
 
     async def _async_os_walk(self, path: str) -> list[tuple[str, list[str], list[str]]]:

--- a/sdk-python/src/daytona/_sync/object_storage.py
+++ b/sdk-python/src/daytona/_sync/object_storage.py
@@ -7,6 +7,7 @@ import hashlib
 import os
 import tarfile
 import threading
+from datetime import timedelta
 
 from obstore.store import S3Store
 
@@ -47,6 +48,8 @@ class ObjectStorage:
                 access_key_id=aws_access_key_id,
                 secret_access_key=aws_secret_access_key,
                 session_token=aws_session_token,
+                client_options={"timeout": timedelta(minutes=2)},
+                retry_config={"retry_timeout": timedelta(minutes=4)},
             )
 
     @with_instrumentation()
@@ -185,5 +188,5 @@ class ObjectStorage:
             finally:
                 read_file.close()
 
-        _ = self.store.put(s3_key, reader_iter())
+        _ = self.store.put(s3_key, reader_iter(), max_concurrency=4)
         thread.join()

--- a/sdk-python/tests/test_async_object_storage.py
+++ b/sdk-python/tests/test_async_object_storage.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -24,12 +25,15 @@ def _make_async_storage():
 
 
 class TestAsyncObjectStorage:
-    def test_constructor_passes_region_to_store(self):
+    def test_constructor_configures_store(self):
         from daytona._async.object_storage import AsyncObjectStorage
 
         with patch("daytona._async.object_storage.S3Store") as mock_store_cls:
             AsyncObjectStorage("https://s3.us-west-2.amazonaws.com", "key", "secret", "token", region="ap-south-1")
-            assert mock_store_cls.call_args.kwargs["region"] == "ap-south-1"
+
+        assert mock_store_cls.call_args.kwargs["region"] == "ap-south-1"
+        assert mock_store_cls.call_args.kwargs["client_options"] == {"timeout": timedelta(minutes=2)}
+        assert mock_store_cls.call_args.kwargs["retry_config"] == {"retry_timeout": timedelta(minutes=4)}
 
     @pytest.mark.asyncio
     async def test_upload_missing_path_raises(self):
@@ -121,7 +125,7 @@ class TestAsyncObjectStorage:
 
         captured: dict[str, bytes] = {}
 
-        async def consume_stream(key: str, chunks):
+        async def consume_stream(key: str, chunks, **_kwargs):
             data = bytearray()
             async for chunk in chunks:
                 data.extend(chunk)
@@ -133,3 +137,4 @@ class TestAsyncObjectStorage:
 
         assert "org/hash/context.tar" in captured
         assert len(captured["org/hash/context.tar"]) > 0
+        assert store.put_async.call_args.kwargs == {"max_concurrency": 4}

--- a/sdk-python/tests/test_object_storage.py
+++ b/sdk-python/tests/test_object_storage.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -22,12 +23,15 @@ def _make_storage():
 
 
 class TestObjectStorage:
-    def test_constructor_passes_region_to_store(self):
+    def test_constructor_configures_store(self):
         from daytona._sync.object_storage import ObjectStorage
 
         with patch("daytona._sync.object_storage.S3Store") as mock_store_cls:
             ObjectStorage("https://s3.us-west-2.amazonaws.com", "key", "secret", "token", region="ap-south-1")
-            assert mock_store_cls.call_args.kwargs["region"] == "ap-south-1"
+
+        assert mock_store_cls.call_args.kwargs["region"] == "ap-south-1"
+        assert mock_store_cls.call_args.kwargs["client_options"] == {"timeout": timedelta(minutes=2)}
+        assert mock_store_cls.call_args.kwargs["retry_config"] == {"retry_timeout": timedelta(minutes=4)}
 
     def test_constructor_requires_region(self):
         from daytona._sync.object_storage import ObjectStorage
@@ -121,7 +125,7 @@ class TestObjectStorage:
 
         captured: dict[str, bytes] = {}
 
-        def consume_stream(key: str, chunks):
+        def consume_stream(key: str, chunks, **_kwargs):
             captured[key] = b"".join(chunks)
 
         store.put.side_effect = consume_stream
@@ -130,3 +134,4 @@ class TestObjectStorage:
 
         assert "org/hash/context.tar" in captured
         assert len(captured["org/hash/context.tar"]) > 0
+        assert store.put.call_args.kwargs == {"max_concurrency": 4}


### PR DESCRIPTION
## Description


S3 uploads could fail when transferring larger sandbox context archives because the client’s default request timeout and upload concurrency were too aggressive for slower or less stable connections.

This increases the request timeout to 2 minutes, allows retries for up to 4 minutes, and limits synchronous and asynchronous uploads to four concurrent operations. Tests cover the updated client configuration and upload concurrency."


## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses an issue reported by a customer

## Screenshots

<img width="656" height="512" alt="s3-issue" src="https://github.com/user-attachments/assets/1c616698-040d-4604-ba74-75053045c14d" />
