### PR TITLE
feat(api-client): add MI355X GPU type

### DIFF
--- a/api-client-go/api/openapi.yaml
+++ b/api-client-go/api/openapi.yaml
@@ -8368,6 +8368,7 @@ components:
       - RTX-PRO-6000
       - RTX-4090
       - RTX-5090
+      - MI355X
       type: string
       x-enum-varnames:
       - H100
@@ -8375,6 +8376,7 @@ components:
       - RTX_PRO_6000
       - RTX_4090
       - RTX_5090
+      - MI355X
     RegionUsageOverview:
       example:
         totalCpuQuota: 0.8008281904610115

--- a/api-client-go/model_gpu_type.go
+++ b/api-client-go/model_gpu_type.go
@@ -25,6 +25,7 @@ const (
 	GPUTYPE_RTX_PRO_6000 GpuType = "RTX-PRO-6000"
 	GPUTYPE_RTX_4090 GpuType = "RTX-4090"
 	GPUTYPE_RTX_5090 GpuType = "RTX-5090"
+	GPUTYPE_MI355X GpuType = "MI355X"
 	GPUTYPE_UNKNOWN_DEFAULT_OPEN_API GpuType = "11184809"
 )
 
@@ -35,6 +36,7 @@ var AllowedGpuTypeEnumValues = []GpuType{
 	"RTX-PRO-6000",
 	"RTX-4090",
 	"RTX-5090",
+	"MI355X",
 	"11184809",
 }
 

