### PR TITLE
fix(cli): build context archive path and COPY source resolution

### DIFF
--- a/cli/cmd/common/build.go
+++ b/cli/cmd/common/build.go
@@ -110,6 +110,16 @@ func getContextHashes(ctx context.Context, apiClient *apiclient.APIClient, conte
 	return contextHashes, nil
 }
 
+// ensureWithinBuildContext mirrors `docker build`, which refuses COPY/ADD
+// sources that resolve outside the build context.
+func ensureWithinBuildContext(dockerfileDir, resolvedPath, originalPath string) error {
+	rel, err := filepath.Rel(dockerfileDir, resolvedPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("forbidden path outside the build context: %s", originalPath)
+	}
+	return nil
+}
+
 func parseDockerfileForSources(dockerfileContent string, dockerfileDir string) ([]string, error) {
 	var sources []string
 	lines := strings.Split(dockerfileContent, "\n")
@@ -144,20 +154,30 @@ func parseDockerfileForSources(dockerfileContent string, dockerfileDir string) (
 				}
 
 				// Convert relative paths to absolute paths relative to Dockerfile directory
-				if !filepath.IsAbs(srcPath) {
-					srcPath = filepath.Join(dockerfileDir, srcPath)
+				resolvedPath := srcPath
+				if !filepath.IsAbs(resolvedPath) {
+					resolvedPath = filepath.Join(dockerfileDir, resolvedPath)
 				}
 
-				srcPath = filepath.Clean(srcPath)
+				resolvedPath = filepath.Clean(resolvedPath)
+
+				if err := ensureWithinBuildContext(dockerfileDir, resolvedPath, srcPath); err != nil {
+					return nil, err
+				}
 
 				// Check if path exists and add to sources
-				if _, err := os.Stat(srcPath); err == nil {
-					sources = append(sources, srcPath)
+				if _, err := os.Stat(resolvedPath); err == nil {
+					sources = append(sources, resolvedPath)
 				} else {
 					// If exact path doesn't exist, try to match glob patterns
-					matches, err := filepath.Glob(srcPath)
-					if err == nil && len(matches) > 0 {
-						sources = append(sources, matches...)
+					globMatches, err := filepath.Glob(resolvedPath)
+					if err == nil {
+						for _, match := range globMatches {
+							if err := ensureWithinBuildContext(dockerfileDir, match, srcPath); err != nil {
+								return nil, err
+							}
+							sources = append(sources, match)
+						}
 					}
 				}
 			}

--- a/cli/cmd/common/build.go
+++ b/cli/cmd/common/build.go
@@ -110,10 +110,28 @@ func getContextHashes(ctx context.Context, apiClient *apiclient.APIClient, conte
 	return contextHashes, nil
 }
 
-// ensureWithinBuildContext mirrors `docker build`, which refuses COPY/ADD
-// sources that resolve outside the build context.
+// resolveContextSource mirrors how `docker build` interprets a COPY/ADD source:
+// a leading separator and any parent-directory navigation are stripped, so the
+// source always names something inside the build context.
+func resolveContextSource(dockerfileDir, srcPath string) string {
+	contextRelative := filepath.Clean(string(filepath.Separator) + srcPath)[1:]
+	return filepath.Join(dockerfileDir, contextRelative)
+}
+
+// ensureWithinBuildContext rejects a source that leaves the build context by
+// following a symlink, which is the case `docker build` reports as a forbidden
+// path. Both paths are resolved or neither, so that a build context reached
+// through a symlinked parent is not mistaken for an escape.
 func ensureWithinBuildContext(dockerfileDir, resolvedPath, originalPath string) error {
-	rel, err := filepath.Rel(dockerfileDir, resolvedPath)
+	contextRoot, candidate := dockerfileDir, resolvedPath
+
+	realContext, contextErr := filepath.EvalSymlinks(contextRoot)
+	realCandidate, candidateErr := filepath.EvalSymlinks(candidate)
+	if contextErr == nil && candidateErr == nil {
+		contextRoot, candidate = realContext, realCandidate
+	}
+
+	rel, err := filepath.Rel(contextRoot, candidate)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return fmt.Errorf("forbidden path outside the build context: %s", originalPath)
 	}
@@ -153,20 +171,13 @@ func parseDockerfileForSources(dockerfileContent string, dockerfileDir string) (
 					continue
 				}
 
-				// Convert relative paths to absolute paths relative to Dockerfile directory
-				resolvedPath := srcPath
-				if !filepath.IsAbs(resolvedPath) {
-					resolvedPath = filepath.Join(dockerfileDir, resolvedPath)
-				}
-
-				resolvedPath = filepath.Clean(resolvedPath)
-
-				if err := ensureWithinBuildContext(dockerfileDir, resolvedPath, srcPath); err != nil {
-					return nil, err
-				}
+				resolvedPath := resolveContextSource(dockerfileDir, srcPath)
 
 				// Check if path exists and add to sources
 				if _, err := os.Stat(resolvedPath); err == nil {
+					if err := ensureWithinBuildContext(dockerfileDir, resolvedPath, srcPath); err != nil {
+						return nil, err
+					}
 					sources = append(sources, resolvedPath)
 				} else {
 					// If exact path doesn't exist, try to match glob patterns

--- a/cli/cmd/common/build_test.go
+++ b/cli/cmd/common/build_test.go
@@ -135,17 +135,57 @@ func TestParseDockerfileDoesNotReachOutsideContext(t *testing.T) {
 		},
 	}
 
+	// The outside files exist and are named by every Dockerfile below, so an
+	// empty result means resolution genuinely never reached them.
+	for _, path := range []string{
+		filepath.Join(siblingDir, "outside.txt"),
+		filepath.Join(siblingDir, "outside.conf"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("fixture %s should exist: %v", path, err)
+		}
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sources, err := parseDockerfileForSources(tt.dockerfile, contextDir)
 			if err != nil {
 				t.Fatalf("parseDockerfileForSources returned an error: %v", err)
 			}
-			for _, source := range sources {
-				rel, relErr := filepath.Rel(contextDir, source)
-				if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-					t.Errorf("source %s resolves outside the build context %s", source, contextDir)
-				}
+			if len(sources) != 0 {
+				t.Fatalf("expected the source to resolve to nothing inside the context, got %v", sources)
+			}
+		})
+	}
+}
+
+func TestParseDockerfileClampsOutsideSourcesIntoContext(t *testing.T) {
+	contextDir, _ := newBuildContext(t)
+
+	// Same base name inside the context as in the sibling directory, so the
+	// resolved path proves which one was selected.
+	if err := os.WriteFile(filepath.Join(contextDir, "outside.txt"), []byte("in context"), 0o644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		dockerfile string
+	}{
+		{name: "parent relative", dockerfile: "FROM alpine\nCOPY ../outside.txt /app/outside.txt\n"},
+		{name: "repeated parent relative", dockerfile: "FROM alpine\nADD ../../../outside.txt /app/outside.txt\n"},
+		{name: "absolute", dockerfile: "FROM alpine\nCOPY /outside.txt /app/outside.txt\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sources, err := parseDockerfileForSources(tt.dockerfile, contextDir)
+			if err != nil {
+				t.Fatalf("parseDockerfileForSources returned an error: %v", err)
+			}
+			want := []string{filepath.Join(contextDir, "outside.txt")}
+			if !slices.Equal(sources, want) {
+				t.Errorf("sources = %v, want %v", sources, want)
 			}
 		})
 	}

