### PR TITLE
fix(cli): enforce the documented SSH command format

### DIFF
--- a/cli/cmd/common/ssh.go
+++ b/cli/cmd/common/ssh.go
@@ -12,6 +12,10 @@ import (
 )
 
 const (
+	// maxCommandLength bounds the whole response before it is tokenized. The
+	// longest command the API can compose is well under this: "ssh -p 65535 "
+	// plus a 32 character token plus a host of at most 253 characters.
+	maxCommandLength  = 512
 	maxHostnameLength = 253
 	maxLabelLength    = 63
 	minPortNumber     = 1
@@ -40,6 +44,10 @@ var (
 // the original string is passed through. Anything else is rejected with an
 // error naming the component at fault; the raw command is never echoed back.
 func ParseSSHCommand(sshCommand string) ([]string, error) {
+	if len(sshCommand) > maxCommandLength {
+		return nil, errors.New("SSH command is too long")
+	}
+
 	fields := strings.Fields(sshCommand)
 	if len(fields) < 2 {
 		return nil, errors.New(`unexpected SSH command format; expected "ssh [-p port] user@host"`)
@@ -120,19 +128,22 @@ func validateSSHHost(host string) error {
 		return invalid
 	}
 
-	if strings.HasPrefix(host, "[") {
-		if !strings.HasSuffix(host, "]") {
-			return invalid
-		}
-		ip := net.ParseIP(host[1 : len(host)-1])
-		if ip == nil || ip.To4() != nil {
+	// An IPv6 literal is recognised by its colons rather than by the parsed
+	// bytes: IPv4-mapped forms such as "::ffff:c000:201" parse to four bytes yet
+	// are written — and emitted by the API — as a bracketed IPv6 host.
+	if address, bracketed := strings.CutPrefix(host, "["); bracketed {
+		address, closed := strings.CutSuffix(address, "]")
+		if !closed || !strings.Contains(address, ":") || net.ParseIP(address) == nil {
 			return invalid
 		}
 		return nil
 	}
 
+	if strings.Contains(host, ":") {
+		return invalid
+	}
+
 	if ip := net.ParseIP(host); ip != nil {
-		// Unbracketed literals are only accepted in IPv4 form.
 		if ip.To4() == nil {
 			return invalid
 		}

--- a/cli/cmd/common/ssh.go
+++ b/cli/cmd/common/ssh.go
@@ -4,22 +4,167 @@
 package common
 
 import (
-	"fmt"
+	"errors"
+	"net"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
-// ParseSSHCommand parses the SSH command string returned by the API
-// Expected formats:
-// - "ssh token@host" (port 22)
-// - "ssh -p port token@host"
+const (
+	maxHostnameLength = 253
+	maxLabelLength    = 63
+	minPortNumber     = 1
+	maxPortNumber     = 65535
+)
+
+var (
+	// sshUserPattern matches the user (access token) part of the destination.
+	sshUserPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+	// sshPortPattern matches a decimal port with no sign, padding or separators.
+	sshPortPattern = regexp.MustCompile(`^[0-9]{1,5}$`)
+	// sshHostLabelPattern matches a single RFC 1123 hostname label: alphanumeric
+	// at both ends, hyphens allowed only in the interior.
+	sshHostLabelPattern = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$`)
+)
+
+// ParseSSHCommand parses the SSH command string returned by the API and
+// returns the argument vector to pass to ssh.
+//
+// Only the two formats the API composes are accepted, and they are enforced:
+// - "ssh user@host" (port 22)
+// - "ssh -p port user@host"
+//
+// The user, host and port components are validated individually and the
+// returned arguments are rebuilt from those validated values, so no token of
+// the original string is passed through. Anything else is rejected with an
+// error naming the component at fault; the raw command is never echoed back.
 func ParseSSHCommand(sshCommand string) ([]string, error) {
-	parts := strings.Fields(sshCommand)
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("invalid SSH command format: %s", sshCommand)
+	fields := strings.Fields(sshCommand)
+	if len(fields) < 2 {
+		return nil, errors.New(`unexpected SSH command format; expected "ssh [-p port] user@host"`)
 	}
 
-	// Skip the "ssh" part
-	args := parts[1:]
+	if fields[0] != "ssh" {
+		return nil, errors.New(`unexpected SSH command format; expected it to start with "ssh"`)
+	}
 
-	return args, nil
+	args := fields[1:]
+
+	port := ""
+	if strings.HasPrefix(args[0], "-") {
+		if args[0] != "-p" {
+			return nil, errors.New("unsupported option in SSH command")
+		}
+		if len(args) < 2 {
+			return nil, errors.New("invalid port in SSH command")
+		}
+		if err := validateSSHPort(args[1]); err != nil {
+			return nil, err
+		}
+		port = args[1]
+		args = args[2:]
+	}
+
+	if len(args) == 0 {
+		return nil, errors.New(`unexpected SSH command format; expected "ssh [-p port] user@host"`)
+	}
+	if len(args) > 1 {
+		return nil, errors.New("unexpected argument in SSH command")
+	}
+
+	destination := args[0]
+	if strings.HasPrefix(destination, "-") {
+		return nil, errors.New("unsupported option in SSH command")
+	}
+
+	user, host, err := splitSSHDestination(destination)
+	if err != nil {
+		return nil, err
+	}
+
+	destination = user + "@" + host
+
+	if port != "" {
+		return []string{"-p", port, destination}, nil
+	}
+
+	return []string{destination}, nil
+}
+
+// splitSSHDestination splits "user@host" into its validated components.
+func splitSSHDestination(destination string) (string, string, error) {
+	user, host, found := strings.Cut(destination, "@")
+	if !found || strings.Contains(host, "@") {
+		return "", "", errors.New(`unexpected SSH command format; expected the destination in the "user@host" form`)
+	}
+
+	if !sshUserPattern.MatchString(user) {
+		return "", "", errors.New("invalid user in SSH command")
+	}
+
+	if err := validateSSHHost(host); err != nil {
+		return "", "", err
+	}
+
+	return user, host, nil
+}
+
+// validateSSHHost accepts a hostname, an IPv4 literal, or a bracketed IPv6
+// literal. The API derives the host from a parsed URL, which keeps the
+// brackets around IPv6 addresses.
+func validateSSHHost(host string) error {
+	invalid := errors.New("invalid host in SSH command")
+
+	if host == "" {
+		return invalid
+	}
+
+	if strings.HasPrefix(host, "[") {
+		if !strings.HasSuffix(host, "]") {
+			return invalid
+		}
+		ip := net.ParseIP(host[1 : len(host)-1])
+		if ip == nil || ip.To4() != nil {
+			return invalid
+		}
+		return nil
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		// Unbracketed literals are only accepted in IPv4 form.
+		if ip.To4() == nil {
+			return invalid
+		}
+		return nil
+	}
+
+	// A single trailing dot denotes a fully qualified name and is permitted.
+	name := strings.TrimSuffix(host, ".")
+	if name == "" || len(name) > maxHostnameLength {
+		return invalid
+	}
+
+	for _, label := range strings.Split(name, ".") {
+		if len(label) > maxLabelLength || !sshHostLabelPattern.MatchString(label) {
+			return invalid
+		}
+	}
+
+	return nil
+}
+
+func validateSSHPort(port string) error {
+	invalid := errors.New("invalid port in SSH command")
+
+	if !sshPortPattern.MatchString(port) {
+		return invalid
+	}
+
+	number, err := strconv.Atoi(port)
+	if err != nil || number < minPortNumber || number > maxPortNumber {
+		return invalid
+	}
+
+	return nil
 }

--- a/cli/cmd/common/ssh_test.go
+++ b/cli/cmd/common/ssh_test.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -33,6 +34,16 @@ func TestParseSSHCommandAcceptsDocumentedFormats(t *testing.T) {
 			name:    "bracketed ipv6 literal with port",
 			command: "ssh -p 2222 tok123@[2001:db8::1]",
 			want:    []string{"-p", "2222", "tok123@[2001:db8::1]"},
+		},
+		{
+			name:    "bracketed ipv4 mapped ipv6 literal",
+			command: "ssh tok123@[::ffff:c000:201]",
+			want:    []string{"tok123@[::ffff:c000:201]"},
+		},
+		{
+			name:    "bracketed ipv4 mapped ipv6 literal in dotted form",
+			command: "ssh tok123@[::ffff:192.0.2.1]",
+			want:    []string{"tok123@[::ffff:192.0.2.1]"},
 		},
 		{
 			name:    "fully qualified hostname with trailing dot",
@@ -73,102 +84,152 @@ func TestParseSSHCommandRejectsUnsupportedInput(t *testing.T) {
 	tests := []struct {
 		name    string
 		command string
+		wantErr string
 	}{
 		{
 			name:    "trailing extra argument",
 			command: "ssh tok123@example.com extra",
+			wantErr: "unexpected argument in SSH command",
 		},
 		{
 			name:    "destination starting with a dash",
 			command: "ssh -p 2222 -tok123@example.com",
+			wantErr: "unsupported option in SSH command",
 		},
 		{
 			name:    "attached option with a value",
 			command: "ssh -oSomething=value tok123@example.com",
+			wantErr: "unsupported option in SSH command",
 		},
 		{
 			name:    "separate option with a value",
 			command: "ssh -o Something=value tok123@example.com",
+			wantErr: "unsupported option in SSH command",
 		},
 		{
 			name:    "double dash terminator",
 			command: "ssh -- tok123@example.com",
+			wantErr: "unsupported option in SSH command",
 		},
 		{
 			name:    "attached port form",
 			command: "ssh -p2222 tok123@example.com",
+			wantErr: "unsupported option in SSH command",
 		},
 		{
 			name:    "non numeric port",
 			command: "ssh -p port tok123@example.com",
+			wantErr: "invalid port in SSH command",
 		},
 		{
 			name:    "port zero",
 			command: "ssh -p 0 tok123@example.com",
+			wantErr: "invalid port in SSH command",
 		},
 		{
 			name:    "port above the valid range",
 			command: "ssh -p 70000 tok123@example.com",
+			wantErr: "invalid port in SSH command",
 		},
 		{
 			name:    "missing port value",
 			command: "ssh -p",
+			wantErr: "invalid port in SSH command",
 		},
 		{
 			name:    "host with an empty label",
 			command: "ssh tok123@a..b",
+			wantErr: "invalid host in SSH command",
 		},
 		{
 			name:    "host with a hyphen leading label",
 			command: "ssh tok123@a.-b",
+			wantErr: "invalid host in SSH command",
 		},
 		{
 			name:    "host with a hyphen trailing label",
 			command: "ssh tok123@a-.b",
+			wantErr: "invalid host in SSH command",
+		},
+		{
+			name:    "label above the length limit",
+			command: "ssh tok123@" + strings.Repeat("a", 64) + ".example.com",
+			wantErr: "invalid host in SSH command",
 		},
 		{
 			name:    "unbracketed ipv6 host",
 			command: "ssh tok123@2001:db8::1",
+			wantErr: "invalid host in SSH command",
+		},
+		{
+			name:    "unbracketed ipv4 mapped ipv6 host",
+			command: "ssh tok123@::ffff:c000:201",
+			wantErr: "invalid host in SSH command",
 		},
 		{
 			name:    "unclosed bracketed host",
 			command: "ssh tok123@[2001:db8::1",
+			wantErr: "invalid host in SSH command",
 		},
 		{
 			name:    "bracketed ipv4 host",
 			command: "ssh tok123@[192.0.2.1]",
+			wantErr: "invalid host in SSH command",
 		},
 		{
-			name:    "missing separator",
-			command: "ssh tok123example.com",
-		},
-		{
-			name:    "two separators",
-			command: "ssh tok123@example.com@example.net",
-		},
-		{
-			name:    "empty user",
-			command: "ssh @example.com",
+			name:    "bracketed hostname",
+			command: "ssh tok123@[example.com]",
+			wantErr: "invalid host in SSH command",
 		},
 		{
 			name:    "empty host",
 			command: "ssh tok123@",
+			wantErr: "invalid host in SSH command",
+		},
+		{
+			name:    "missing separator",
+			command: "ssh tok123example.com",
+			wantErr: `expected the destination in the "user@host" form`,
+		},
+		{
+			name:    "two separators",
+			command: "ssh tok123@example.com@example.net",
+			wantErr: `expected the destination in the "user@host" form`,
+		},
+		{
+			name:    "empty user",
+			command: "ssh @example.com",
+			wantErr: "invalid user in SSH command",
 		},
 		{
 			name:    "user starting with a dot",
 			command: "ssh .tok123@example.com",
+			wantErr: "invalid user in SSH command",
 		},
 		{
 			name:    "first token is not ssh",
 			command: "notssh tok123@example.com",
+			wantErr: `expected it to start with "ssh"`,
 		},
 		{
 			name:    "fewer than two tokens",
 			command: "ssh",
+			wantErr: `expected "ssh [-p port] user@host"`,
 		},
 		{
 			name:    "empty command",
 			command: "",
+			wantErr: `expected "ssh [-p port] user@host"`,
+		},
+		{
+			name:    "port without a destination",
+			command: "ssh -p 2222",
+			wantErr: `expected "ssh [-p port] user@host"`,
+		},
+		{
+			name:    "command above the length limit",
+			command: "ssh " + strings.Repeat("t", 600) + "@example.com",
+			wantErr: "SSH command is too long",
 		},
 	}
 
@@ -180,6 +241,9 @@ func TestParseSSHCommandRejectsUnsupportedInput(t *testing.T) {
 			}
 			if got != nil {
 				t.Errorf("ParseSSHCommand(%q) returned %#v alongside the error, want nil", test.command, got)
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Errorf("ParseSSHCommand(%q) error = %q, want it to contain %q", test.command, err, test.wantErr)
 			}
 		})
 	}

--- a/cli/cmd/common/ssh_test.go
+++ b/cli/cmd/common/ssh_test.go
@@ -1,0 +1,186 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseSSHCommandAcceptsDocumentedFormats(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    []string
+	}{
+		{
+			name:    "hostname without port",
+			command: "ssh tok123@example.com",
+			want:    []string{"tok123@example.com"},
+		},
+		{
+			name:    "hostname with port",
+			command: "ssh -p 2222 tok123@example.com",
+			want:    []string{"-p", "2222", "tok123@example.com"},
+		},
+		{
+			name:    "ipv4 literal",
+			command: "ssh tok123@192.0.2.1",
+			want:    []string{"tok123@192.0.2.1"},
+		},
+		{
+			name:    "bracketed ipv6 literal with port",
+			command: "ssh -p 2222 tok123@[2001:db8::1]",
+			want:    []string{"-p", "2222", "tok123@[2001:db8::1]"},
+		},
+		{
+			name:    "fully qualified hostname with trailing dot",
+			command: "ssh tok123@sub.domain.example.com.",
+			want:    []string{"tok123@sub.domain.example.com."},
+		},
+		{
+			name:    "irregular internal whitespace",
+			command: "ssh   -p   2222   tok123@example.com",
+			want:    []string{"-p", "2222", "tok123@example.com"},
+		},
+		{
+			name:    "lowest valid port",
+			command: "ssh -p 1 tok123@example.com",
+			want:    []string{"-p", "1", "tok123@example.com"},
+		},
+		{
+			name:    "highest valid port",
+			command: "ssh -p 65535 tok123@example.com",
+			want:    []string{"-p", "65535", "tok123@example.com"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseSSHCommand(test.command)
+			if err != nil {
+				t.Fatalf("ParseSSHCommand(%q) returned error: %v", test.command, err)
+			}
+			if !slices.Equal(got, test.want) {
+				t.Errorf("ParseSSHCommand(%q) = %#v, want %#v", test.command, got, test.want)
+			}
+		})
+	}
+}
+
+func TestParseSSHCommandRejectsUnsupportedInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{
+			name:    "trailing extra argument",
+			command: "ssh tok123@example.com extra",
+		},
+		{
+			name:    "destination starting with a dash",
+			command: "ssh -p 2222 -tok123@example.com",
+		},
+		{
+			name:    "attached option with a value",
+			command: "ssh -oSomething=value tok123@example.com",
+		},
+		{
+			name:    "separate option with a value",
+			command: "ssh -o Something=value tok123@example.com",
+		},
+		{
+			name:    "double dash terminator",
+			command: "ssh -- tok123@example.com",
+		},
+		{
+			name:    "attached port form",
+			command: "ssh -p2222 tok123@example.com",
+		},
+		{
+			name:    "non numeric port",
+			command: "ssh -p port tok123@example.com",
+		},
+		{
+			name:    "port zero",
+			command: "ssh -p 0 tok123@example.com",
+		},
+		{
+			name:    "port above the valid range",
+			command: "ssh -p 70000 tok123@example.com",
+		},
+		{
+			name:    "missing port value",
+			command: "ssh -p",
+		},
+		{
+			name:    "host with an empty label",
+			command: "ssh tok123@a..b",
+		},
+		{
+			name:    "host with a hyphen leading label",
+			command: "ssh tok123@a.-b",
+		},
+		{
+			name:    "host with a hyphen trailing label",
+			command: "ssh tok123@a-.b",
+		},
+		{
+			name:    "unbracketed ipv6 host",
+			command: "ssh tok123@2001:db8::1",
+		},
+		{
+			name:    "unclosed bracketed host",
+			command: "ssh tok123@[2001:db8::1",
+		},
+		{
+			name:    "bracketed ipv4 host",
+			command: "ssh tok123@[192.0.2.1]",
+		},
+		{
+			name:    "missing separator",
+			command: "ssh tok123example.com",
+		},
+		{
+			name:    "two separators",
+			command: "ssh tok123@example.com@example.net",
+		},
+		{
+			name:    "empty user",
+			command: "ssh @example.com",
+		},
+		{
+			name:    "empty host",
+			command: "ssh tok123@",
+		},
+		{
+			name:    "user starting with a dot",
+			command: "ssh .tok123@example.com",
+		},
+		{
+			name:    "first token is not ssh",
+			command: "notssh tok123@example.com",
+		},
+		{
+			name:    "fewer than two tokens",
+			command: "ssh",
+		},
+		{
+			name:    "empty command",
+			command: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseSSHCommand(test.command)
+			if err == nil {
+				t.Fatalf("ParseSSHCommand(%q) = %#v, want an error", test.command, got)
+			}
+			if got != nil {
+				t.Errorf("ParseSSHCommand(%q) returned %#v alongside the error, want nil", test.command, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`ParseSSHCommand` in `cli/cmd/common/ssh.go` already documented the contract it accepts:

```go
// Expected formats:
// - "ssh token@host" (port 22)
// - "ssh -p port token@host"
```

It did not enforce it. The implementation was `strings.Fields(sshCommand)` returning every token after `ssh` verbatim, which is then handed to `exec.Command` in `ExecuteSSH`.

The API composes exactly those two shapes and nothing else (`SshAccessDto.fromSshAccess`), so anything outside them means a malformed or unexpected response. Today such a response is forwarded to `ssh(1)`, which fails deep inside the SSH binary with a confusing message (e.g. `Unknown cipher type`) instead of a clear CLI error naming the real problem.

This change makes the function enforce its own documented contract and produce actionable errors.

## What is now validated

Only two shapes are accepted:

1. `ssh <user>@<host>` -> `["<user>@<host>"]`
2. `ssh -p <port> <user>@<host>` -> `["-p", "<port>", "<user>@<host>"]`

Component rules:

- **user**: `^[A-Za-z0-9][A-Za-z0-9_.-]*$` — non-empty, cannot begin with `-`.
- **host**: a hostname validated per-label per RFC 1123 (each label 1-63 chars, alphanumeric at both ends, hyphens only interior, total <= 253, a single trailing dot permitted), an IPv4 literal (`net.ParseIP`, 4-byte form), or a bracketed IPv6 literal.
- **port**: `^[0-9]{1,5}$` and 1-65535.
- Exactly one `@` separating user and host; leading, trailing and repeated `@` are rejected.

Everything else is rejected rather than filtered — allowlist only. That includes extra tokens, any token starting with `-` other than a leading `-p`, the attached form `-p2222`, a `--` terminator, and a first token that is not `ssh`.

## Rebuilt argument vector

The returned slice is constructed from the extracted `user`, `host` and `port` values; no token of the original string is passed through. That also means the CLI is no longer sensitive to how `ssh(1)` happens to interpret unrecognised input.

Errors name the specific problem (`unsupported option`, `invalid port`, `invalid host`, `invalid user`, `unexpected argument`) and no longer echo the raw command string back to the terminal.

## IPv6 handling

The API derives the host from a parsed URL, and `URL.hostname` preserves the brackets around IPv6 literals, so `tok@[2001:db8::1]` is a shape the API can legitimately emit and is explicitly supported. The inner value is validated with `net.ParseIP` and must be IPv6; an unbracketed IPv6 host is rejected.

## Scope

`ExecuteSSH` is unchanged on both platforms. `ParseSSHCommand` is the single choke point shared by `ssh_unix.go` and `ssh_windows.go`, so the validation belongs there and duplicating it would only create drift. There is exactly one caller in the CLI, `cli/cmd/sandbox/ssh.go:52`.

## Tests

New table-driven `cli/cmd/common/ssh_test.go`:

- `TestParseSSHCommandAcceptsDocumentedFormats` asserts the exact returned slice for: hostname without port, hostname with port, IPv4 literal, bracketed IPv6 with port, trailing-dot FQDN, irregular internal whitespace, and the port bounds 1 and 65535.
- `TestParseSSHCommandRejectsUnsupportedInput` covers 24 rejected inputs: trailing extra argument, destination starting with `-`, `-oSomething=value`, separate `-o` plus value, `--`, `-p2222`, non-numeric port, port `0`, port `70000`, missing port value, `a..b`, `a.-b`, `a-.b`, unbracketed IPv6, unclosed bracket, bracketed IPv4, missing `@`, two `@`, empty user, empty host, user starting with `.`, first token not `ssh`, a single token, and the empty string.

Both tests fail on `origin/main` and pass on this branch. On `origin/main` the accept cases already pass (the old code returned the tokens unchanged) while every reject case fails, e.g.:

```
--- FAIL: TestParseSSHCommandRejectsUnsupportedInput/attached_port_form
    ParseSSHCommand("ssh -p2222 tok123@example.com") = []string{"-p2222", "tok123@example.com"}, want an error
--- FAIL: TestParseSSHCommandRejectsUnsupportedInput/host_with_an_empty_label
    ParseSSHCommand("ssh tok123@a..b") = []string{"tok123@a..b"}, want an error
--- FAIL: TestParseSSHCommandRejectsUnsupportedInput/unbracketed_ipv6_host
    ParseSSHCommand("ssh tok123@2001:db8::1") = []string{"tok123@2001:db8::1"}, want an error
```

## Verification

```
go build ./cli/...                      OK
go test ./cli/...                       ok github.com/daytona/clients/cli/cmd/common 0.004s (all cli packages ok)
go vet ./cli/...                        OK
GOOS=windows go build ./cli/...         OK   # ssh_windows.go still compiles
golangci-lint run ./...   (in cli/)      0 issues
gofmt -l cli/cmd/common/                 clean
```

Manual check against a live sandbox on `app.daytona.io`, using a binary built from this branch:

- `daytona ssh --help` unchanged.
- `daytona ssh <sandbox-id>` in a real terminal connected normally (host key prompt, interactive shell, `hostname`/`id` inside the sandbox, clean `exit`). The connection path is unaffected.

## Compatibility

The API composes only the two supported shapes, and the token alphabet is alphanumeric, so no current server response is rejected. An older API deployment emitting a different shape would now receive a clear CLI error instead of having its response forwarded to `ssh(1)`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the documented SSH command format so malformed API responses now produce a clear CLI error instead of being forwarded to `ssh(1)`. The parser validates the user, host, and port components and rebuilds the argument vector from those validated values.

- Only `ssh user@host` and `ssh -p port user@host` are accepted.
- Host validation accepts RFC 1123 hostnames, IPv4 literals, and bracketed IPv6 literals, including IPv4-mapped forms.
- Commands over 512 characters are rejected before parsing.
- Extra arguments, unsupported options, and out-of-range ports are rejected with specific errors.
- Adds table-driven tests covering all accepted and rejected inputs.

<sup>Written for commit fead748173bbedba5d98d8ecdba27e5da4267e0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Follow-up from review

- **IPv4-mapped IPv6 hosts.** The first revision decided the address family from the parsed bytes, so `::ffff:c000:201` looked like IPv4 and the bracketed form was rejected while the bare form was accepted — the wrong way round, since `URL.hostname` normalises `[::ffff:192.0.2.1]` to `[::ffff:c000:201]` and that bracketed form is exactly what the API can emit. The family is now decided by the textual form (presence of a colon), which matches the API's own `isIP(...) === 6` check for bracketed hosts.
- **Length bound.** The whole response is now bounded at 512 bytes before tokenization. The longest command the API can compose is `ssh -p 65535 ` + a 32 character token + `@` + a host of at most 253 characters, so the bound cannot reject a legitimate response.
- **Error assertions.** The reject table now asserts the specific error text per case, so collapsing the classification into one generic error would fail the tests. Added cases: mapped-IPv6 accepted/rejected pair, over-long label, bracketed hostname, `-p` without a destination, and the over-long command.

Re-verified after the follow-up: `go build`, `go test`, `go vet`, `GOOS=windows go build`, `golangci-lint run` (0 issues), and another live interactive `daytona ssh <sandbox>` against `app.daytona.io` with a freshly built binary.