--- a/api-client-java/src/main/java/io/daytona/api/client/model/GpuType.java
+++ b/api-client-java/src/main/java/io/daytona/api/client/model/GpuType.java
@@ -39,6 +39,8 @@ public enum GpuType {
   
   RTX_5090("RTX-5090"),
   
+  MI355X("MI355X"),
+  
   UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 
   private String value;

--- a/api-client-python-async/daytona_api_client_async/models/gpu_type.py
+++ b/api-client-python-async/daytona_api_client_async/models/gpu_type.py
@@ -32,6 +32,7 @@ class GpuType(str, Enum):
     RTX_PRO_6000 = 'RTX-PRO-6000'
     RTX_4090 = 'RTX-4090'
     RTX_5090 = 'RTX-5090'
+    MI355X = 'MI355X'
     UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api'
 
     @classmethod

--- a/api-client-python/daytona_api_client/models/gpu_type.py
+++ b/api-client-python/daytona_api_client/models/gpu_type.py
@@ -32,6 +32,7 @@ class GpuType(str, Enum):
     RTX_PRO_6000 = 'RTX-PRO-6000'
     RTX_4090 = 'RTX-4090'
     RTX_5090 = 'RTX-5090'
+    MI355X = 'MI355X'
     UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api'
 
     @classmethod

--- a/api-client-ruby/lib/daytona_api_client/models/gpu_type.rb
+++ b/api-client-ruby/lib/daytona_api_client/models/gpu_type.rb
@@ -20,10 +20,11 @@ module DaytonaApiClient
     RTX_PRO_6000 = "RTX-PRO-6000".freeze
     RTX_4090 = "RTX-4090".freeze
     RTX_5090 = "RTX-5090".freeze
+    MI355X = "MI355X".freeze
     UNKNOWN_DEFAULT_OPEN_API = "unknown_default_open_api".freeze
 
     def self.all_vars
-      @all_vars ||= [H100, H200, RTX_PRO_6000, RTX_4090, RTX_5090, UNKNOWN_DEFAULT_OPEN_API].freeze
+      @all_vars ||= [H100, H200, RTX_PRO_6000, RTX_4090, RTX_5090, MI355X, UNKNOWN_DEFAULT_OPEN_API].freeze
     end
 
     # Builds the enum from string

--- a/api-client/src/models/gpu-type.ts
+++ b/api-client/src/models/gpu-type.ts
@@ -21,6 +21,7 @@ export const GpuType = {
     RTX_PRO_6000: 'RTX-PRO-6000',
     RTX_4090: 'RTX-4090',
     RTX_5090: 'RTX-5090',
+    MI355X: 'MI355X',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 

--- a/artifacts/sdk-docs/go-sdk/types.mdx
+++ b/artifacts/sdk-docs/go-sdk/types.mdx
@@ -368,7 +368,7 @@ type GitStatus struct {
 <a name="GpuType"></a>
 ## type GpuType
 
-GpuType identifies a specific NVIDIA GPU model. Used in \[Resources.GpuType\] as an ordered preference list — the scheduler tries each in order and pins the sandbox/snapshot to the first that has capacity. It is an alias for the API client's GpuType type.
+GpuType identifies a specific GPU model. Used in \[Resources.GpuType\] as an ordered preference list — the scheduler tries each in order and pins the sandbox/snapshot to the first that has capacity. It is an alias for the API client's GpuType type.
 
 ```go
 type GpuType = apiclient.GpuType
@@ -380,6 +380,7 @@ type GpuType = apiclient.GpuType
 const (
     GpuTypeH100       GpuType = apiclient.GPUTYPE_H100
     GpuTypeRtxPro6000 GpuType = apiclient.GPUTYPE_RTX_PRO_6000
+    GpuTypeMI355X     GpuType = apiclient.GPUTYPE_MI355X
 )
 ```
 

--- a/openapi-specs/api.json
+++ b/openapi-specs/api.json
@@ -11950,14 +11950,16 @@
           "H200",
           "RTX-PRO-6000",
           "RTX-4090",
-          "RTX-5090"
+          "RTX-5090",
+          "MI355X"
         ],
         "x-enum-varnames": [
           "H100",
           "H200",
           "RTX_PRO_6000",
           "RTX_4090",
-          "RTX_5090"
+          "RTX_5090",
+          "MI355X"
         ]
       },
       "RegionUsageOverview": {

--- a/sdk-go/pkg/types/types.go
+++ b/sdk-go/pkg/types/types.go
@@ -22,7 +22,7 @@ const (
 	CodeLanguageTypeScript CodeLanguage = "typescript"
 )
 
-// GpuType identifies a specific NVIDIA GPU model. Used in [Resources.GpuType]
+// GpuType identifies a specific GPU model. Used in [Resources.GpuType]
 // as an ordered preference list — the scheduler tries each in order and pins
 // the sandbox/snapshot to the first that has capacity. It is an alias for the
 // API client's GpuType type.
@@ -31,6 +31,7 @@ type GpuType = apiclient.GpuType
 const (
 	GpuTypeH100       GpuType = apiclient.GPUTYPE_H100
 	GpuTypeRtxPro6000 GpuType = apiclient.GPUTYPE_RTX_PRO_6000
+	GpuTypeMI355X     GpuType = apiclient.GPUTYPE_MI355X
 )
 
 // SandboxClass determines which runners can host sandboxes created from a snapshot.


### PR DESCRIPTION
Adds `MI355X` (AMD Instinct MI355X) to the `GpuType` enum in
`openapi-specs/api.json` and regenerates the
six API clients (TypeScript, Go, Python sync/async, Java, Ruby) with the
pinned openapi-generator 7.21.0. The diff is the spec plus one enum file per
client. Without this the SDKs deserialize the value to the unknown-default
sentinel and cannot request the type by name.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the AMD Instinct MI355X to the `GpuType` enum in the OpenAPI spec, regenerates all six API clients, and adds the `sdk-go` convenience constant. Clients previously fell back to `unknown_default_open_api`, so callers could not request this GPU type by name.

- Regenerates the Go SDK reference docs and removes the NVIDIA qualifier from the `GpuType` comment.

<sup>Written for commit dd1bdfcc929b2d4bada46d50e1d6402579f57333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