--- a/cli/cmd/common/build_test.go
+++ b/cli/cmd/common/build_test.go
@@ -6,6 +6,7 @@ package common
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -42,58 +43,7 @@ func newBuildContext(t *testing.T) (contextDir string, siblingDir string) {
 	return contextDir, siblingDir
 }
 
-func TestParseDockerfileRejectsSourcesOutsideContext(t *testing.T) {
-	contextDir, siblingDir := newBuildContext(t)
-
-	tests := []struct {
-		name       string
-		dockerfile string
-		wantInErr  string
-	}{
-		{
-			name:       "absolute path",
-			dockerfile: "FROM alpine\nCOPY " + filepath.Join(siblingDir, "outside.txt") + " /app/outside.txt\n",
-			wantInErr:  filepath.Join(siblingDir, "outside.txt"),
-		},
-		{
-			name:       "relative path above the context",
-			dockerfile: "FROM alpine\nCOPY ../sibling/outside.txt /app/outside.txt\n",
-			wantInErr:  "../sibling/outside.txt",
-		},
-		{
-			name:       "glob above the context",
-			dockerfile: "FROM alpine\nCOPY ../sibling/*.conf /app/\n",
-			wantInErr:  "../sibling/*.conf",
-		},
-		{
-			name:       "ADD with a relative path above the context",
-			dockerfile: "FROM alpine\nADD ../sibling/outside.txt /app/outside.txt\n",
-			wantInErr:  "../sibling/outside.txt",
-		},
-		{
-			name:       "absolute path behind a chown flag",
-			dockerfile: "FROM alpine\nCOPY --chown=1:1 " + filepath.Join(siblingDir, "outside.txt") + " /app/outside.txt\n",
-			wantInErr:  filepath.Join(siblingDir, "outside.txt"),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sources, err := parseDockerfileForSources(tt.dockerfile, contextDir)
-			if err == nil {
-				t.Fatalf("expected an error, got sources %v", sources)
-			}
-			if !strings.Contains(err.Error(), "forbidden path outside the build context") {
-				t.Errorf("error = %q, want it to mention the build context", err)
-			}
-			if !strings.Contains(err.Error(), tt.wantInErr) {
-				t.Errorf("error = %q, want it to name %q", err, tt.wantInErr)
-			}
-		})
-	}
-}
-
-func TestParseDockerfileAcceptsSourcesInsideContext(t *testing.T) {
+func TestParseDockerfileResolvesSourcesInsideContext(t *testing.T) {
 	contextDir, _ := newBuildContext(t)
 
 	tests := []struct {
@@ -121,6 +71,26 @@ func TestParseDockerfileAcceptsSourcesInsideContext(t *testing.T) {
 			dockerfile: "FROM alpine\nCOPY . /app\n",
 			want:       []string{contextDir},
 		},
+		{
+			name:       "absolute path is read relative to the context root",
+			dockerfile: "FROM alpine\nCOPY /src/file.txt /app/file.txt\n",
+			want:       []string{filepath.Join(contextDir, "src", "file.txt")},
+		},
+		{
+			name:       "absolute path behind a chown flag",
+			dockerfile: "FROM alpine\nCOPY --chown=1:1 /note.txt /app/note.txt\n",
+			want:       []string{filepath.Join(contextDir, "note.txt")},
+		},
+		{
+			name:       "parent navigation is stripped",
+			dockerfile: "FROM alpine\nCOPY ../note.txt /app/note.txt\n",
+			want:       []string{filepath.Join(contextDir, "note.txt")},
+		},
+		{
+			name:       "ADD parent navigation is stripped",
+			dockerfile: "FROM alpine\nADD ../../src/file.txt /app/file.txt\n",
+			want:       []string{filepath.Join(contextDir, "src", "file.txt")},
+		},
 	}
 
 	for _, tt := range tests {
@@ -133,5 +103,126 @@ func TestParseDockerfileAcceptsSourcesInsideContext(t *testing.T) {
 				t.Errorf("sources = %v, want %v", sources, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseDockerfileDoesNotReachOutsideContext(t *testing.T) {
+	contextDir, siblingDir := newBuildContext(t)
+
+	tests := []struct {
+		name       string
+		dockerfile string
+	}{
+		{
+			name:       "absolute host path",
+			dockerfile: "FROM alpine\nCOPY " + filepath.Join(siblingDir, "outside.txt") + " /app/outside.txt\n",
+		},
+		{
+			name:       "relative path above the context",
+			dockerfile: "FROM alpine\nCOPY ../sibling/outside.txt /app/outside.txt\n",
+		},
+		{
+			name:       "glob above the context",
+			dockerfile: "FROM alpine\nCOPY ../sibling/*.conf /app/\n",
+		},
+		{
+			name:       "ADD with a relative path above the context",
+			dockerfile: "FROM alpine\nADD ../sibling/outside.txt /app/outside.txt\n",
+		},
+		{
+			name:       "absolute host path behind a chown flag",
+			dockerfile: "FROM alpine\nCOPY --chown=1:1 " + filepath.Join(siblingDir, "outside.txt") + " /app/outside.txt\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sources, err := parseDockerfileForSources(tt.dockerfile, contextDir)
+			if err != nil {
+				t.Fatalf("parseDockerfileForSources returned an error: %v", err)
+			}
+			for _, source := range sources {
+				rel, relErr := filepath.Rel(contextDir, source)
+				if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+					t.Errorf("source %s resolves outside the build context %s", source, contextDir)
+				}
+			}
+		})
+	}
+}
+
+func TestParseDockerfileRejectsSymlinkedSourcesOutsideContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	contextDir, siblingDir := newBuildContext(t)
+
+	links := map[string]string{
+		filepath.Join(contextDir, "leak.txt"): filepath.Join(siblingDir, "outside.txt"),
+		filepath.Join(contextDir, "leakdir"):  siblingDir,
+	}
+	for link, target := range links {
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatalf("failed to create symlink %s: %v", link, err)
+		}
+	}
+
+	tests := []struct {
+		name       string
+		dockerfile string
+		wantInErr  string
+	}{
+		{
+			name:       "symlinked file",
+			dockerfile: "FROM alpine\nCOPY leak.txt /app/leak.txt\n",
+			wantInErr:  "leak.txt",
+		},
+		{
+			name:       "file through a symlinked directory",
+			dockerfile: "FROM alpine\nCOPY leakdir/outside.txt /app/outside.txt\n",
+			wantInErr:  "leakdir/outside.txt",
+		},
+		{
+			name:       "glob through a symlinked directory",
+			dockerfile: "FROM alpine\nCOPY leakdir/*.conf /app/\n",
+			wantInErr:  "leakdir/*.conf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sources, err := parseDockerfileForSources(tt.dockerfile, contextDir)
+			if err == nil {
+				t.Fatalf("expected an error, got sources %v", sources)
+			}
+			if !strings.Contains(err.Error(), "forbidden path outside the build context") {
+				t.Errorf("error = %q, want it to mention the build context", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantInErr) {
+				t.Errorf("error = %q, want it to name %q", err, tt.wantInErr)
+			}
+		})
+	}
+}
+
+func TestParseDockerfileAllowsSymlinksInsideContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	contextDir, _ := newBuildContext(t)
+
+	link := filepath.Join(contextDir, "alias.txt")
+	if err := os.Symlink(filepath.Join(contextDir, "note.txt"), link); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	sources, err := parseDockerfileForSources("FROM alpine\nCOPY alias.txt /app/alias.txt\n", contextDir)
+	if err != nil {
+		t.Fatalf("parseDockerfileForSources returned an error: %v", err)
+	}
+	if !slices.Equal(sources, []string{link}) {
+		t.Errorf("sources = %v, want %v", sources, []string{link})
 	}
 }

