### PR TITLE
fix(sdk-typescript): retry requests on stale connections

### DIFF
--- a/sdk-typescript/runtime-tests/azure-functions/run.sh
+++ b/sdk-typescript/runtime-tests/azure-functions/run.sh
@@ -29,7 +29,7 @@ EOF
 PORT=${RUNTIME_TEST_PORT:-3805}
 
 env DAYTONA_API_KEY="$DAYTONA_API_KEY" DAYTONA_API_URL="$DAYTONA_API_URL" \
-  func start --port "$PORT" >/tmp/azure-runtime.log 2>&1 &
+  func start --port "$PORT" >/tmp/azure-functions-runtime.log 2>&1 &
 PID=$!
 trap "kill -9 $PID 2>/dev/null || true; pkill -9 -f 'func.*start' 2>/dev/null || true" EXIT
 

--- a/sdk-typescript/runtime-tests/cloudflare-workers/run.sh
+++ b/sdk-typescript/runtime-tests/cloudflare-workers/run.sh
@@ -14,7 +14,7 @@ DAYTONA_API_KEY=$DAYTONA_API_KEY
 DAYTONA_API_URL=$DAYTONA_API_URL
 EOF
 
-npx wrangler dev --local --port "$PORT" >/tmp/wrangler-runtime.log 2>&1 &
+npx wrangler dev --local --port "$PORT" >/tmp/cloudflare-workers-runtime.log 2>&1 &
 PID=$!
 trap "kill -9 $PID 2>/dev/null || true; pkill -9 -f 'wrangler dev' 2>/dev/null || true; pkill -9 -f workerd 2>/dev/null || true; rm -f .dev.vars" EXIT
 

--- a/sdk-typescript/runtime-tests/nextjs-external/run.sh
+++ b/sdk-typescript/runtime-tests/nextjs-external/run.sh
@@ -56,12 +56,12 @@ echo "Sandbox created: $SANDBOX_ID"
 ls node_modules/@next >/tmp/nextjs-external-build.log 2>&1 || true
 NODE_ENV=production npm run build >>/tmp/nextjs-external-build.log 2>&1
 
-PORT=${RUNTIME_TEST_PORT:-3804}
+PORT=${RUNTIME_TEST_PORT:-3806}
 NODE_ENV=production npx next start -p "$PORT" >/tmp/nextjs-external-runtime.log 2>&1 &
 SERVER_PID=$!
 
 for i in $(seq 1 30); do
-  if curl -sf "http://localhost:$PORT/api/sandboxes" >/dev/null 2>&1; then break; fi
+  if curl -sf -m 5 "http://localhost:$PORT/api/sandboxes" >/dev/null 2>&1; then break; fi
   sleep 1
 done
 