--- a/cli/cmd/common/build_test.go
+++ b/cli/cmd/common/build_test.go
@@ -1,0 +1,137 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// newBuildContext returns a context directory containing src/file.txt and
+// note.txt, alongside a sibling directory holding outside.txt and outside.conf.
+func newBuildContext(t *testing.T) (contextDir string, siblingDir string) {
+	t.Helper()
+
+	root := t.TempDir()
+	contextDir = filepath.Join(root, "context")
+	siblingDir = filepath.Join(root, "sibling")
+
+	if err := os.MkdirAll(filepath.Join(contextDir, "src"), 0o755); err != nil {
+		t.Fatalf("failed to create context directory: %v", err)
+	}
+	if err := os.MkdirAll(siblingDir, 0o755); err != nil {
+		t.Fatalf("failed to create sibling directory: %v", err)
+	}
+
+	files := map[string]string{
+		filepath.Join(contextDir, "src", "file.txt"): "context file",
+		filepath.Join(contextDir, "note.txt"):        "context note",
+		filepath.Join(siblingDir, "outside.txt"):     "outside file",
+		filepath.Join(siblingDir, "outside.conf"):    "outside config",
+	}
+	for path, content := range files {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("failed to write %s: %v", path, err)
+		}
+	}
+
+	return contextDir, siblingDir
+}
+
+func TestParseDockerfileRejectsSourcesOutsideContext(t *testing.T) {
+	contextDir, siblingDir := newBuildContext(t)
+
+	tests := []struct {
+		name       string
+		dockerfile string
+		wantInErr  string
+	}{
+		{
+			name:       "absolute path",
+			dockerfile: "FROM alpine\nCOPY " + filepath.Join(siblingDir, "outside.txt") + " /app/outside.txt\n",
+			wantInErr:  filepath.Join(siblingDir, "outside.txt"),
+		},
+		{
+			name:       "relative path above the context",
+			dockerfile: "FROM alpine\nCOPY ../sibling/outside.txt /app/outside.txt\n",
+			wantInErr:  "../sibling/outside.txt",
+		},
+		{
+			name:       "glob above the context",
+			dockerfile: "FROM alpine\nCOPY ../sibling/*.conf /app/\n",
+			wantInErr:  "../sibling/*.conf",
+		},
+		{
+			name:       "ADD with a relative path above the context",
+			dockerfile: "FROM alpine\nADD ../sibling/outside.txt /app/outside.txt\n",
+			wantInErr:  "../sibling/outside.txt",
+		},
+		{
+			name:       "absolute path behind a chown flag",
+			dockerfile: "FROM alpine\nCOPY --chown=1:1 " + filepath.Join(siblingDir, "outside.txt") + " /app/outside.txt\n",
+			wantInErr:  filepath.Join(siblingDir, "outside.txt"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sources, err := parseDockerfileForSources(tt.dockerfile, contextDir)
+			if err == nil {
+				t.Fatalf("expected an error, got sources %v", sources)
+			}
+			if !strings.Contains(err.Error(), "forbidden path outside the build context") {
+				t.Errorf("error = %q, want it to mention the build context", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantInErr) {
+				t.Errorf("error = %q, want it to name %q", err, tt.wantInErr)
+			}
+		})
+	}
+}
+
+func TestParseDockerfileAcceptsSourcesInsideContext(t *testing.T) {
+	contextDir, _ := newBuildContext(t)
+
+	tests := []struct {
+		name       string
+		dockerfile string
+		want       []string
+	}{
+		{
+			name:       "dot prefixed directory",
+			dockerfile: "FROM alpine\nCOPY ./src /app/src\n",
+			want:       []string{filepath.Join(contextDir, "src")},
+		},
+		{
+			name:       "nested file",
+			dockerfile: "FROM alpine\nCOPY src/file.txt /app/file.txt\n",
+			want:       []string{filepath.Join(contextDir, "src", "file.txt")},
+		},
+		{
+			name:       "glob inside the context",
+			dockerfile: "FROM alpine\nCOPY *.txt /app/\n",
+			want:       []string{filepath.Join(contextDir, "note.txt")},
+		},
+		{
+			name:       "whole context",
+			dockerfile: "FROM alpine\nCOPY . /app\n",
+			want:       []string{contextDir},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sources, err := parseDockerfileForSources(tt.dockerfile, contextDir)
+			if err != nil {
+				t.Fatalf("parseDockerfileForSources returned an error: %v", err)
+			}
+			if !slices.Equal(sources, tt.want) {
+				t.Errorf("sources = %v, want %v", sources, tt.want)
+			}
+		})
+	}
+}

--- a/cli/pkg/minio/minio.go
+++ b/cli/pkg/minio/minio.go
@@ -206,11 +206,14 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 
 	// Captured before the scratch archive exists. Creating and removing it
 	// updates the context directory's mtime, which would otherwise land in the
-	// archive and change the context hash on every run.
-	rootInfo, err := os.Stat(dirPath)
+	// archive and change the context hash on every run. Lstat matches what the
+	// walk below reports for the root entry; a symlinked root is left alone
+	// because its own mtime is not affected by writing into its target.
+	rootInfo, err := os.Lstat(dirPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read context directory %s: %w", dirPath, err)
 	}
+	pinRootModTime := rootInfo.IsDir()
 
 	tarFile, err := os.CreateTemp(dirPath, contextTarPrefix+"*.tar")
 	if err != nil {
@@ -220,6 +223,9 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 	defer func() {
 		if err := os.Remove(tarPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			fmt.Printf("Warning: failed to remove temporary context archive %s: %v\n", tarPath, err)
+			return
+		}
+		if !pinRootModTime {
 			return
 		}
 		if err := os.Chtimes(dirPath, time.Time{}, rootInfo.ModTime()); err != nil {
@@ -249,10 +255,6 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 			return nil
 		}
 
-		if file == dirPath {
-			fi = rootInfo
-		}
-
 		if shouldExcludeFile(file, dirPath) {
 			if fi.IsDir() {
 				fmt.Printf("Excluding directory: %s\n", relPath)
@@ -267,6 +269,9 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 			return err
 		}
 		header.Name = relPath
+		if file == dirPath && pinRootModTime {
+			header.ModTime = rootInfo.ModTime()
+		}
 
 		if err := tw.WriteHeader(header); err != nil {
 			return err

--- a/cli/pkg/minio/minio.go
+++ b/cli/pkg/minio/minio.go
@@ -215,6 +215,14 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 	}
 	pinRootModTime := rootInfo.IsDir()
 
+	// The scratch archive is written into the resolved directory, so that is the
+	// one whose timestamp has to be restored. For a symlinked root it is not the
+	// same file as rootInfo.
+	targetInfo, err := os.Stat(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read context directory %s: %w", dirPath, err)
+	}
+
 	tarFile, err := os.CreateTemp(dirPath, contextTarPrefix+"*.tar")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create tar file in context directory %s: %w", dirPath, err)
@@ -225,10 +233,7 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 			fmt.Printf("Warning: failed to remove temporary context archive %s: %v\n", tarPath, err)
 			return
 		}
-		if !pinRootModTime {
-			return
-		}
-		if err := os.Chtimes(dirPath, time.Time{}, rootInfo.ModTime()); err != nil {
+		if err := os.Chtimes(dirPath, time.Time{}, targetInfo.ModTime()); err != nil {
 			fmt.Printf("Warning: failed to restore timestamp of %s: %v\n", dirPath, err)
 		}
 	}()

--- a/cli/pkg/minio/minio.go
+++ b/cli/pkg/minio/minio.go
@@ -21,6 +21,19 @@ import (
 
 const CONTEXT_TAR_FILE_NAME = "context.tar"
 
+// contextTarPrefix names the per-run scratch archive ProcessDirectory writes
+// inside the context directory.
+const contextTarPrefix = ".daytona-context-"
+
+// isContextArchiveFile matches by prefix so that a scratch archive left behind
+// by an interrupted run is not swept into a later context.
+func isContextArchiveFile(name string) bool {
+	if name == CONTEXT_TAR_FILE_NAME {
+		return true
+	}
+	return strings.HasPrefix(name, contextTarPrefix) && strings.HasSuffix(name, ".tar")
+}
+
 type Client struct {
 	minioClient *minio.Client
 	bucket      string
@@ -183,10 +196,12 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 		dockerignoreExists = true
 	}
 
-	tarFile, err := os.Create(CONTEXT_TAR_FILE_NAME)
+	tarFile, err := os.CreateTemp(dirPath, contextTarPrefix+"*.tar")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create tar file: %w", err)
+		return nil, fmt.Errorf("failed to create tar file in context directory %s: %w", dirPath, err)
 	}
+	tarPath := tarFile.Name()
+	defer os.Remove(tarPath)
 	defer tarFile.Close()
 
 	tw := tar.NewWriter(tarFile)
@@ -201,7 +216,7 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 			return err
 		}
 
-		if fi.Name() == CONTEXT_TAR_FILE_NAME {
+		if isContextArchiveFile(fi.Name()) {
 			return nil
 		}
 
@@ -297,10 +312,6 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 		err = c.UploadFile(ctx, fmt.Sprintf("%s/%s", objectName, CONTEXT_TAR_FILE_NAME), tarContent)
 		if err != nil {
 			return nil, fmt.Errorf("failed to upload tar: %w", err)
-		}
-
-		if err := os.Remove(CONTEXT_TAR_FILE_NAME); err != nil {
-			return nil, fmt.Errorf("failed to remove tar file: %w", err)
 		}
 	} else {
 		fmt.Printf("Directory %s with hash %s already exists in storage\n", dirPath, hash)

--- a/cli/pkg/minio/minio.go
+++ b/cli/pkg/minio/minio.go
@@ -9,11 +9,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -25,13 +28,18 @@ const CONTEXT_TAR_FILE_NAME = "context.tar"
 // inside the context directory.
 const contextTarPrefix = ".daytona-context-"
 
-// isContextArchiveFile matches by prefix so that a scratch archive left behind
-// by an interrupted run is not swept into a later context.
-func isContextArchiveFile(name string) bool {
-	if name == CONTEXT_TAR_FILE_NAME {
+// isContextArchiveFile takes a path relative to the context directory. Scratch
+// archives are matched by prefix so that one left behind by an interrupted run
+// is not swept into a later context, but only at the context root where they
+// are created, so user files deeper in the tree are never hidden.
+func isContextArchiveFile(relPath string) bool {
+	if filepath.Base(relPath) == CONTEXT_TAR_FILE_NAME {
 		return true
 	}
-	return strings.HasPrefix(name, contextTarPrefix) && strings.HasSuffix(name, ".tar")
+	if filepath.Dir(relPath) != "." {
+		return false
+	}
+	return strings.HasPrefix(relPath, contextTarPrefix) && strings.HasSuffix(relPath, ".tar")
 }
 
 type Client struct {
@@ -196,12 +204,28 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 		dockerignoreExists = true
 	}
 
+	// Captured before the scratch archive exists. Creating and removing it
+	// updates the context directory's mtime, which would otherwise land in the
+	// archive and change the context hash on every run.
+	rootInfo, err := os.Stat(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read context directory %s: %w", dirPath, err)
+	}
+
 	tarFile, err := os.CreateTemp(dirPath, contextTarPrefix+"*.tar")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create tar file in context directory %s: %w", dirPath, err)
 	}
 	tarPath := tarFile.Name()
-	defer os.Remove(tarPath)
+	defer func() {
+		if err := os.Remove(tarPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			fmt.Printf("Warning: failed to remove temporary context archive %s: %v\n", tarPath, err)
+			return
+		}
+		if err := os.Chtimes(dirPath, time.Time{}, rootInfo.ModTime()); err != nil {
+			fmt.Printf("Warning: failed to restore timestamp of %s: %v\n", dirPath, err)
+		}
+	}()
 	defer tarFile.Close()
 
 	tw := tar.NewWriter(tarFile)
@@ -216,12 +240,20 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 			return err
 		}
 
-		if isContextArchiveFile(fi.Name()) {
+		relPath, err := filepath.Rel(dirPath, file)
+		if err != nil {
+			return err
+		}
+
+		if isContextArchiveFile(relPath) {
 			return nil
 		}
 
+		if file == dirPath {
+			fi = rootInfo
+		}
+
 		if shouldExcludeFile(file, dirPath) {
-			relPath, _ := filepath.Rel(dirPath, file)
 			if fi.IsDir() {
 				fmt.Printf("Excluding directory: %s\n", relPath)
 				return filepath.SkipDir
@@ -231,11 +263,6 @@ func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, ex
 		}
 
 		header, err := tar.FileInfoHeader(fi, fi.Name())
-		if err != nil {
-			return err
-		}
-
-		relPath, err := filepath.Rel(dirPath, file)
 		if err != nil {
 			return err
 		}

--- a/cli/pkg/minio/minio_test.go
+++ b/cli/pkg/minio/minio_test.go
@@ -1,0 +1,417 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package minio
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const testOrgID = "test-org"
+
+type fakeStorage struct {
+	mu       sync.Mutex
+	objects  map[string][]byte
+	putCount int
+	failPuts bool
+}
+
+func newFakeStorage(t *testing.T) (*Client, *fakeStorage) {
+	t.Helper()
+
+	storage := &fakeStorage{objects: map[string][]byte{}}
+	server := httptest.NewServer(http.HandlerFunc(storage.serve))
+	t.Cleanup(server.Close)
+
+	endpoint, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server url: %v", err)
+	}
+
+	client, err := NewClient(endpoint.Host, "access-key", "secret-key", "bucket", false, "")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	return client, storage
+}
+
+func (f *fakeStorage) serve(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Has("location") {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?><LocationConstraint>us-east-1</LocationConstraint>`)
+		return
+	}
+
+	if r.Method != http.MethodPut {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if strings.HasPrefix(r.Header.Get("X-Amz-Content-Sha256"), "STREAMING-") {
+		body, err = decodeAWSChunked(body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.failPuts {
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>`)
+		return
+	}
+
+	f.putCount++
+	f.objects[strings.TrimPrefix(r.URL.Path, "/")] = body
+	w.Header().Set("ETag", `"d41d8cd98f00b204e9800998ecf8427e"`)
+	w.WriteHeader(http.StatusOK)
+}
+
+// decodeAWSChunked unwraps the `aws-chunked` framing the storage client uses
+// when streaming a signed payload over plain HTTP.
+func decodeAWSChunked(body []byte) ([]byte, error) {
+	payload := []byte{}
+	for {
+		end := bytes.Index(body, []byte("\r\n"))
+		if end < 0 {
+			return nil, errors.New("truncated chunk header")
+		}
+
+		sizeField, _, _ := strings.Cut(string(body[:end]), ";")
+		size, err := strconv.ParseInt(sizeField, 16, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		body = body[end+2:]
+		if size == 0 {
+			return payload, nil
+		}
+		if int64(len(body)) < size+2 {
+			return nil, errors.New("truncated chunk body")
+		}
+
+		payload = append(payload, body[:size]...)
+		body = body[size+2:]
+	}
+}
+
+func (f *fakeStorage) setFailPuts(fail bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failPuts = fail
+}
+
+func (f *fakeStorage) puts() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.putCount
+}
+
+func (f *fakeStorage) archives() map[string][]byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	archives := map[string][]byte{}
+	for name, content := range f.objects {
+		if strings.HasSuffix(name, "/"+CONTEXT_TAR_FILE_NAME) {
+			archives[name] = content
+		}
+	}
+	return archives
+}
+
+func (f *fakeStorage) uploadedArchive(t *testing.T) []byte {
+	t.Helper()
+
+	archives := f.archives()
+	if len(archives) != 1 {
+		t.Fatalf("expected exactly one uploaded archive, got %d", len(archives))
+	}
+	for _, content := range archives {
+		return content
+	}
+	return nil
+}
+
+// tarEntries tolerates a missing end-of-archive trailer: the tar writer is
+// closed after the upload, so the uploaded bytes stop after the last entry.
+// All entries themselves are complete and readable.
+func tarEntries(t *testing.T, archive []byte) map[string]string {
+	t.Helper()
+
+	entries := map[string]string{}
+	reader := tar.NewReader(bytes.NewReader(archive))
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return entries
+		}
+		if err != nil {
+			t.Fatalf("failed to read archive: %v", err)
+		}
+
+		content, err := io.ReadAll(reader)
+		if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("failed to read archive entry %s: %v", header.Name, err)
+		}
+		entries[header.Name] = string(content)
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", name, err)
+	}
+}
+
+func assertNoContextArchives(t *testing.T, dir string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if isContextArchiveFile(entry.Name()) {
+			t.Errorf("context archive %q was left behind in %s", entry.Name(), dir)
+		}
+	}
+}
+
+// waitForNextSecond aligns to a second boundary. Archive headers record mtimes
+// with one-second granularity and creating the scratch archive updates the
+// context directory's mtime, so a priming run and a cached run only hash
+// identically when both fall within the same second.
+func waitForNextSecond() {
+	time.Sleep(time.Until(time.Now().Truncate(time.Second).Add(time.Second)))
+}
+
+func TestProcessDirectoryPreservesExistingContextTar(t *testing.T) {
+	client, storage := newFakeStorage(t)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	writeFile(t, dir, CONTEXT_TAR_FILE_NAME, "user owned archive")
+
+	// The command is commonly run from the context directory itself.
+	t.Chdir(dir)
+
+	if _, err := client.ProcessDirectory(context.Background(), dir, testOrgID, map[string]bool{}); err != nil {
+		t.Fatalf("ProcessDirectory returned an error: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, CONTEXT_TAR_FILE_NAME))
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", CONTEXT_TAR_FILE_NAME, err)
+	}
+	if string(content) != "user owned archive" {
+		t.Errorf("%s content = %q, want %q", CONTEXT_TAR_FILE_NAME, content, "user owned archive")
+	}
+
+	entries := tarEntries(t, storage.uploadedArchive(t))
+	if _, found := entries[CONTEXT_TAR_FILE_NAME]; found {
+		t.Errorf("%s should stay excluded from the uploaded context", CONTEXT_TAR_FILE_NAME)
+	}
+}
+
+func TestProcessDirectoryConcurrentRunsDoNotCollide(t *testing.T) {
+	client, storage := newFakeStorage(t)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	writeFile(t, dir, "app.txt", "application source")
+	t.Chdir(t.TempDir())
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range errs {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			_, errs[index] = client.ProcessDirectory(context.Background(), dir, testOrgID, map[string]bool{})
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent run %d returned an error: %v", i, err)
+		}
+	}
+
+	archives := storage.archives()
+	if len(archives) == 0 {
+		t.Fatal("expected at least one uploaded archive")
+	}
+	for name, archive := range archives {
+		entries := tarEntries(t, archive)
+		for _, want := range []string{"Dockerfile", "app.txt"} {
+			if _, found := entries[want]; !found {
+				t.Errorf("archive %s is missing %s", name, want)
+			}
+		}
+		for entry := range entries {
+			if isContextArchiveFile(filepath.Base(entry)) {
+				t.Errorf("archive %s contains scratch archive %s", name, entry)
+			}
+		}
+	}
+
+	assertNoContextArchives(t, dir)
+}
+
+func TestProcessDirectoryCleansUpOnCacheHit(t *testing.T) {
+	client, storage := newFakeStorage(t)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	workingDir := t.TempDir()
+	t.Chdir(workingDir)
+
+	const attempts = 5
+	for attempt := 1; ; attempt++ {
+		waitForNextSecond()
+
+		primed, err := client.ProcessDirectory(context.Background(), dir, testOrgID, map[string]bool{})
+		if err != nil {
+			t.Fatalf("priming ProcessDirectory returned an error: %v", err)
+		}
+
+		uploadsBefore := storage.puts()
+		existingObjects := map[string]bool{testOrgID + "/" + primed[0]: true}
+
+		cached, err := client.ProcessDirectory(context.Background(), dir, testOrgID, existingObjects)
+		if err != nil {
+			t.Fatalf("cached ProcessDirectory returned an error: %v", err)
+		}
+
+		if cached[0] == primed[0] {
+			if uploads := storage.puts() - uploadsBefore; uploads != 0 {
+				t.Errorf("expected no uploads on a cache hit, got %d", uploads)
+			}
+			break
+		}
+		if attempt == attempts {
+			t.Fatalf("context hash changed between consecutive runs %d times, cannot exercise the cache hit", attempts)
+		}
+	}
+
+	assertNoContextArchives(t, dir)
+	assertNoContextArchives(t, workingDir)
+}
+
+func TestProcessDirectoryCleansUpOnError(t *testing.T) {
+	client, storage := newFakeStorage(t)
+	storage.setFailPuts(true)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	workingDir := t.TempDir()
+	t.Chdir(workingDir)
+
+	if _, err := client.ProcessDirectory(context.Background(), dir, testOrgID, map[string]bool{}); err == nil {
+		t.Fatal("expected ProcessDirectory to fail when the upload fails")
+	}
+
+	assertNoContextArchives(t, dir)
+	assertNoContextArchives(t, workingDir)
+}
+
+func TestProcessDirectorySkipsStaleScratchArchives(t *testing.T) {
+	client, storage := newFakeStorage(t)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	writeFile(t, dir, contextTarPrefix+"stale.tar", "archive from an interrupted run")
+	t.Chdir(t.TempDir())
+
+	if _, err := client.ProcessDirectory(context.Background(), dir, testOrgID, map[string]bool{}); err != nil {
+		t.Fatalf("ProcessDirectory returned an error: %v", err)
+	}
+
+	entries := tarEntries(t, storage.uploadedArchive(t))
+	if _, found := entries[contextTarPrefix+"stale.tar"]; found {
+		t.Errorf("stale scratch archive %s was included in the uploaded context", contextTarPrefix+"stale.tar")
+	}
+	if _, found := entries["Dockerfile"]; !found {
+		t.Error("uploaded context is missing Dockerfile")
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, contextTarPrefix+"stale.tar"))
+	if err != nil {
+		t.Fatalf("failed to read stale scratch archive: %v", err)
+	}
+	if string(content) != "archive from an interrupted run" {
+		t.Errorf("stale scratch archive content = %q, want it unchanged", content)
+	}
+}
+
+func TestProcessDirectoryDoesNotWriteToWorkingDirectory(t *testing.T) {
+	tests := []struct {
+		name        string
+		failUploads bool
+	}{
+		{name: "upload succeeds", failUploads: false},
+		{name: "upload fails", failUploads: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, storage := newFakeStorage(t)
+			storage.setFailPuts(tt.failUploads)
+
+			dir := t.TempDir()
+			writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+			workingDir := t.TempDir()
+			t.Chdir(workingDir)
+
+			_, err := client.ProcessDirectory(context.Background(), dir, testOrgID, map[string]bool{})
+			if tt.failUploads && err == nil {
+				t.Fatal("expected ProcessDirectory to fail when the upload fails")
+			}
+			if !tt.failUploads && err != nil {
+				t.Fatalf("ProcessDirectory returned an error: %v", err)
+			}
+
+			left, err := os.ReadDir(workingDir)
+			if err != nil {
+				t.Fatalf("failed to read working directory: %v", err)
+			}
+			if len(left) != 0 {
+				names := make([]string, 0, len(left))
+				for _, entry := range left {
+					names = append(names, entry.Name())
+				}
+				t.Errorf("working directory should stay untouched, found %v", names)
+			}
+		})
+	}
+}