--- a/sdk-typescript/runtime-tests/nextjs-external/run.sh
+++ b/sdk-typescript/runtime-tests/nextjs-external/run.sh
@@ -42,6 +42,7 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
+trap 'exit 143' TERM
 
 SANDBOX_ID=$(node --input-type=module -e "
 import { Daytona } from '@daytona/sdk';
@@ -52,7 +53,8 @@ process.stdout.write(s.id);
 ")
 echo "Sandbox created: $SANDBOX_ID"
 
-NODE_ENV=production npm run build >/tmp/nextjs-external-build.log 2>&1
+ls node_modules/@next >/tmp/nextjs-external-build.log 2>&1 || true
+NODE_ENV=production npm run build >>/tmp/nextjs-external-build.log 2>&1
 
 PORT=${RUNTIME_TEST_PORT:-3804}
 NODE_ENV=production npx next start -p "$PORT" >/tmp/nextjs-external-runtime.log 2>&1 &

--- a/sdk-typescript/runtime-tests/nextjs-external/run.sh
+++ b/sdk-typescript/runtime-tests/nextjs-external/run.sh
@@ -23,6 +23,13 @@ FILE_PATH="test.txt"
 SANDBOX_ID=""
 SERVER_PID=""
 cleanup() {
+  local status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "--- next build output (tail) ---"
+    tail -n 60 /tmp/nextjs-external-build.log 2>/dev/null || true
+    echo "--- next start output (tail) ---"
+    tail -n 60 /tmp/nextjs-external-runtime.log 2>/dev/null || true
+  fi
   if [ -n "$SANDBOX_ID" ]; then
     node --input-type=module -e "
       import { Daytona } from '@daytona/sdk';
@@ -45,7 +52,7 @@ process.stdout.write(s.id);
 ")
 echo "Sandbox created: $SANDBOX_ID"
 
-NODE_ENV=production npm run build >/dev/null
+NODE_ENV=production npm run build >/tmp/nextjs-external-build.log 2>&1
 
 PORT=${RUNTIME_TEST_PORT:-3804}
 NODE_ENV=production npx next start -p "$PORT" >/tmp/nextjs-external-runtime.log 2>&1 &

--- a/sdk-typescript/runtime-tests/nextjs/run.sh
+++ b/sdk-typescript/runtime-tests/nextjs/run.sh
@@ -30,7 +30,7 @@ npx next start -p "$PORT" >/tmp/nextjs-runtime.log 2>&1 &
 PID=$!
 
 for i in $(seq 1 30); do
-  if curl -sf "http://localhost:$PORT/api/sandboxes" >/dev/null 2>&1; then break; fi
+  if curl -sf -m 5 "http://localhost:$PORT/api/sandboxes" >/dev/null 2>&1; then break; fi
   sleep 1
 done
 

--- a/sdk-typescript/runtime-tests/nextjs/run.sh
+++ b/sdk-typescript/runtime-tests/nextjs/run.sh
@@ -6,12 +6,26 @@ set -euo pipefail
 rm -rf node_modules package-lock.json .next
 npm install --silent
 npm install --silent "$API_CLIENT_TARBALL" "$TOOLBOX_API_CLIENT_TARBALL" "$ANALYTICS_API_CLIENT_TARBALL" "$SDK_TARBALL"
-npm run build >/dev/null
+cleanup() {
+  local status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "--- next build output (tail) ---"
+    tail -n 60 /tmp/nextjs-build.log 2>/dev/null || true
+    echo "--- next start output (tail) ---"
+    tail -n 60 /tmp/nextjs-runtime.log 2>/dev/null || true
+  fi
+  if [ -n "${PID:-}" ]; then
+    kill -9 "$PID" 2>/dev/null || true
+  fi
+  pkill -9 -f 'next start' 2>/dev/null || true
+}
+trap cleanup EXIT
+
+npm run build >/tmp/nextjs-build.log 2>&1
 
 PORT=${RUNTIME_TEST_PORT:-3801}
 npx next start -p "$PORT" >/tmp/nextjs-runtime.log 2>&1 &
 PID=$!
-trap "kill -9 $PID 2>/dev/null || true; pkill -9 -f 'next start' 2>/dev/null || true" EXIT
 
 for i in $(seq 1 30); do
   if curl -sf "http://localhost:$PORT/api/sandboxes" >/dev/null 2>&1; then break; fi

--- a/sdk-typescript/runtime-tests/nextjs/run.sh
+++ b/sdk-typescript/runtime-tests/nextjs/run.sh
@@ -20,8 +20,10 @@ cleanup() {
   pkill -9 -f 'next start' 2>/dev/null || true
 }
 trap cleanup EXIT
+trap 'exit 143' TERM
 
-npm run build >/tmp/nextjs-build.log 2>&1
+ls node_modules/@next >/tmp/nextjs-build.log 2>&1 || true
+npm run build >>/tmp/nextjs-build.log 2>&1
 
 PORT=${RUNTIME_TEST_PORT:-3801}
 npx next start -p "$PORT" >/tmp/nextjs-runtime.log 2>&1 &

--- a/sdk-typescript/runtime-tests/run-all.sh
+++ b/sdk-typescript/runtime-tests/run-all.sh
@@ -34,6 +34,11 @@ fi
 export npm_config_audit=false
 export npm_config_fund=false
 export npm_config_update_notifier=false
+# `next build` fetches full registry packuments (no timeout) to patch the
+# throwaway lockfile's missing platform-specific @next/swc-* entries, and posts
+# telemetry. Neither matters here; both are network calls we don't want to wait on.
+export NEXT_IGNORE_INCORRECT_LOCKFILE=1
+export NEXT_TELEMETRY_DISABLED=1
 
 DIST_LIBS="$(cd "$DIST/../" && pwd)"
 API_CLIENT_DIST="$DIST_LIBS/api-client"

--- a/sdk-typescript/runtime-tests/run-all.sh
+++ b/sdk-typescript/runtime-tests/run-all.sh
@@ -117,11 +117,13 @@ for runtime in "${RUNTIMES[@]}"; do
   start=$SECONDS
   # Strip any ambient NODE_ENV (e.g. the Nix dev shell sets development) so each
   # framework's production build/prerender runs with the React production build.
-  if (cd "$WORK_DIR" && timeout -k 15 "$RUNTIME_TIMEOUT_SECONDS" env -u NODE_ENV bash run.sh); then
+  status=0
+  (cd "$WORK_DIR" && timeout -k 15 "$RUNTIME_TIMEOUT_SECONDS" env -u NODE_ENV bash run.sh) || status=$?
+  if [ "$status" -eq 0 ]; then
     duration=$((SECONDS - start))
     PASS+=("$runtime (${duration}s)")
     echo "✓ $runtime PASS (${duration}s)"
-  elif [ $? -eq 124 ]; then
+  elif [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
     FAIL+=("$runtime (timed out after ${RUNTIME_TIMEOUT_SECONDS}s)")
     echo "✗ $runtime TIMEOUT (${RUNTIME_TIMEOUT_SECONDS}s)"
     for log in /tmp/"$runtime"-*.log; do

--- a/sdk-typescript/runtime-tests/run-all.sh
+++ b/sdk-typescript/runtime-tests/run-all.sh
@@ -124,6 +124,11 @@ for runtime in "${RUNTIMES[@]}"; do
   elif [ $? -eq 124 ]; then
     FAIL+=("$runtime (timed out after ${RUNTIME_TIMEOUT_SECONDS}s)")
     echo "✗ $runtime TIMEOUT (${RUNTIME_TIMEOUT_SECONDS}s)"
+    for log in /tmp/"$runtime"-*.log; do
+      [ -f "$log" ] || continue
+      echo "--- $(basename "$log") (tail) ---"
+      tail -n 60 "$log"
+    done
   else
     duration=$((SECONDS - start))
     FAIL+=("$runtime (${duration}s)")

--- a/sdk-typescript/runtime-tests/run-all.sh
+++ b/sdk-typescript/runtime-tests/run-all.sh
@@ -27,6 +27,14 @@ if [ -z "${DAYTONA_API_KEY:-}" ] || [ -z "${DAYTONA_API_URL:-}" ]; then
   exit 1
 fi
 
+# Each runtime does a cold `npm install` into a throwaway directory. Skip the
+# registry side-calls that add nothing there (audit, funding, npm self-update
+# check): they hit separate registry endpoints whose degradation has stalled
+# installs for many minutes and pushed the whole job past its timeout.
+export npm_config_audit=false
+export npm_config_fund=false
+export npm_config_update_notifier=false
+
 DIST_LIBS="$(cd "$DIST/../" && pwd)"
 API_CLIENT_DIST="$DIST_LIBS/api-client"
 TOOLBOX_DIST="$DIST_LIBS/toolbox-api-client"

--- a/sdk-typescript/runtime-tests/run-all.sh
+++ b/sdk-typescript/runtime-tests/run-all.sh
@@ -40,6 +40,10 @@ export npm_config_update_notifier=false
 export NEXT_IGNORE_INCORRECT_LOCKFILE=1
 export NEXT_TELEMETRY_DISABLED=1
 
+# A single stalled runtime must fail visibly (with its output) rather than eat
+# the whole job's time budget and surface as "cancelled" with no diagnostics.
+RUNTIME_TIMEOUT_SECONDS="${RUNTIME_TEST_TIMEOUT_SECONDS:-480}"
+
 DIST_LIBS="$(cd "$DIST/../" && pwd)"
 API_CLIENT_DIST="$DIST_LIBS/api-client"
 TOOLBOX_DIST="$DIST_LIBS/toolbox-api-client"
@@ -113,10 +117,13 @@ for runtime in "${RUNTIMES[@]}"; do
   start=$SECONDS
   # Strip any ambient NODE_ENV (e.g. the Nix dev shell sets development) so each
   # framework's production build/prerender runs with the React production build.
-  if (cd "$WORK_DIR" && env -u NODE_ENV bash run.sh); then
+  if (cd "$WORK_DIR" && timeout -k 15 "$RUNTIME_TIMEOUT_SECONDS" env -u NODE_ENV bash run.sh); then
     duration=$((SECONDS - start))
     PASS+=("$runtime (${duration}s)")
     echo "✓ $runtime PASS (${duration}s)"
+  elif [ $? -eq 124 ]; then
+    FAIL+=("$runtime (timed out after ${RUNTIME_TIMEOUT_SECONDS}s)")
+    echo "✗ $runtime TIMEOUT (${RUNTIME_TIMEOUT_SECONDS}s)"
   else
     duration=$((SECONDS - start))
     FAIL+=("$runtime (${duration}s)")

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -36,6 +36,7 @@ import { WarmPoolService } from './WarmPool'
 import { getPackageInfo, dynamicRequire } from './utils/Import'
 import { EventDispatcher } from './utils/EventDispatcher'
 import { EventSubscriptionManager } from './utils/EventSubscriptionManager'
+import { withConnectionRetry } from './utils/RetryAdapter'
 
 const packageJson = getPackageInfo()
 import { processStreamingResponse } from './utils/Stream'
@@ -1017,6 +1018,7 @@ export class Daytona implements AsyncDisposable {
       // fetch adapter would otherwise apply, so set a mode workerd accepts.
       // Ignored by the Node http adapter. API responses are not cacheable anyway.
       fetchOptions: { cache: 'no-store' },
+      adapter: withConnectionRetry(axios.getAdapter(axios.defaults.adapter)),
     })
 
     // Request interceptor: Inject trace context into headers

--- a/sdk-typescript/src/__tests__/ConnectionRetry.server.test.ts
+++ b/sdk-typescript/src/__tests__/ConnectionRetry.server.test.ts
@@ -1,0 +1,72 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as http from 'http'
+import { AddressInfo } from 'net'
+
+import { Daytona } from '../Daytona'
+import { DaytonaConnectionError } from '../errors/DaytonaError'
+
+/**
+ * Real-socket regression for stale keep-alive handling: the server reads the
+ * request, then closes the connection without writing a single response byte.
+ * Node reports that as `socket hang up` (ECONNRESET) — the same signature a
+ * client sees when a proxy/LB drops a kept-alive connection during a rollout.
+ */
+function startFlakyServer(dropFirst: number): Promise<{ url: string; seen: () => number; close: () => Promise<void> }> {
+  let requests = 0
+  const server = http.createServer((req, res) => {
+    requests++
+    req.on('data', () => undefined)
+    req.on('end', () => {
+      if (requests <= dropFirst) {
+        req.socket.destroy()
+        return
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ attempt: requests }))
+    })
+  })
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        seen: () => requests,
+        close: () => new Promise((done) => server.close(() => done())),
+      })
+    })
+  })
+}
+
+describe('Daytona.createAxiosInstance against a server that drops connections', () => {
+  it('a POST whose connection is closed before any response bytes is retried transparently', async () => {
+    const server = await startFlakyServer(1)
+    try {
+      const axios = Daytona.createAxiosInstance()
+
+      const res = await axios.post(`${server.url}/process/execute`, { command: 'echo hi' })
+
+      expect(res.status).toBe(200)
+      expect(res.data).toEqual({ attempt: 2 })
+      expect(server.seen()).toBe(2)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('surfaces DaytonaConnectionError once the retry budget is exhausted', async () => {
+    const server = await startFlakyServer(Infinity)
+    try {
+      const axios = Daytona.createAxiosInstance()
+
+      await expect(axios.post(`${server.url}/process/execute`, { command: 'echo hi' })).rejects.toBeInstanceOf(
+        DaytonaConnectionError,
+      )
+
+      expect(server.seen()).toBe(3)
+    } finally {
+      await server.close()
+    }
+  })
+})

--- a/sdk-typescript/src/__tests__/ConnectionRetry.server.test.ts
+++ b/sdk-typescript/src/__tests__/ConnectionRetry.server.test.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as http from 'http'
-import { AddressInfo } from 'net'
+import * as net from 'net'
+import type { AddressInfo } from 'net'
 
 import { Daytona } from '../Daytona'
 import { DaytonaConnectionError } from '../errors/DaytonaError'
@@ -40,16 +41,31 @@ function startFlakyServer(dropFirst: number): Promise<{ url: string; seen: () =>
 }
 
 describe('Daytona.createAxiosInstance against a server that drops connections', () => {
-  it('a POST whose connection is closed before any response bytes is retried transparently', async () => {
+  it('a GET whose connection is closed before any response bytes is retried transparently', async () => {
     const server = await startFlakyServer(1)
     try {
       const axios = Daytona.createAxiosInstance()
 
-      const res = await axios.post(`${server.url}/process/execute`, { command: 'echo hi' })
+      const res = await axios.get(`${server.url}/sandbox/abc`)
 
       expect(res.status).toBe(200)
       expect(res.data).toEqual({ attempt: 2 })
       expect(server.seen()).toBe(2)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('a POST whose connection is closed before any response bytes is not replayed', async () => {
+    const server = await startFlakyServer(1)
+    try {
+      const axios = Daytona.createAxiosInstance()
+
+      await expect(axios.post(`${server.url}/process/execute`, { command: 'echo hi' })).rejects.toBeInstanceOf(
+        DaytonaConnectionError,
+      )
+
+      expect(server.seen()).toBe(1)
     } finally {
       await server.close()
     }
@@ -60,13 +76,41 @@ describe('Daytona.createAxiosInstance against a server that drops connections', 
     try {
       const axios = Daytona.createAxiosInstance()
 
-      await expect(axios.post(`${server.url}/process/execute`, { command: 'echo hi' })).rejects.toBeInstanceOf(
-        DaytonaConnectionError,
-      )
+      await expect(axios.get(`${server.url}/sandbox/abc`)).rejects.toBeInstanceOf(DaytonaConnectionError)
 
       expect(server.seen()).toBe(3)
     } finally {
       await server.close()
     }
+  })
+
+  it('a POST to a refused port (connect-phase failure) is attempted three times', async () => {
+    const probe = http.createServer()
+    const port = await new Promise<number>((resolve) =>
+      probe.listen(0, '127.0.0.1', () => {
+        const { port } = probe.address() as AddressInfo
+        probe.close(() => resolve(port))
+      }),
+    )
+    const agent = new http.Agent()
+    const connectAttempts: number[] = []
+    const createConnection = agent.createConnection.bind(agent)
+    agent.createConnection = ((
+      options: http.ClientRequestArgs,
+      callback?: (err: Error | null, stream: net.Socket) => void,
+    ) => {
+      connectAttempts.push(Number(options.port))
+      return createConnection(options, callback)
+    }) as typeof agent.createConnection
+    const axios = Daytona.createAxiosInstance()
+
+    await expect(
+      axios.post(`http://127.0.0.1:${port}/sandbox`, { name: 'x' }, { httpAgent: agent }),
+    ).rejects.toMatchObject({
+      constructor: DaytonaConnectionError,
+      message: expect.stringContaining('ECONNREFUSED'),
+    })
+
+    expect(connectAttempts).toEqual([port, port, port])
   })
 })

--- a/sdk-typescript/src/__tests__/Daytona.test.ts
+++ b/sdk-typescript/src/__tests__/Daytona.test.ts
@@ -30,10 +30,13 @@ const mockConfigurationCtor = jest.fn().mockImplementation((args: Record<string,
 
 jest.mock('axios', () => {
   class MockAxiosError extends Error {}
+  const mockAdapter = jest.fn()
   return {
     __esModule: true,
     default: {
       create: mockAxiosCreate,
+      defaults: { adapter: mockAdapter },
+      getAdapter: () => mockAdapter,
       AxiosError: MockAxiosError,
     },
     create: mockAxiosCreate,

--- a/sdk-typescript/src/__tests__/RetryAdapter.test.ts
+++ b/sdk-typescript/src/__tests__/RetryAdapter.test.ts
@@ -5,7 +5,7 @@ import { AxiosError, AxiosHeaders } from 'axios'
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { Readable } from 'stream'
 
-import { withConnectionRetry } from '../utils/RetryAdapter'
+import { retryBackoffSleep, withConnectionRetry } from '../utils/RetryAdapter'
 
 type ErrnoProps = { code: string; syscall?: string }
 
@@ -182,6 +182,16 @@ describe('withConnectionRetry', () => {
 
       expect(base).toHaveBeenCalledTimes(1)
       expect(abortingSleep).toHaveBeenCalledWith(expect.any(Number), controller.signal)
+    })
+
+    it('the default backoff returns immediately for an already-aborted signal', async () => {
+      const controller = new AbortController()
+      controller.abort()
+      const started = Date.now()
+
+      await retryBackoffSleep(10_000, controller.signal)
+
+      expect(Date.now() - started).toBeLessThan(100)
     })
 
     it('the default backoff wakes up as soon as the signal aborts', async () => {

--- a/sdk-typescript/src/__tests__/RetryAdapter.test.ts
+++ b/sdk-typescript/src/__tests__/RetryAdapter.test.ts
@@ -1,0 +1,222 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AxiosError, AxiosHeaders, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
+import { Readable } from 'stream'
+
+import { withConnectionRetry } from '../utils/RetryAdapter'
+
+type ErrnoProps = { code: string; syscall?: string }
+
+function nodeError(message: string, props: ErrnoProps): Error {
+  return Object.assign(new Error(message), props)
+}
+
+function requestConfig(overrides: Partial<InternalAxiosRequestConfig> = {}): InternalAxiosRequestConfig {
+  return { method: 'post', url: 'http://localhost/x', headers: new AxiosHeaders(), ...overrides }
+}
+
+/** Mirrors how axios' http adapter wraps a Node socket error: `AxiosError.from(err, null, config, req)`. */
+function transportError(config: InternalAxiosRequestConfig, message: string, props: ErrnoProps): AxiosError {
+  return AxiosError.from(nodeError(message, props), undefined, config, {})
+}
+
+function okResponse(config: InternalAxiosRequestConfig): AxiosResponse {
+  return { data: 'ok', status: 200, statusText: 'OK', headers: {}, config }
+}
+
+const SOCKET_HANG_UP: [string, ErrnoProps] = ['socket hang up', { code: 'ECONNRESET' }]
+const READ_RESET: [string, ErrnoProps] = ['read ECONNRESET', { code: 'ECONNRESET', syscall: 'read' }]
+const CONNECT_REFUSED: [string, ErrnoProps] = [
+  'connect ECONNREFUSED 127.0.0.1:1',
+  { code: 'ECONNREFUSED', syscall: 'connect' },
+]
+const CONNECT_TIMEOUT: [string, ErrnoProps] = [
+  'connect ETIMEDOUT 10.0.0.1:443',
+  { code: 'ETIMEDOUT', syscall: 'connect' },
+]
+
+/** Base adapter that fails `failures` times with the given error factory, then succeeds. */
+function failingAdapter(failures: number, makeError: (config: InternalAxiosRequestConfig) => unknown) {
+  let calls = 0
+  const adapter = jest.fn(async (config: InternalAxiosRequestConfig) => {
+    calls++
+    if (calls <= failures) throw makeError(config)
+    return okResponse(config)
+  })
+  return adapter
+}
+
+describe('withConnectionRetry', () => {
+  const sleep = jest.fn(async () => undefined)
+
+  beforeEach(() => sleep.mockClear())
+
+  it('returns the first successful response without sleeping', async () => {
+    const base = failingAdapter(0, () => new Error('unused'))
+    const adapter = withConnectionRetry(base, { sleep })
+
+    const res = await adapter(requestConfig())
+
+    expect(res.status).toBe(200)
+    expect(base).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  describe('zero-byte disconnect ("socket hang up") is retried on any method', () => {
+    it.each(['post', 'patch', 'get', 'delete'])('retries %s and backs off with jitter', async (method) => {
+      const base = failingAdapter(1, (c) => transportError(c, ...SOCKET_HANG_UP))
+      const adapter = withConnectionRetry(base, { sleep })
+
+      const res = await adapter(requestConfig({ method }))
+
+      expect(res.status).toBe(200)
+      expect(base).toHaveBeenCalledTimes(2)
+      expect(sleep).toHaveBeenCalledTimes(1)
+      const [delay] = sleep.mock.calls[0] as unknown as [number]
+      expect(delay).toBeGreaterThanOrEqual(250)
+      expect(delay).toBeLessThan(350)
+    })
+  })
+
+  describe('connect-phase failures (nothing written) are retried on any method', () => {
+    it.each([CONNECT_REFUSED, CONNECT_TIMEOUT])('retries POST after %s', async (message, props) => {
+      const base = failingAdapter(1, (c) => transportError(c, message, props))
+      const adapter = withConnectionRetry(base, { sleep })
+
+      const res = await adapter(requestConfig({ method: 'post' }))
+
+      expect(res.status).toBe(200)
+      expect(base).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('mid-flight resets (server may have processed the request)', () => {
+    it.each(['post', 'patch'])('surfaces the error unchanged for non-idempotent %s', async (method) => {
+      const base = failingAdapter(1, (c) => transportError(c, ...READ_RESET))
+      const adapter = withConnectionRetry(base, { sleep })
+
+      await expect(adapter(requestConfig({ method }))).rejects.toMatchObject({ code: 'ECONNRESET' })
+
+      expect(base).toHaveBeenCalledTimes(1)
+      expect(sleep).not.toHaveBeenCalled()
+    })
+
+    it.each(['get', 'head', 'put', 'delete'])('retries idempotent %s', async (method) => {
+      const base = failingAdapter(1, (c) => transportError(c, ...READ_RESET))
+      const adapter = withConnectionRetry(base, { sleep })
+
+      const res = await adapter(requestConfig({ method }))
+
+      expect(res.status).toBe(200)
+      expect(base).toHaveBeenCalledTimes(2)
+    })
+
+    it('retries EPIPE only for idempotent methods', async () => {
+      const epipe = (c: InternalAxiosRequestConfig) =>
+        transportError(c, 'write EPIPE', { code: 'EPIPE', syscall: 'write' })
+
+      await expect(
+        withConnectionRetry(failingAdapter(1, epipe), { sleep })(requestConfig({ method: 'post' })),
+      ).rejects.toMatchObject({
+        code: 'EPIPE',
+      })
+      await expect(
+        withConnectionRetry(failingAdapter(1, epipe), { sleep })(requestConfig({ method: 'get' })),
+      ).resolves.toMatchObject({
+        status: 200,
+      })
+    })
+  })
+
+  describe('never retried', () => {
+    it('HTTP responses (even 5xx) are not retried', async () => {
+      const base = failingAdapter(1, (c) => {
+        const response: AxiosResponse = { ...okResponse(c), status: 502, statusText: 'Bad Gateway' }
+        return new AxiosError('Bad Gateway', AxiosError.ERR_BAD_RESPONSE, c, {}, response)
+      })
+      const adapter = withConnectionRetry(base, { sleep })
+
+      await expect(adapter(requestConfig({ method: 'get' }))).rejects.toMatchObject({ response: { status: 502 } })
+
+      expect(base).toHaveBeenCalledTimes(1)
+    })
+
+    it('client-side axios timeouts are not retried', async () => {
+      const base = failingAdapter(1, (c) => new AxiosError('timeout of 10ms exceeded', AxiosError.ECONNABORTED, c, {}))
+      const adapter = withConnectionRetry(base, { sleep })
+
+      await expect(adapter(requestConfig({ method: 'get' }))).rejects.toMatchObject({ code: 'ECONNABORTED' })
+
+      expect(base).toHaveBeenCalledTimes(1)
+    })
+
+    it('an already-aborted request is not retried', async () => {
+      const controller = new AbortController()
+      const base = failingAdapter(1, (c) => {
+        controller.abort()
+        return transportError(c, ...SOCKET_HANG_UP)
+      })
+      const adapter = withConnectionRetry(base, { sleep })
+
+      await expect(adapter(requestConfig({ method: 'get', signal: controller.signal }))).rejects.toMatchObject({
+        code: 'ECONNRESET',
+      })
+
+      expect(base).toHaveBeenCalledTimes(1)
+    })
+
+    it.each<[string, unknown]>([
+      ['a Node Readable body', Readable.from(['chunk'])],
+      ['a form-data body', { getBoundary: () => 'b', pipe: () => undefined }],
+      ['a web ReadableStream body', { getReader: () => undefined }],
+    ])('a request with %s is not replayed', async (_label, data) => {
+      const base = failingAdapter(1, (c) => transportError(c, ...SOCKET_HANG_UP))
+      const adapter = withConnectionRetry(base, { sleep })
+
+      await expect(adapter(requestConfig({ method: 'post', data }))).rejects.toMatchObject({ code: 'ECONNRESET' })
+
+      expect(base).toHaveBeenCalledTimes(1)
+    })
+
+    it.each<[string, unknown]>([
+      ['a JSON string', '{"a":1}'],
+      ['a Buffer', Buffer.from('x')],
+      ['a Uint8Array', new Uint8Array(2)],
+      ['a plain object', { a: 1 }],
+      ['no body', undefined],
+    ])('a request with %s is replayed', async (_label, data) => {
+      const base = failingAdapter(1, (c) => transportError(c, ...SOCKET_HANG_UP))
+      const adapter = withConnectionRetry(base, { sleep })
+
+      await expect(adapter(requestConfig({ method: 'post', data }))).resolves.toMatchObject({ status: 200 })
+
+      expect(base).toHaveBeenCalledTimes(2)
+    })
+
+    it('non-axios errors pass through untouched', async () => {
+      const boom = new TypeError('boom')
+      const base = failingAdapter(1, () => boom)
+      const adapter = withConnectionRetry(base, { sleep })
+
+      await expect(adapter(requestConfig({ method: 'get' }))).rejects.toBe(boom)
+
+      expect(base).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('gives up after the retry budget and rethrows the last error with linear backoff', async () => {
+    const base = failingAdapter(Infinity, (c) => transportError(c, ...SOCKET_HANG_UP))
+    const adapter = withConnectionRetry(base, { sleep, maxRetries: 2 })
+
+    await expect(adapter(requestConfig({ method: 'get' }))).rejects.toMatchObject({ message: 'socket hang up' })
+
+    expect(base).toHaveBeenCalledTimes(3)
+    expect(sleep).toHaveBeenCalledTimes(2)
+    const delays = sleep.mock.calls.map((call) => (call as unknown as [number])[0])
+    expect(delays[0]).toBeGreaterThanOrEqual(250)
+    expect(delays[0]).toBeLessThan(350)
+    expect(delays[1]).toBeGreaterThanOrEqual(500)
+    expect(delays[1]).toBeLessThan(600)
+  })
+})

--- a/sdk-typescript/src/__tests__/RetryAdapter.test.ts
+++ b/sdk-typescript/src/__tests__/RetryAdapter.test.ts
@@ -1,7 +1,8 @@
 // Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AxiosError, AxiosHeaders, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
+import { AxiosError, AxiosHeaders } from 'axios'
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { Readable } from 'stream'
 
 import { withConnectionRetry } from '../utils/RetryAdapter'
@@ -163,6 +164,40 @@ describe('withConnectionRetry', () => {
         code: 'ECONNRESET',
       })
 
+      expect(base).toHaveBeenCalledTimes(1)
+    })
+
+    it('a request aborted during the backoff is cancelled instead of re-attempted', async () => {
+      const controller = new AbortController()
+      const abortingSleep = jest.fn(async (_ms: number, signal?: { aborted: boolean }) => {
+        controller.abort()
+        expect(signal?.aborted).toBe(true)
+      })
+      const base = failingAdapter(1, (c) => transportError(c, ...SOCKET_HANG_UP))
+      const adapter = withConnectionRetry(base, { sleep: abortingSleep })
+
+      await expect(adapter(requestConfig({ method: 'get', signal: controller.signal }))).rejects.toMatchObject({
+        code: 'ERR_CANCELED',
+      })
+
+      expect(base).toHaveBeenCalledTimes(1)
+      expect(abortingSleep).toHaveBeenCalledWith(expect.any(Number), controller.signal)
+    })
+
+    it('the default backoff wakes up as soon as the signal aborts', async () => {
+      const controller = new AbortController()
+      const base = failingAdapter(1, (c) => {
+        setTimeout(() => controller.abort(), 5)
+        return transportError(c, ...SOCKET_HANG_UP)
+      })
+      const adapter = withConnectionRetry(base)
+      const started = Date.now()
+
+      await expect(adapter(requestConfig({ method: 'get', signal: controller.signal }))).rejects.toMatchObject({
+        code: 'ERR_CANCELED',
+      })
+
+      expect(Date.now() - started).toBeLessThan(200)
       expect(base).toHaveBeenCalledTimes(1)
     })
 

--- a/sdk-typescript/src/__tests__/RetryAdapter.test.ts
+++ b/sdk-typescript/src/__tests__/RetryAdapter.test.ts
@@ -64,37 +64,33 @@ describe('withConnectionRetry', () => {
     expect(sleep).not.toHaveBeenCalled()
   })
 
-  describe('zero-byte disconnect ("socket hang up") is retried on any method', () => {
-    it.each(['post', 'patch', 'get', 'delete'])('retries %s and backs off with jitter', async (method) => {
-      const base = failingAdapter(1, (c) => transportError(c, ...SOCKET_HANG_UP))
-      const adapter = withConnectionRetry(base, { sleep })
-
-      const res = await adapter(requestConfig({ method }))
-
-      expect(res.status).toBe(200)
-      expect(base).toHaveBeenCalledTimes(2)
-      expect(sleep).toHaveBeenCalledTimes(1)
-      const [delay] = sleep.mock.calls[0] as unknown as [number]
-      expect(delay).toBeGreaterThanOrEqual(250)
-      expect(delay).toBeLessThan(350)
-    })
-  })
-
   describe('connect-phase failures (nothing written) are retried on any method', () => {
-    it.each([CONNECT_REFUSED, CONNECT_TIMEOUT])('retries POST after %s', async (message, props) => {
-      const base = failingAdapter(1, (c) => transportError(c, message, props))
-      const adapter = withConnectionRetry(base, { sleep })
+    it.each([CONNECT_REFUSED, CONNECT_TIMEOUT])(
+      'retries POST after %s and backs off with jitter',
+      async (message, props) => {
+        const base = failingAdapter(1, (c) => transportError(c, message, props))
+        const adapter = withConnectionRetry(base, { sleep })
 
-      const res = await adapter(requestConfig({ method: 'post' }))
+        const res = await adapter(requestConfig({ method: 'post' }))
 
-      expect(res.status).toBe(200)
-      expect(base).toHaveBeenCalledTimes(2)
-    })
+        expect(res.status).toBe(200)
+        expect(base).toHaveBeenCalledTimes(2)
+        expect(sleep).toHaveBeenCalledTimes(1)
+        const [delay] = sleep.mock.calls[0] as unknown as [number]
+        expect(delay).toBeGreaterThanOrEqual(250)
+        expect(delay).toBeLessThan(350)
+      },
+    )
   })
 
-  describe('mid-flight resets (server may have processed the request)', () => {
-    it.each(['post', 'patch'])('surfaces the error unchanged for non-idempotent %s', async (method) => {
-      const base = failingAdapter(1, (c) => transportError(c, ...READ_RESET))
+  describe('disconnects after the request may have been sent (server may have processed it)', () => {
+    it.each([
+      ['post', SOCKET_HANG_UP],
+      ['patch', SOCKET_HANG_UP],
+      ['post', READ_RESET],
+      ['patch', READ_RESET],
+    ])('surfaces the error unchanged for non-idempotent %s after %s', async (method, [message, props]) => {
+      const base = failingAdapter(1, (c) => transportError(c, message, props))
       const adapter = withConnectionRetry(base, { sleep })
 
       await expect(adapter(requestConfig({ method }))).rejects.toMatchObject({ code: 'ECONNRESET' })
@@ -103,8 +99,17 @@ describe('withConnectionRetry', () => {
       expect(sleep).not.toHaveBeenCalled()
     })
 
-    it.each(['get', 'head', 'put', 'delete'])('retries idempotent %s', async (method) => {
-      const base = failingAdapter(1, (c) => transportError(c, ...READ_RESET))
+    it.each([
+      ['get', SOCKET_HANG_UP],
+      ['head', SOCKET_HANG_UP],
+      ['put', SOCKET_HANG_UP],
+      ['delete', SOCKET_HANG_UP],
+      ['get', READ_RESET],
+      ['head', READ_RESET],
+      ['put', READ_RESET],
+      ['delete', READ_RESET],
+    ])('retries idempotent %s after %s', async (method, [message, props]) => {
+      const base = failingAdapter(1, (c) => transportError(c, message, props))
       const adapter = withConnectionRetry(base, { sleep })
 
       const res = await adapter(requestConfig({ method }))
@@ -216,10 +221,10 @@ describe('withConnectionRetry', () => {
       ['a form-data body', { getBoundary: () => 'b', pipe: () => undefined }],
       ['a web ReadableStream body', { getReader: () => undefined }],
     ])('a request with %s is not replayed', async (_label, data) => {
-      const base = failingAdapter(1, (c) => transportError(c, ...SOCKET_HANG_UP))
+      const base = failingAdapter(1, (c) => transportError(c, ...CONNECT_REFUSED))
       const adapter = withConnectionRetry(base, { sleep })
 
-      await expect(adapter(requestConfig({ method: 'post', data }))).rejects.toMatchObject({ code: 'ECONNRESET' })
+      await expect(adapter(requestConfig({ method: 'post', data }))).rejects.toMatchObject({ code: 'ECONNREFUSED' })
 
       expect(base).toHaveBeenCalledTimes(1)
     })
@@ -231,7 +236,7 @@ describe('withConnectionRetry', () => {
       ['a plain object', { a: 1 }],
       ['no body', undefined],
     ])('a request with %s is replayed', async (_label, data) => {
-      const base = failingAdapter(1, (c) => transportError(c, ...SOCKET_HANG_UP))
+      const base = failingAdapter(1, (c) => transportError(c, ...CONNECT_REFUSED))
       const adapter = withConnectionRetry(base, { sleep })
 
       await expect(adapter(requestConfig({ method: 'post', data }))).resolves.toMatchObject({ status: 200 })

--- a/sdk-typescript/src/utils/RetryAdapter.ts
+++ b/sdk-typescript/src/utils/RetryAdapter.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { trace } from '@opentelemetry/api'
-import { AxiosAdapter, AxiosError, InternalAxiosRequestConfig } from 'axios'
+import { AxiosError, CanceledError } from 'axios'
+import type { AxiosAdapter, GenericAbortSignal, InternalAxiosRequestConfig } from 'axios'
 
 /**
  * Transport-level retry for transient connection failures, mirroring the
@@ -45,7 +46,7 @@ type RetryVerdict = 'any-method' | 'idempotent-only' | 'never'
 
 interface ConnectionRetryOptions {
   readonly maxRetries?: number
-  readonly sleep?: (ms: number) => Promise<void>
+  readonly sleep?: (ms: number, signal?: GenericAbortSignal) => Promise<void>
 }
 
 function syscallOf(error: AxiosError): string | undefined {
@@ -64,7 +65,13 @@ function classify(error: AxiosError): RetryVerdict {
     return syscallOf(error) === 'connect' ? 'any-method' : 'never'
   }
   // Node reports "socket hang up" only when the peer closed before a single
-  // response byte arrived — the request was never processed.
+  // response byte arrived — for a well-behaved HTTP server that means the
+  // request was never processed (stale keep-alive socket, or a proxy/LB that
+  // dropped the connection during a rollout). The residual risk is a peer that
+  // processes a non-idempotent request and then dies before writing any
+  // response; the Python SDK (RemoteDisconnectedRetry) and the toolbox proxy's
+  // own upstream retry accept the same trade-off, so semantics stay consistent
+  // across clients.
   if (error.code === 'ECONNRESET' && error.message === 'socket hang up') return 'any-method'
   if (CONNECT_PHASE_CODES.has(error.code) || syscallOf(error) === 'connect') return 'any-method'
   if (MID_FLIGHT_CODES.has(error.code)) return 'idempotent-only'
@@ -97,7 +104,19 @@ function backoffMs(attempt: number): number {
   return BACKOFF_BASE_MS * attempt + Math.random() * BACKOFF_JITTER_MS
 }
 
-const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+function defaultSleep(ms: number, signal?: GenericAbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener?.('abort', onAbort)
+      resolve()
+    }, ms)
+    signal?.addEventListener?.('abort', onAbort, { once: true })
+  })
+}
 
 /**
  * Wraps an axios adapter with connection-level retries. See module docs for
@@ -119,7 +138,8 @@ export function withConnectionRetry(base: AxiosAdapter, options: ConnectionRetry
           'error.code': retryable.code ?? '',
           'error.message': retryable.message,
         })
-        await sleep(backoffMs(attempt))
+        await sleep(backoffMs(attempt), config.signal)
+        if (config.signal?.aborted) throw new CanceledError(undefined, config)
       }
     }
   }

--- a/sdk-typescript/src/utils/RetryAdapter.ts
+++ b/sdk-typescript/src/utils/RetryAdapter.ts
@@ -104,7 +104,8 @@ function backoffMs(attempt: number): number {
   return BACKOFF_BASE_MS * attempt + Math.random() * BACKOFF_JITTER_MS
 }
 
-function defaultSleep(ms: number, signal?: GenericAbortSignal): Promise<void> {
+export function retryBackoffSleep(ms: number, signal?: GenericAbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve()
   return new Promise<void>((resolve) => {
     const onAbort = () => {
       clearTimeout(timer)
@@ -124,7 +125,7 @@ function defaultSleep(ms: number, signal?: GenericAbortSignal): Promise<void> {
  */
 export function withConnectionRetry(base: AxiosAdapter, options: ConnectionRetryOptions = {}): AxiosAdapter {
   const maxRetries = options.maxRetries ?? MAX_RETRIES
-  const sleep = options.sleep ?? defaultSleep
+  const sleep = options.sleep ?? retryBackoffSleep
 
   return async (config) => {
     for (let attempt = 1; ; attempt++) {

--- a/sdk-typescript/src/utils/RetryAdapter.ts
+++ b/sdk-typescript/src/utils/RetryAdapter.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { trace } from '@opentelemetry/api'
+import { AxiosAdapter, AxiosError, InternalAxiosRequestConfig } from 'axios'
+
+/**
+ * Transport-level retry for transient connection failures, mirroring the
+ * Python SDK (`urllib3_retry.RemoteDisconnectedRetry` / `SharedAiohttpSession`).
+ *
+ * Node's http client, unlike Go's transport or urllib3, never retries a request
+ * whose kept-alive socket the server already closed. That surfaces as
+ * `socket hang up` (ECONNRESET) — typically after a proxy/LB rollout — even
+ * though the request was never processed. This wraps the axios adapter so each
+ * logical request gets a small retry budget for exactly those cases, without
+ * re-running request interceptors (one span covers all attempts).
+ */
+
+const MAX_RETRIES = 2
+// Backoff = base * attempt + uniform(0, jitter); jitter de-correlates fleets
+// that hit the same blip so they don't return in synchronized waves.
+const BACKOFF_BASE_MS = 250
+const BACKOFF_JITTER_MS = 100
+
+// RFC 9110 §9.2.2 — safe to replay even if the server saw the first attempt.
+const IDEMPOTENT_METHODS: ReadonlySet<string> = new Set(['GET', 'HEAD', 'OPTIONS', 'TRACE', 'PUT', 'DELETE'])
+
+// Raised before any bytes reach the socket (DNS / TCP connect). The server
+// cannot have seen the request, so any method may be retried.
+const CONNECT_PHASE_CODES: ReadonlySet<string> = new Set([
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EADDRNOTAVAIL',
+])
+
+// May fire after the request was (partially) written — the server may have
+// started processing it — so only idempotent methods are retried.
+const MID_FLIGHT_CODES: ReadonlySet<string> = new Set(['ECONNRESET', 'EPIPE'])
+
+type RetryVerdict = 'any-method' | 'idempotent-only' | 'never'
+
+interface ConnectionRetryOptions {
+  readonly maxRetries?: number
+  readonly sleep?: (ms: number) => Promise<void>
+}
+
+function syscallOf(error: AxiosError): string | undefined {
+  const cause: unknown = error.cause
+  if (typeof cause === 'object' && cause !== null && 'syscall' in cause) {
+    const syscall: unknown = (cause as { syscall?: unknown }).syscall
+    return typeof syscall === 'string' ? syscall : undefined
+  }
+  return undefined
+}
+
+function classify(error: AxiosError): RetryVerdict {
+  if (error.response || !error.code) return 'never'
+  // axios' own deadline (ECONNABORTED / clarified ETIMEDOUT) is never a stale socket.
+  if (error.code === AxiosError.ECONNABORTED || error.code === AxiosError.ETIMEDOUT) {
+    return syscallOf(error) === 'connect' ? 'any-method' : 'never'
+  }
+  // Node reports "socket hang up" only when the peer closed before a single
+  // response byte arrived — the request was never processed.
+  if (error.code === 'ECONNRESET' && error.message === 'socket hang up') return 'any-method'
+  if (CONNECT_PHASE_CODES.has(error.code) || syscallOf(error) === 'connect') return 'any-method'
+  if (MID_FLIGHT_CODES.has(error.code)) return 'idempotent-only'
+  return 'never'
+}
+
+/** Streams (Node Readable, web ReadableStream, `form-data`) are consumed by the first attempt. */
+function isReplayable(data: unknown): boolean {
+  if (typeof data !== 'object' || data === null) return true
+  const shape = data as { pipe?: unknown; getReader?: unknown; getBoundary?: unknown }
+  return (
+    typeof shape.pipe !== 'function' && typeof shape.getReader !== 'function' && typeof shape.getBoundary !== 'function'
+  )
+}
+
+function retryableError(error: unknown, config: InternalAxiosRequestConfig): AxiosError | undefined {
+  if (!(error instanceof AxiosError) || config.signal?.aborted || !isReplayable(config.data)) return undefined
+  const method = (config.method ?? 'get').toUpperCase()
+  switch (classify(error)) {
+    case 'any-method':
+      return error
+    case 'idempotent-only':
+      return IDEMPOTENT_METHODS.has(method) ? error : undefined
+    case 'never':
+      return undefined
+  }
+}
+
+function backoffMs(attempt: number): number {
+  return BACKOFF_BASE_MS * attempt + Math.random() * BACKOFF_JITTER_MS
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Wraps an axios adapter with connection-level retries. See module docs for
+ * the classification rules.
+ */
+export function withConnectionRetry(base: AxiosAdapter, options: ConnectionRetryOptions = {}): AxiosAdapter {
+  const maxRetries = options.maxRetries ?? MAX_RETRIES
+  const sleep = options.sleep ?? defaultSleep
+
+  return async (config) => {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await base(config)
+      } catch (error) {
+        const retryable = attempt <= maxRetries ? retryableError(error, config) : undefined
+        if (!retryable) throw error
+        trace.getActiveSpan()?.addEvent('http.request.retry', {
+          'retry.attempt': attempt,
+          'error.code': retryable.code ?? '',
+          'error.message': retryable.message,
+        })
+        await sleep(backoffMs(attempt))
+      }
+    }
+  }
+}

--- a/sdk-typescript/src/utils/RetryAdapter.ts
+++ b/sdk-typescript/src/utils/RetryAdapter.ts
@@ -7,15 +7,20 @@ import { AxiosError, CanceledError } from 'axios'
 import type { AxiosAdapter, GenericAbortSignal, InternalAxiosRequestConfig } from 'axios'
 
 /**
- * Transport-level retry for transient connection failures, mirroring the
- * Python SDK (`urllib3_retry.RemoteDisconnectedRetry` / `SharedAiohttpSession`).
+ * Transport-level retry for transient connection failures, modelled on the
+ * Python async SDK's `SharedAiohttpSession`.
  *
- * Node's http client, unlike Go's transport or urllib3, never retries a request
- * whose kept-alive socket the server already closed. That surfaces as
- * `socket hang up` (ECONNRESET) — typically after a proxy/LB rollout — even
- * though the request was never processed. This wraps the axios adapter so each
- * logical request gets a small retry budget for exactly those cases, without
- * re-running request interceptors (one span covers all attempts).
+ * Node's http client never retries a request whose kept-alive socket the server
+ * already closed; that surfaces as `socket hang up` (ECONNRESET), typically
+ * after a proxy/LB rollout. This wraps the axios adapter so each logical
+ * request gets a small retry budget, without re-running request interceptors
+ * (one span covers all attempts).
+ *
+ * Policy: a failure is replayed on any method only when it provably happened
+ * before any bytes were written (DNS / TCP connect). Anything that may have
+ * reached the server — including `socket hang up`, which only says the peer
+ * closed before writing a response — is replayed for idempotent methods only,
+ * since the server may already have executed the request.
  */
 
 const MAX_RETRIES = 2
@@ -39,7 +44,10 @@ const CONNECT_PHASE_CODES: ReadonlySet<string> = new Set([
 ])
 
 // May fire after the request was (partially) written — the server may have
-// started processing it — so only idempotent methods are retried.
+// processed it — so only idempotent methods are retried. This includes
+// "socket hang up": Node raises it both for a stale keep-alive socket that
+// never read the request and for a peer that processed it and then dropped
+// the connection, and the client cannot tell the two apart.
 const MID_FLIGHT_CODES: ReadonlySet<string> = new Set(['ECONNRESET', 'EPIPE'])
 
 type RetryVerdict = 'any-method' | 'idempotent-only' | 'never'
@@ -64,15 +72,6 @@ function classify(error: AxiosError): RetryVerdict {
   if (error.code === AxiosError.ECONNABORTED || error.code === AxiosError.ETIMEDOUT) {
     return syscallOf(error) === 'connect' ? 'any-method' : 'never'
   }
-  // Node reports "socket hang up" only when the peer closed before a single
-  // response byte arrived — for a well-behaved HTTP server that means the
-  // request was never processed (stale keep-alive socket, or a proxy/LB that
-  // dropped the connection during a rollout). The residual risk is a peer that
-  // processes a non-idempotent request and then dies before writing any
-  // response; the Python SDK (RemoteDisconnectedRetry) and the toolbox proxy's
-  // own upstream retry accept the same trade-off, so semantics stay consistent
-  // across clients.
-  if (error.code === 'ECONNRESET' && error.message === 'socket hang up') return 'any-method'
   if (CONNECT_PHASE_CODES.has(error.code) || syscallOf(error) === 'connect') return 'any-method'
   if (MID_FLIGHT_CODES.has(error.code)) return 'idempotent-only'
   return 'never'


### PR DESCRIPTION
## Description

The TypeScript SDK is the only Daytona client with no stale-connection handling. Node's http client, unlike Go's transport or urllib3, never retries a request whose kept-alive socket the server already closed, so a proxy/LB rollout surfaces to users as `DaytonaConnectionError("socket hang up")` even though the request was never processed. Callers that wrap the SDK typically end up reporting these as 5xx.

This wraps the axios adapter in `Daytona.createAxiosInstance` with a small transport-level retry, modelled on the Python async client's `SharedAiohttpSession`. A failure is replayed on any method only when it provably happened before any bytes were written; anything that may have reached the server is replayed for idempotent methods only.

| Failure | Meaning | Retried on |
|---|---|---|
| `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`, `EHOSTUNREACH`, `ENETUNREACH`, `EADDRNOTAVAIL`, or `cause.syscall === 'connect'` (incl. `ETIMEDOUT`/`ECONNABORTED` during connect) | connect-phase; nothing written | any method |
| `ECONNRESET` (incl. `socket hang up`), `EPIPE` | peer closed after the request may have been sent; the server may have processed it | idempotent methods only (GET/HEAD/OPTIONS/TRACE/PUT/DELETE) |
| any HTTP response, axios deadline (`ECONNABORTED`/`ETIMEDOUT`), aborted `signal`, stream bodies (uploads) | — | never |

`socket hang up` deliberately does **not** get an any-method exception: Node raises it both for a stale keep-alive socket that never read the request and for a server that processed the request and then dropped the connection, and the client cannot tell them apart. Replaying a `POST /sandbox` or `POST .../process/execute` in the second case would execute the mutation twice.

- 3 attempts total, backoff `250ms × attempt + 0–100ms jitter` (same constants as the Python async client); the backoff is abort-aware and rejects with `CanceledError` if the request signal fires
- Applied to API, toolbox and analytics axios instances
- Adapter-level rather than a response interceptor: request interceptors (trace-context injection, timing metadata) do not re-run, one span covers all attempts (a `http.request.retry` span event is recorded per retry), and it sits below the `createAxiosDaytonaError` mapping so error types are unchanged
- No behavior change for HTTP error responses — `5xx` on `POST` is still surfaced immediately since the server may have executed the operation

### Tests

- `RetryAdapter.test.ts` — unit matrix over the classification rules and method idempotency (`socket hang up`/`read ECONNRESET` × POST/PATCH not retried, × GET/HEAD/PUT/DELETE retried; connect-phase failures retried on POST), body replayability (string/Buffer/Uint8Array/object replayed; Node `Readable`, web `ReadableStream`, `form-data` not), abort signal before and during backoff, backoff and budget exhaustion
- `ConnectionRetry.server.test.ts` — real `http.Server` that reads the request and then destroys the socket without responding (genuine Node `socket hang up`): a `GET` through `Daytona.createAxiosInstance()` succeeds on attempt 2; a `POST` fails immediately with `DaytonaConnectionError` after exactly one server-side request; `DaytonaConnectionError` after 3 attempts when every connection is dropped; a `POST` to a refused port is connected 3 times (counted via `http.Agent.createConnection`)
- `Daytona.test.ts` axios mock extended with `defaults.adapter` / `getAdapter`

Verified additionally against the built `dist` artifact with the generated clients through a local proxy that drops the socket before responding: `GET` recovers on attempt 2; `POST` surfaces `DaytonaConnectionError` on attempt 1.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

N/A

## Notes

Gotcha worth knowing: axios 1.19 `AxiosError.from` copies only `code`/`message` onto the wrapped error and exposes the original Node error as a non-enumerable `cause`, so `syscall` must be read from `error.cause`.

This is client-side mitigation; connection draining during rollouts on the server side is a separate follow-up. Note that a `POST` (e.g. `process/execute`) whose stale connection is dropped is intentionally not replayed by the SDK — callers that need at-least-once semantics for non-idempotent operations should retry at their own level, where they can check whether the operation already took effect.

`DELETE` is idempotent by RFC 9110 and is replayed; a `DELETE /sandbox/:id` whose first attempt succeeded but whose response was lost will surface as `DaytonaNotFoundError` on the replay even though the delete happened. The Python clients have the same exposure (urllib3's default allowed methods include DELETE); left as-is for parity.

Also hardens `sdk-typescript/runtime-tests/run-all.sh` so the runtime compatibility job stops hitting its 30 minute timeout (it had been reported as `cancelled` on every PR since a registry slowdown): the throwaway per-runtime installs now skip npm audit/fund/update-notifier, and `next build` no longer does untimed registry packument fetches to patch the disposable lockfile (`NEXT_IGNORE_INCORRECT_LOCKFILE=1`) or post telemetry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TypeScript SDK's stale-connection handling so requests dropped by a proxy/LB rollout retry instead of surfacing as `DaytonaConnectionError("socket hang up")`.

**Retry rules**
- Connect-phase failures (`ECONNREFUSED`, DNS errors, `syscall=connect`) retry on any method since the request never reached the server.
- `socket hang up` and other `ECONNRESET`/`EPIPE` retry only on idempotent methods (GET/HEAD/OPTIONS/TRACE/PUT/DELETE) because the server may have processed the request.
- HTTP responses, non-connect `axios` timeouts, aborted signals, and stream bodies never retry; an abort during backoff rejects with `CanceledError`.
- 3 attempts total with 250ms × attempt + jitter backoff; one span covers all attempts and records a `http.request.retry` event per retry.

**Runtime tests**
- Throwaway per-runtime installs skip npm audit/fund/update-notifier and Next.js registry packument fetches, so slow registry side-calls don't stall the job.
- Each runtime is bounded by a timeout (default 480s); timeouts and kill-after exits report as a visible TIMEOUT with per-runtime log tails instead of cancelling the whole job.
- The TERM trap ensures the runtime's cleanup (sandbox deletion) still runs when the timeout kills it.
- Per-runtime log names let the timeout dump find the right files, and Next.js failures now print build/start log tails.
- `nextjs-external` moved to its own port and readiness probes are bounded so a stale listener can't hang the job.

<sup>Written for commit b07454b81adb4172026228b59064f80f8ea7e75f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