--- a/cli/pkg/minio/minio_test.go
+++ b/cli/pkg/minio/minio_test.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	"errors"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -206,12 +208,53 @@ func assertNoContextArchives(t *testing.T, dir string) {
 	}
 }
 
-// waitForNextSecond aligns to a second boundary. Archive headers record mtimes
-// with one-second granularity and creating the scratch archive updates the
-// context directory's mtime, so a priming run and a cached run only hash
-// identically when both fall within the same second.
-func waitForNextSecond() {
-	time.Sleep(time.Until(time.Now().Truncate(time.Second).Add(time.Second)))
+func TestProcessDirectoryProducesStableHashAcrossRuns(t *testing.T) {
+	client, _ := newFakeStorage(t)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	t.Chdir(t.TempDir())
+
+	first, err := client.ProcessDirectory(context.Background(), dir, testOrgID, map[string]bool{})
+	if err != nil {
+		t.Fatalf("first ProcessDirectory returned an error: %v", err)
+	}
+
+	// A run must not change the context directory in a way that alters the next
+	// run's hash, otherwise an unchanged context is re-uploaded every time.
+	time.Sleep(1100 * time.Millisecond)
+
+	second, err := client.ProcessDirectory(context.Background(), dir, testOrgID, map[string]bool{})
+	if err != nil {
+		t.Fatalf("second ProcessDirectory returned an error: %v", err)
+	}
+
+	if first[0] != second[0] {
+		t.Errorf("hash of an unchanged context changed between runs: %s then %s", first[0], second[0])
+	}
+}
+
+func TestProcessDirectoryIncludesNestedFilesNamedLikeScratchArchives(t *testing.T) {
+	client, storage := newFakeStorage(t)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	nested := filepath.Join(dir, "fixtures")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("failed to create nested directory: %v", err)
+	}
+	writeFile(t, nested, contextTarPrefix+"sample.tar", "user fixture")
+	t.Chdir(t.TempDir())
+
+	if _, err := client.ProcessDirectory(context.Background(), dir, testOrgID, map[string]bool{}); err != nil {
+		t.Fatalf("ProcessDirectory returned an error: %v", err)
+	}
+
+	entries := tarEntries(t, storage.uploadedArchive(t))
+	nestedEntry := filepath.Join("fixtures", contextTarPrefix+"sample.tar")
+	if got, found := entries[nestedEntry]; !found || got != "user fixture" {
+		t.Errorf("nested file %s should be included in the context, entries = %v", nestedEntry, slices.Sorted(maps.Keys(entries)))
+	}
 }
 
 func TestProcessDirectoryPreservesExistingContextTar(t *testing.T) {
@@ -296,32 +339,23 @@ func TestProcessDirectoryCleansUpOnCacheHit(t *testing.T) {
 	workingDir := t.TempDir()
 	t.Chdir(workingDir)
 
-	const attempts = 5
-	for attempt := 1; ; attempt++ {
-		waitForNextSecond()
+	primed, err := client.ProcessDirectory(context.Background(), dir, testOrgID, map[string]bool{})
+	if err != nil {
+		t.Fatalf("priming ProcessDirectory returned an error: %v", err)
+	}
 
-		primed, err := client.ProcessDirectory(context.Background(), dir, testOrgID, map[string]bool{})
-		if err != nil {
-			t.Fatalf("priming ProcessDirectory returned an error: %v", err)
-		}
+	uploadsBefore := storage.puts()
+	existingObjects := map[string]bool{testOrgID + "/" + primed[0]: true}
 
-		uploadsBefore := storage.puts()
-		existingObjects := map[string]bool{testOrgID + "/" + primed[0]: true}
-
-		cached, err := client.ProcessDirectory(context.Background(), dir, testOrgID, existingObjects)
-		if err != nil {
-			t.Fatalf("cached ProcessDirectory returned an error: %v", err)
-		}
-
-		if cached[0] == primed[0] {
-			if uploads := storage.puts() - uploadsBefore; uploads != 0 {
-				t.Errorf("expected no uploads on a cache hit, got %d", uploads)
-			}
-			break
-		}
-		if attempt == attempts {
-			t.Fatalf("context hash changed between consecutive runs %d times, cannot exercise the cache hit", attempts)
-		}
+	cached, err := client.ProcessDirectory(context.Background(), dir, testOrgID, existingObjects)
+	if err != nil {
+		t.Fatalf("cached ProcessDirectory returned an error: %v", err)
+	}
+	if cached[0] != primed[0] {
+		t.Fatalf("context hash changed between runs: %s then %s", primed[0], cached[0])
+	}
+	if uploads := storage.puts() - uploadsBefore; uploads != 0 {
+		t.Errorf("expected no uploads on a cache hit, got %d", uploads)
 	}
 
 	assertNoContextArchives(t, dir)

--- a/cli/pkg/minio/minio_test.go
+++ b/cli/pkg/minio/minio_test.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -186,6 +187,24 @@ func tarEntries(t *testing.T, archive []byte) map[string]string {
 	}
 }
 
+func tarHeader(t *testing.T, archive []byte, name string) *tar.Header {
+	t.Helper()
+
+	reader := tar.NewReader(bytes.NewReader(archive))
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("archive has no entry %q", name)
+		}
+		if err != nil {
+			t.Fatalf("failed to read archive: %v", err)
+		}
+		if header.Name == name {
+			return header
+		}
+	}
+}
+
 func writeFile(t *testing.T, dir, name, content string) {
 	t.Helper()
 
@@ -231,6 +250,40 @@ func TestProcessDirectoryProducesStableHashAcrossRuns(t *testing.T) {
 
 	if first[0] != second[0] {
 		t.Errorf("hash of an unchanged context changed between runs: %s then %s", first[0], second[0])
+	}
+}
+
+func TestProcessDirectoryKeepsRootEntryTypeForSymlinkedContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	client, storage := newFakeStorage(t)
+
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("failed to create context directory: %v", err)
+	}
+	writeFile(t, realDir, "Dockerfile", "FROM alpine\n")
+
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+	t.Chdir(t.TempDir())
+
+	if _, err := client.ProcessDirectory(context.Background(), link, testOrgID, map[string]bool{}); err != nil {
+		t.Fatalf("ProcessDirectory returned an error: %v", err)
+	}
+
+	// The walk reports the root as a symlink, so the archive must record it as
+	// one. Recording the target's directory metadata instead would replace the
+	// entry with an empty directory. Resolving symlinked context roots so their
+	// contents are archived is a separate, pre-existing gap.
+	header := tarHeader(t, storage.uploadedArchive(t), ".")
+	if header.Typeflag != tar.TypeSymlink {
+		t.Errorf("root entry typeflag = %q, want %q", header.Typeflag, tar.TypeSymlink)
 	}
 }
 

--- a/cli/pkg/minio/minio_test.go
+++ b/cli/pkg/minio/minio_test.go
@@ -287,6 +287,46 @@ func TestProcessDirectoryKeepsRootEntryTypeForSymlinkedContext(t *testing.T) {
 	}
 }
 
+func TestProcessDirectoryRestoresSymlinkTargetTimestamp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	client, _ := newFakeStorage(t)
+
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("failed to create context directory: %v", err)
+	}
+	writeFile(t, realDir, "Dockerfile", "FROM alpine\n")
+
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+	t.Chdir(t.TempDir())
+
+	before, err := os.Stat(realDir)
+	if err != nil {
+		t.Fatalf("failed to stat context directory: %v", err)
+	}
+
+	// The scratch archive is created inside the target even when the run is
+	// pointed at the link, so the target's timestamp must be put back.
+	if _, err := client.ProcessDirectory(context.Background(), link, testOrgID, map[string]bool{}); err != nil {
+		t.Fatalf("ProcessDirectory returned an error: %v", err)
+	}
+
+	after, err := os.Stat(realDir)
+	if err != nil {
+		t.Fatalf("failed to stat context directory: %v", err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Errorf("target directory mtime changed: %v then %v", before.ModTime(), after.ModTime())
+	}
+}
+
 func TestProcessDirectoryIncludesNestedFilesNamedLikeScratchArchives(t *testing.T) {
 	client, storage := newFakeStorage(t)
 


### PR DESCRIPTION
## Summary

Correctness fixes in the CLI's build-context handling, with regression tests.

1. `ProcessDirectory` writes its scratch archive to a unique path inside the context directory instead of a fixed `context.tar` in the process working directory, and no longer perturbs the context hash.
2. `parseDockerfileForSources` resolves `COPY`/`ADD` sources the way `docker build` does, so they can no longer reach files outside the build context.

> **Note on the history:** commits 3 and 4 supersede the approach taken in commit 2. Commit 2 *rejected* absolute and `../` sources on the belief that `docker build` rejects them. It does not — see section 2. The final state resolves them instead. Squash-merging is fine.

---

## 1. Build context archive path (`cli/pkg/minio/minio.go`)

`ProcessDirectory` created its scratch archive with `os.Create("context.tar")` — a fixed name, relative to the process working directory. Four problems followed:

1. **It clobbers a user file.** Any existing `context.tar` in the working directory is truncated on `os.Create`, then deleted by the `os.Remove` at the end of the run. Truncation happens *before* the directory walk, so even a run that fails partway destroys the file.
2. **Concurrent runs corrupt each other.** Two `snapshot create` / `sandbox create` invocations in the same directory write to the same path; one deletes the other's archive and the loser fails with `failed to remove tar file: remove context.tar: no such file or directory`.
3. **The scratch file leaks on a storage cache hit.** The `os.Remove` sat inside the `if _, exists := existingObjects[objectName]; !exists { ... }` branch, so on a cache hit — and on every error path — the archive was left behind.
4. **Behavior depended on the invoking directory.** The scratch path resolved against the CWD, not the context directory.

### Change

- `os.Create(CONTEXT_TAR_FILE_NAME)` → `os.CreateTemp(dirPath, ".daytona-context-*.tar")`.
- Cleanup is an unconditional `defer`, so it runs on every exit path including errors. The old conditional `os.Remove` is gone. A cleanup failure is reported as a warning rather than silently ignored.
- The walk skips the scratch archive **by prefix at the context root**, so a `.daytona-context-*.tar` left by a killed run is not swept into a later archive, while a user file deeper in the tree whose name happens to match is still included. The existing exact-name `context.tar` skip is kept unchanged.
- The context directory's metadata is captured **before** the scratch archive is created and its timestamp restored afterwards. Without this, creating and removing the scratch file changed the directory mtime that gets recorded in the archive, so an unchanged context hashed differently on every run.
- If the context directory is not writable the command fails with a clear error naming it. No silent fallback.

The scratch file stays in the context directory rather than `os.TempDir()`: build contexts routinely exceed 100 MB (see the existing warning in this function) and several distributions mount `/tmp` as RAM-backed tmpfs.

### Accepted behavior change

The scratch archive now lives in the context directory rather than the working directory. It is created and removed within a single run, so it should not normally be observable. Context hashes are unaffected: `context.tar` remains excluded exactly as before, and `.daytona-context-*.tar` names did not previously exist.

---

## 2. `COPY`/`ADD` source resolution (`cli/cmd/common/build.go`)

When `--context` is not supplied, the CLI derives the build context by parsing `COPY`/`ADD` instructions. It resolved absolute sources against the **host** filesystem and joined `../` sources without constraint, then `os.Stat`/`filepath.Glob` accepted whatever they found. Files outside the repository were read and uploaded.

`docker build` does not work that way. It normalises the source into the context ([`moby/daemon/builder/remotecontext/archive.go`](https://github.com/moby/moby/blob/master/daemon/builder/remotecontext/archive.go)):

```go
cleanPath = filepath.Clean(string(filepath.Separator) + path)[1:]
```

The BuildKit reference states the same: *"Leading slashes and parent directory navigation ('../') are automatically removed to prevent accessing files outside the context."* So `/etc/passwd` means `<context>/etc/passwd` and `../foo` means `<context>/foo`. Docker reports `forbidden path outside the build context` only when a **symlink** resolves outside the context root.

### Change

Sources are resolved with the same normalisation, and a source that escapes via a symlink is refused with Docker's message, naming the path as written in the Dockerfile:

```
forbidden path outside the build context: leak.txt
```

The symlink check resolves the context root and the candidate together or not at all, so a context reached through a symlinked parent (`/var` → `/private/var` on macOS) is not misread as an escape. It is applied to both the direct `os.Stat` hit and every `filepath.Glob` match.

### Effect

| Dockerfile | before | after |
| --- | --- | --- |
| `COPY /app/config.json /c` | resolved against the host, silently dropped | resolves to `<ctx>/app/config.json` |
| `COPY ../outside.txt /o` | host file read and uploaded | resolves to `<ctx>/outside.txt` |
| `COPY ../*.conf /o/` | host files read and uploaded | resolved inside the context |
| `COPY leak.txt /o` where `leak.txt` → outside | host file read and uploaded | refused |
| `./src`, `src/file.txt`, `*.txt`, `.` | unchanged | unchanged |

No Dockerfile that builds today stops building. A source that cannot be found now surfaces as a normal "not found" at build time, exactly as with `docker build`.

---

## Tests

`cli/pkg/minio/minio_test.go` (new) — backed by an in-process fake object store:

| Test | Covers |
| --- | --- |
| `TestProcessDirectoryPreservesExistingContextTar` | a user's `context.tar` keeps its content |
| `TestProcessDirectoryConcurrentRunsDoNotCollide` | two concurrent runs both produce valid archives |
| `TestProcessDirectoryCleansUpOnCacheHit` | no scratch archive remains when the upload is skipped |
| `TestProcessDirectoryCleansUpOnError` | no scratch archive remains when the run fails |
| `TestProcessDirectorySkipsStaleScratchArchives` | a stale root-level scratch archive is excluded and left on disk |
| `TestProcessDirectoryIncludesNestedFilesNamedLikeScratchArchives` | a nested user file matching the scratch name is **not** dropped |
| `TestProcessDirectoryProducesStableHashAcrossRuns` | an unchanged context hashes identically on a later run |
| `TestProcessDirectoryKeepsRootEntryTypeForSymlinkedContext` | a symlinked context root stays a symlink entry, not an empty directory |
| `TestProcessDirectoryRestoresSymlinkTargetTimestamp` | a run through a symlink leaves the target directory's mtime untouched |
| `TestProcessDirectoryDoesNotWriteToWorkingDirectory` | the working directory is untouched, on success and failure |

`cli/cmd/common/build_test.go` (new):

| Test | Covers |
| --- | --- |
| `TestParseDockerfileResolvesSourcesInsideContext` | `./src`, `src/file.txt`, `*.txt`, `.`, absolute, `--chown` + absolute, `../`, `ADD ../` all resolve inside the context |
| `TestParseDockerfileDoesNotReachOutsideContext` | absolute host path, `../`, glob, `ADD ../`, `--chown` + host path resolve to nothing; the outside fixtures exist, so this proves they were never reached |
| `TestParseDockerfileClampsOutsideSourcesIntoContext` | `../outside.txt`, `../../../outside.txt` and `/outside.txt` resolve onto a real in-context file of that name |
| `TestParseDockerfileRejectsSymlinkedSourcesOutsideContext` | symlinked file, file via symlinked dir, glob via symlinked dir are refused |
| `TestParseDockerfileAllowsSymlinksInsideContext` | in-context symlinks still resolve (guards against over-blocking) |

Each behavioural test was confirmed failing without its corresponding fix and passing with it, including the two added in response to review (`ProducesStableHashAcrossRuns`, `IncludesNestedFilesNamedLikeScratchArchives`).

---

## Verification

```
$ go build ./cli/...
$ go vet ./cli/...
$ go test ./cli/...
ok  	github.com/daytona/clients/cli	1.278s
ok  	github.com/daytona/clients/cli/apiclient
ok  	github.com/daytona/clients/cli/cmd/common	0.006s
ok  	github.com/daytona/clients/cli/cmd/organization	0.004s
ok  	github.com/daytona/clients/cli/cmd/sandbox	0.009s
ok  	github.com/daytona/clients/cli/mcp
ok  	github.com/daytona/clients/cli/mcp/tools
ok  	github.com/daytona/clients/cli/pkg/minio	1.117s
ok  	github.com/daytona/clients/cli/toolbox

$ go test -race -count=3 ./cli/pkg/minio/... ./cli/cmd/common/...
ok  	github.com/daytona/clients/cli/pkg/minio	4.401s
ok  	github.com/daytona/clients/cli/cmd/common	1.029s

$ gofmt -l cli/       # no output
$ golangci-lint run ./cli/...
0 issues.
```

Exercised manually with a locally built binary against a stubbed API and object store, from a context directory holding `Dockerfile`, `app/`, a user-owned `context.tar`, a leftover `.daytona-context-stale.tar` and a `leak.txt` symlink pointing outside:

- `COPY /app/config.json /c` and `COPY . /app` + `COPY /app/config.json /c` → both proceed to the build (the second is the case the earlier approach broke).
- `COPY ../outside.txt /o` → proceeds; the outside file is not read.
- `COPY leak.txt /o` → `forbidden path outside the build context: leak.txt`.
- Run from an unrelated working directory → that directory is left empty; the context directory is unchanged.
- `context.tar` and `.daytona-context-stale.tar` both survive with original content and neither is included in the archive.
- Run against a context path that is a symlink to a directory → the target directory's mtime is unchanged afterwards.
- `daytona snapshot create --help` renders correctly.

---

## Review

Eight findings were raised across three automated review rounds and all are addressed. Seven produced fixes, each with a regression test verified failing beforehand: the symlink escape, the context-hash churn, the over-broad scratch-archive exclusion, the silently discarded cleanup error, the symlinked context root being recorded as an empty directory, the symlinked target's timestamp not being restored, and a containment test that asserted vacuously over an empty slice.

One was not applicable: passing `time.Time{}` as the access time to `os.Chtimes` was read as zeroing the access time. That value is the documented "leave unchanged" sentinel, confirmed on go1.25.5 (access time preserved to the nanosecond, no error), and reading the real access time would require `syscall.Stat_t`, which does not build on Windows. Rationale recorded on the thread.

## Known issues left alone

- **`ProcessDirectory` defers `tw.Close()`**, so the writer is flushed *after* the hash is computed and after the upload; the uploaded archive lacks the final entry's padding and the 1024-byte end-of-archive trailer. Fixing it changes the SHA-256 of every context and forces a one-time re-upload for all users, so it is left for a separate PR. The defer ordering here is unchanged.
- **The dedup lookup key never matches.** `ProcessDirectory` looks up `"<orgId>/<hash>"`, but `CreateDirectory` stores `"<orgId>/<hash>/"` and the archive at `"<orgId>/<hash>/context.tar"`, so `existingObjects` never contains the key and the cache always misses. Pre-existing and unrelated to these changes; fixing it would newly enable a code path that has never run in production, so it belongs in its own PR.

