### PR TITLE
fix(sdk-python,sdk-ruby,sdk-typescript): do not resolve the API URL from .env

### DIFF
--- a/examples/ruby/README.md
+++ b/examples/ruby/README.md
@@ -18,11 +18,12 @@ This directory contains example scripts demonstrating how to use the Daytona Rub
    DAYTONA_ORGANIZATION_ID=your-org-id  # required when using JWT token
 
    # Optional
-   DAYTONA_API_URL=https://app.daytona.io/api  # defaults to this if not specified
    DAYTONA_TARGET=us  # defaults to your organization's default region
    ```
 
    The SDK automatically loads only Daytona-specific variables from `.env` and `.env.local` files in the current working directory, where `.env.local` overrides `.env`. Runtime environment variables always take precedence over `.env` files.
+
+   `DAYTONA_API_URL` is the exception: the API endpoint is never read from `.env` or `.env.local`, because the working directory is not always authored by whoever runs the code. Set it with the `api_url:` argument to `Daytona::Config.new` or in the environment of the process (Option B). A value in a dotenv file is ignored, and reported on stderr if it differs from the endpoint in use.
 
    **Option B: Export manually**
 

--- a/sdk-python/src/daytona/_async/daytona.py
+++ b/sdk-python/src/daytona/_async/daytona.py
@@ -44,7 +44,7 @@ from daytona_api_client_async import WarmPoolsApi
 from daytona_toolbox_api_client_async import ApiClient as ToolboxApiClient
 
 from .._utils.enum import to_enum
-from .._utils.env import DaytonaEnvReader
+from .._utils.env import DaytonaEnvReader, warn_if_dotenv_api_url_ignored
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from .._utils.stream import process_streaming_response
@@ -217,10 +217,18 @@ class AsyncDaytona:
             self._api_key = self._api_key or (env_reader.get("DAYTONA_API_KEY") if not self._jwt_token else None)
             self._jwt_token = self._jwt_token or env_reader.get("DAYTONA_JWT_TOKEN")
             self._organization_id = self._organization_id or env_reader.get("DAYTONA_ORGANIZATION_ID")
-            api_url = api_url or env_reader.get("DAYTONA_API_URL") or env_reader.get("DAYTONA_SERVER_URL")
+            # Resolved from the process environment only, never from .env / .env.local:
+            # the endpoint decides where the credential above is sent.
+            api_url = (
+                api_url
+                or env_reader.get_from_process_env("DAYTONA_API_URL")
+                or env_reader.get_from_process_env("DAYTONA_SERVER_URL")
+            )
             self._target = self._target or env_reader.get("DAYTONA_TARGET")
 
-            if env_reader.get("DAYTONA_SERVER_URL") and not env_reader.get("DAYTONA_API_URL"):
+            if env_reader.get_from_process_env("DAYTONA_SERVER_URL") and not env_reader.get_from_process_env(
+                "DAYTONA_API_URL"
+            ):
                 warnings.warn(
                     "Environment variable `DAYTONA_SERVER_URL` is deprecated and will be removed in future versions. "
                     + "Use `DAYTONA_API_URL` instead.",
@@ -229,6 +237,13 @@ class AsyncDaytona:
                 )
 
         self._api_url = api_url or default_api_url
+
+        # A dotenv file that tried to redirect the endpoint is always reported, however the
+        # client was configured: it tells the caller the working directory is hostile, which
+        # matters even when their explicit configuration already made them immune. Reusing
+        # the reader here means no extra parse - one is constructed further down regardless.
+        env_reader = env_reader or DaytonaEnvReader()
+        warn_if_dotenv_api_url_ignored(env_reader, self._api_url)
 
         if not self._api_key and not self._jwt_token:
             msg = (

--- a/sdk-python/src/daytona/_sync/daytona.py
+++ b/sdk-python/src/daytona/_sync/daytona.py
@@ -30,7 +30,7 @@ from daytona_api_client import WarmPoolsApi
 from daytona_toolbox_api_client import ApiClient as ToolboxApiClient
 
 from .._utils.enum import to_enum
-from .._utils.env import DaytonaEnvReader
+from .._utils.env import DaytonaEnvReader, warn_if_dotenv_api_url_ignored
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from .._utils.stream import process_streaming_response
@@ -167,10 +167,18 @@ class Daytona:
             self._api_key = self._api_key or (env_reader.get("DAYTONA_API_KEY") if not self._jwt_token else None)
             self._jwt_token = self._jwt_token or env_reader.get("DAYTONA_JWT_TOKEN")
             self._organization_id = self._organization_id or env_reader.get("DAYTONA_ORGANIZATION_ID")
-            api_url = api_url or env_reader.get("DAYTONA_API_URL") or env_reader.get("DAYTONA_SERVER_URL")
+            # Resolved from the process environment only, never from .env / .env.local:
+            # the endpoint decides where the credential above is sent.
+            api_url = (
+                api_url
+                or env_reader.get_from_process_env("DAYTONA_API_URL")
+                or env_reader.get_from_process_env("DAYTONA_SERVER_URL")
+            )
             self._target = self._target or env_reader.get("DAYTONA_TARGET")
 
-            if env_reader.get("DAYTONA_SERVER_URL") and not env_reader.get("DAYTONA_API_URL"):
+            if env_reader.get_from_process_env("DAYTONA_SERVER_URL") and not env_reader.get_from_process_env(
+                "DAYTONA_API_URL"
+            ):
                 warnings.warn(
                     "Environment variable `DAYTONA_SERVER_URL` is deprecated and will be removed in future versions. "
                     + "Use `DAYTONA_API_URL` instead.",
@@ -179,6 +187,13 @@ class Daytona:
                 )
 
         self._api_url = api_url or default_api_url
+
+        # A dotenv file that tried to redirect the endpoint is always reported, however the
+        # client was configured: it tells the caller the working directory is hostile, which
+        # matters even when their explicit configuration already made them immune. Reusing
+        # the reader here means no extra parse - one is constructed further down regardless.
+        env_reader = env_reader or DaytonaEnvReader()
+        warn_if_dotenv_api_url_ignored(env_reader, self._api_url)
 
         if not self._api_key and not self._jwt_token:
             msg = (

--- a/sdk-python/src/daytona/_utils/env.py
+++ b/sdk-python/src/daytona/_utils/env.py
@@ -72,10 +72,10 @@ def warn_if_dotenv_api_url_ignored(env_reader: DaytonaEnvReader, api_url: str) -
         if file_value and file_value != api_url:
             warnings.warn(
                 f"`{name}` set in a .env or .env.local file was ignored:"
-                " the Daytona API endpoint is never read from dotenv files, because the working"
-                f" directory is not always authored by you. Using `{api_url}` instead."
-                f" To change the endpoint, pass `api_url` to `DaytonaConfig` or set `{name}`"
-                " in the environment of the process.",
+                + " the Daytona API endpoint is never read from dotenv files, because the working"
+                + f" directory is not always authored by you. Using `{api_url}` instead."
+                + f" To change the endpoint, pass `api_url` to `DaytonaConfig` or set `{name}`"
+                + " in the environment of the process.",
                 UserWarning,
                 stacklevel=3,
             )

--- a/sdk-python/src/daytona/_utils/env.py
+++ b/sdk-python/src/daytona/_utils/env.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 
 from dotenv import dotenv_values
 
@@ -12,7 +13,10 @@ class DaytonaEnvReader:
     """Reads DAYTONA_* env vars on demand without polluting os.environ.
 
     Parses .env and .env.local once at construction.
-    Precedence: runtime env → .env.local → .env
+
+    `get` applies the precedence runtime env → .env.local → .env. That precedence must NOT
+    be used for values that decide where a credential is sent, because the dotenv files come
+    from the working directory; use `get_from_process_env` for those.
     """
 
     def __init__(self) -> None:
@@ -20,19 +24,58 @@ class DaytonaEnvReader:
         self._env_vars: dict[str, str] = self._load(".env")
 
     def get(self, name: str) -> str | None:
-        if not name.startswith("DAYTONA_"):
-            raise ValueError(f"DaytonaEnvReader: variable name must start with 'DAYTONA_', got '{name}'")
+        self._check_name(name)
         # 1. Runtime env
         val = os.environ.get(name)
         if val is not None:
             return val
-        # 2. .env.local
+        # 2. .env.local, 3. .env
+        return self.get_from_file(name)
+
+    def get_from_process_env(self, name: str) -> str | None:
+        """Read `name` from the process environment only, never from .env / .env.local.
+
+        The dotenv files are read from the current working directory, which is not
+        necessarily authored by whoever runs the process. Anything that determines the
+        host a credential is sent to must be resolved through this method so that a
+        file in the working directory cannot redirect the SDK.
+        """
+        self._check_name(name)
+        return os.environ.get(name)
+
+    def get_from_file(self, name: str) -> str | None:
+        """Read `name` from .env.local / .env only, ignoring the process environment."""
+        self._check_name(name)
         if name in self._env_local_vars:
             return self._env_local_vars[name]
-        # 3. .env
         return self._env_vars.get(name)
+
+    @staticmethod
+    def _check_name(name: str) -> None:
+        if not name.startswith("DAYTONA_"):
+            raise ValueError(f"DaytonaEnvReader: variable name must start with 'DAYTONA_', got '{name}'")
 
     @staticmethod
     def _load(path: str) -> dict[str, str]:
         parsed = dotenv_values(path)
         return {k: v for k, v in parsed.items() if k.startswith("DAYTONA_") and v is not None}
+
+
+def warn_if_dotenv_api_url_ignored(env_reader: DaytonaEnvReader, api_url: str) -> None:
+    """Warn when a dotenv file asked for an API endpoint that was not used.
+
+    Staying silent when the file value matches the endpoint in use keeps the documented
+    `.env` layout quiet, while a file that would have changed the destination is reported.
+    """
+    for name in ("DAYTONA_API_URL", "DAYTONA_SERVER_URL"):
+        file_value = env_reader.get_from_file(name)
+        if file_value and file_value != api_url:
+            warnings.warn(
+                f"`{name}` set in a .env or .env.local file was ignored:"
+                " the Daytona API endpoint is never read from dotenv files, because the working"
+                f" directory is not always authored by you. Using `{api_url}` instead."
+                f" To change the endpoint, pass `api_url` to `DaytonaConfig` or set `{name}`"
+                " in the environment of the process.",
+                UserWarning,
+                stacklevel=3,
+            )

--- a/sdk-python/tests/test_config.py
+++ b/sdk-python/tests/test_config.py
@@ -51,3 +51,48 @@ class TestDaytonaEnvReader:
             return_value={"DAYTONA_API_KEY": "key", "OTHER": "nope", "DAYTONA_TARGET": None},
         ):
             assert DaytonaEnvReader._load(".env") == {"DAYTONA_API_KEY": "key"}
+
+
+class TestDaytonaEnvReaderTrustSeparation:
+    """The endpoint must be resolvable without consulting the working directory."""
+
+    def test_get_from_process_env_ignores_dotenv_files(self, monkeypatch):
+        monkeypatch.delenv("DAYTONA_API_URL", raising=False)
+
+        with patch.object(
+            DaytonaEnvReader,
+            "_load",
+            side_effect=[
+                {"DAYTONA_API_URL": "http://local.example/api"},
+                {"DAYTONA_API_URL": "http://env.example/api"},
+            ],
+        ):
+            reader = DaytonaEnvReader()
+
+        assert reader.get("DAYTONA_API_URL") == "http://local.example/api"
+        assert reader.get_from_process_env("DAYTONA_API_URL") is None
+
+    def test_get_from_process_env_reads_the_process_environment(self, monkeypatch):
+        monkeypatch.setenv("DAYTONA_API_URL", "https://runtime.example/api")
+
+        with patch.object(DaytonaEnvReader, "_load", side_effect=[{}, {"DAYTONA_API_URL": "http://env.example/api"}]):
+            reader = DaytonaEnvReader()
+
+        assert reader.get_from_process_env("DAYTONA_API_URL") == "https://runtime.example/api"
+
+    def test_get_from_file_ignores_the_process_environment(self, monkeypatch):
+        monkeypatch.setenv("DAYTONA_API_URL", "https://runtime.example/api")
+
+        with patch.object(DaytonaEnvReader, "_load", side_effect=[{}, {"DAYTONA_API_URL": "http://env.example/api"}]):
+            reader = DaytonaEnvReader()
+
+        assert reader.get_from_file("DAYTONA_API_URL") == "http://env.example/api"
+
+    def test_new_accessors_reject_non_daytona_variable_names(self):
+        reader = DaytonaEnvReader()
+
+        with pytest.raises(ValueError, match="must start with 'DAYTONA_'"):
+            reader.get_from_process_env("OTHER_VAR")
+
+        with pytest.raises(ValueError, match="must start with 'DAYTONA_'"):
+            reader.get_from_file("OTHER_VAR")

--- a/sdk-python/tests/test_daytona.py
+++ b/sdk-python/tests/test_daytona.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -323,3 +324,142 @@ class TestDaytonaValidateLanguageLabel:
         daytona = _make_daytona()
         with pytest.raises(DaytonaValidationError, match=f"Invalid {CODE_TOOLBOX_LANGUAGE_LABEL}"):
             daytona._validate_language_label("ruby")
+
+
+DEFAULT_API_URL = "https://app.daytona.io/api"
+_CREDENTIAL_ENV_KEYS = (
+    "DAYTONA_API_KEY",
+    "DAYTONA_API_URL",
+    "DAYTONA_SERVER_URL",
+    "DAYTONA_TARGET",
+    "DAYTONA_JWT_TOKEN",
+    "DAYTONA_ORGANIZATION_ID",
+)
+
+
+class TestCwdDotenvCannotRedirectTheEndpoint:
+    """A `.env` in the working directory must not decide where the credential is sent.
+
+    The working directory is frequently a cloned repository, so its files are authored by a
+    third party. The credential comes from the caller; the endpoint must never come from
+    a file the caller did not write.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_cwd(self, tmp_path, monkeypatch):
+        for key in _CREDENTIAL_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.chdir(tmp_path)
+        return tmp_path
+
+    @staticmethod
+    def _construct(config=None):
+        """Construct a client, returning it alongside every warning it emitted.
+
+        The endpoint assertion has to be the primary signal, so construction must not
+        happen inside `pytest.warns` — a missing warning would fail the test before the
+        resolved URL is ever checked.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            daytona = _make_daytona(config)
+        return daytona, [str(w.message) for w in caught]
+
+    @staticmethod
+    def _ignored_endpoint_warnings(messages, name="DAYTONA_API_URL"):
+        return [m for m in messages if name in m and "was ignored" in m]
+
+    def test_dotenv_api_url_is_ignored(self, _isolated_cwd):
+        (_isolated_cwd / ".env").write_text("DAYTONA_API_URL=http://attacker.example/api\n")
+
+        daytona, messages = self._construct(DaytonaConfig(api_key="victim-key"))
+
+        assert daytona._api_url == DEFAULT_API_URL
+        assert daytona._api_key == "victim-key"
+        assert self._ignored_endpoint_warnings(messages)
+
+    def test_dotenv_local_api_url_is_ignored(self, _isolated_cwd):
+        (_isolated_cwd / ".env.local").write_text("DAYTONA_API_URL=http://attacker.example/api\n")
+
+        daytona, messages = self._construct(DaytonaConfig(api_key="victim-key"))
+
+        assert daytona._api_url == DEFAULT_API_URL
+        assert self._ignored_endpoint_warnings(messages)
+
+    def test_dotenv_server_url_is_ignored(self, _isolated_cwd):
+        (_isolated_cwd / ".env").write_text("DAYTONA_SERVER_URL=http://attacker.example/api\n")
+
+        daytona, messages = self._construct(DaytonaConfig(api_key="victim-key"))
+
+        assert daytona._api_url == DEFAULT_API_URL
+        assert self._ignored_endpoint_warnings(messages, "DAYTONA_SERVER_URL")
+
+    def test_dotenv_cannot_redirect_a_credential_taken_from_the_process_environment(self, _isolated_cwd, monkeypatch):
+        monkeypatch.setenv("DAYTONA_API_KEY", "victim-key")
+        (_isolated_cwd / ".env").write_text("DAYTONA_API_URL=http://attacker.example/api\n")
+
+        daytona, messages = self._construct()
+
+        assert daytona._api_url == DEFAULT_API_URL
+        assert daytona._api_key == "victim-key"
+        assert self._ignored_endpoint_warnings(messages)
+
+    def test_dotenv_cannot_redirect_even_when_it_also_supplies_the_credential(self, _isolated_cwd):
+        """A file that supplies both must still not move the endpoint.
+
+        Same-source pairing would allow this; resolving the endpoint from the process
+        environment only does not.
+        """
+        (_isolated_cwd / ".env").write_text(
+            "DAYTONA_API_KEY=attacker-key\nDAYTONA_API_URL=http://attacker.example/api\n"
+        )
+
+        daytona, messages = self._construct()
+
+        assert daytona._api_url == DEFAULT_API_URL
+        assert self._ignored_endpoint_warnings(messages)
+
+    def test_process_environment_api_url_still_wins(self, _isolated_cwd, monkeypatch):
+        monkeypatch.setenv("DAYTONA_API_URL", "https://chosen-by-env.example/api")
+        (_isolated_cwd / ".env").write_text("DAYTONA_API_URL=http://attacker.example/api\n")
+
+        daytona, messages = self._construct(DaytonaConfig(api_key="victim-key"))
+
+        assert daytona._api_url == "https://chosen-by-env.example/api"
+        assert self._ignored_endpoint_warnings(messages)
+
+    def test_explicit_api_url_still_wins(self, _isolated_cwd):
+        (_isolated_cwd / ".env").write_text("DAYTONA_API_URL=http://attacker.example/api\n")
+
+        daytona, messages = self._construct(DaytonaConfig(api_key="victim-key", api_url="https://chosen.example/api"))
+
+        assert daytona._api_url == "https://chosen.example/api"
+        assert self._ignored_endpoint_warnings(messages)
+
+    def test_fully_configured_client_is_still_told_about_a_hostile_dotenv(self, _isolated_cwd):
+        """Reported even when explicit config already made the caller immune.
+
+        The value of the report is that the working directory is hostile, which the caller
+        wants to know regardless of how this particular client was configured.
+        """
+        (_isolated_cwd / ".env").write_text("DAYTONA_API_URL=http://attacker.example/api\n")
+
+        daytona, messages = self._construct(
+            DaytonaConfig(api_key="victim-key", api_url="https://chosen.example/api", target="us")
+        )
+
+        assert daytona._api_url == "https://chosen.example/api"
+        assert self._ignored_endpoint_warnings(messages)
+
+    def test_documented_dotenv_layout_still_works_and_stays_quiet(self, _isolated_cwd):
+        """The documented `.env` sets the endpoint to its default, so nothing changes."""
+        (_isolated_cwd / ".env").write_text(
+            f"DAYTONA_API_KEY=victim-key\nDAYTONA_API_URL={DEFAULT_API_URL}\nDAYTONA_TARGET=us\n"
+        )
+
+        daytona, messages = self._construct()
+
+        assert daytona._api_url == DEFAULT_API_URL
+        assert daytona._api_key == "victim-key"
+        assert daytona._target == "us"
+        assert self._ignored_endpoint_warnings(messages) == []

--- a/sdk-ruby/lib/daytona/config.rb
+++ b/sdk-ruby/lib/daytona/config.rb
@@ -80,7 +80,9 @@ module Daytona
 
       @api_key = api_key || @env_reader.call('DAYTONA_API_KEY')
       @jwt_token = jwt_token || @env_reader.call('DAYTONA_JWT_TOKEN')
-      @api_url = api_url || @env_reader.call('DAYTONA_API_URL') || API_URL
+      # Resolved from the process environment only, never from .env / .env.local:
+      # the endpoint decides where the credential above is sent.
+      @api_url = resolve_api_url(api_url)
       @target = target || @env_reader.call('DAYTONA_TARGET')
       @organization_id = organization_id || @env_reader.call('DAYTONA_ORGANIZATION_ID')
       @otel_enabled = otel_enabled
@@ -101,20 +103,57 @@ module Daytona
 
     private
 
-    # Returns a lambda that looks up DAYTONA_-prefixed env vars without writing to ENV.
-    # Files are parsed once; lookups check runtime env first, then .env.local, then .env.
-    def daytona_env_reader
+    # Resolves the API endpoint without consulting the working directory, then reports a
+    # dotenv value that was passed over. Staying silent when the file value matches the
+    # endpoint in use keeps the documented .env layout quiet, while a file that would have
+    # changed the destination is surfaced.
+    def resolve_api_url(api_url)
+      resolved = api_url || process_env('DAYTONA_API_URL') || API_URL
+      file_value = env_file_vars['DAYTONA_API_URL']
+      return resolved if file_value.nil? || file_value.empty? || file_value == resolved
+
+      warn(
+        '`DAYTONA_API_URL` set in a .env or .env.local file was ignored: the Daytona API endpoint ' \
+        'is never read from dotenv files, because the working directory is not always authored ' \
+        "by you. Using `#{resolved}` instead. To change the endpoint, pass `api_url:` to " \
+        '`Daytona::Config.new` or set `DAYTONA_API_URL` in the environment of the process.'
+      )
+      resolved
+    end
+
+    # Parses DAYTONA_-prefixed vars out of .env and .env.local in the working directory.
+    # These files are not necessarily authored by whoever runs the process, so anything
+    # that determines where a credential is sent must not be read from them.
+    def env_file_vars
+      @env_file_vars ||= parse_dotenv_files
+    end
+
+    def parse_dotenv_files
       file_vars = {}
       env_file = File.join(Dir.pwd, '.env')
       file_vars.merge!(daytona_filter(Dotenv.parse(env_file))) if File.exist?(env_file)
       env_local_file = File.join(Dir.pwd, '.env.local')
       file_vars.merge!(daytona_filter(Dotenv.parse(env_local_file))) if File.exist?(env_local_file)
+      file_vars
+    end
+
+    # Returns a lambda that looks up DAYTONA_-prefixed env vars without writing to ENV.
+    # Files are parsed once; lookups check runtime env first, then .env.local, then .env.
+    def daytona_env_reader
+      file_vars = env_file_vars
 
       lambda do |name|
         raise ArgumentError, "Variable must start with 'DAYTONA_', got '#{name}'" unless name.start_with?('DAYTONA_')
 
         ENV.key?(name) ? ENV[name] : file_vars[name]
       end
+    end
+
+    # Reads a DAYTONA_-prefixed variable from the process environment only.
+    def process_env(name)
+      raise ArgumentError, "Variable must start with 'DAYTONA_', got '#{name}'" unless name.start_with?('DAYTONA_')
+
+      ENV.fetch(name, nil)
     end
 
     def daytona_filter(env_hash)

--- a/sdk-ruby/spec/daytona/config_spec.rb
+++ b/sdk-ruby/spec/daytona/config_spec.rb
@@ -3,6 +3,9 @@
 
 # frozen_string_literal: true
 
+require 'stringio'
+require 'tmpdir'
+
 RSpec.describe Daytona::Config do
   around do |example|
     env_keys = %w[
@@ -75,11 +78,21 @@ RSpec.describe Daytona::Config do
         ENVFILE
 
         Dir.chdir(dir) do
-          config = described_class.new
+          captured = StringIO.new
+          original = $stderr
+          $stderr = captured
+          # The endpoint is deliberately excluded from dotenv precedence, so the
+          # `https://local.api` value in .env.local is reported and not used.
+          begin
+            config = described_class.new
+          ensure
+            $stderr = original
+          end
+          expect(captured.string).to include('was ignored')
 
           expect(config.api_key).to eq('env-local-key')
           expect(config.target).to eq('us')
-          expect(config.api_url).to eq('https://local.api')
+          expect(config.api_url).to eq(Daytona::Config::API_URL)
           expect(ENV.fetch('DAYTONA_API_KEY', nil)).to be_nil
         end
       end
@@ -133,6 +146,100 @@ RSpec.describe Daytona::Config do
 
       expect { config.read_env('OTHER_VAR') }
         .to raise_error(ArgumentError, /Variable must start with 'DAYTONA_'/)
+    end
+  end
+
+  describe 'endpoint trust separation', :real_dotenv do
+    # A .env in the working directory must not decide where the credential is sent: the
+    # working directory is frequently a cloned repository, authored by a third party.
+    around do |example|
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) { example.run }
+      end
+    end
+
+    # Construction must happen OUTSIDE an output matcher: if the report is missing, the
+    # example has to still reach the endpoint assertion, or a regression is diagnosed as
+    # "no warning" when the real defect is the credential's destination.
+    def build_config(**kwargs)
+      captured = StringIO.new
+      original = $stderr
+      $stderr = captured
+      begin
+        [described_class.new(**kwargs), captured.string]
+      ensure
+        $stderr = original
+      end
+    end
+
+    def ignored_endpoint_report?(stderr)
+      stderr.include?('`DAYTONA_API_URL`') && stderr.include?('was ignored')
+    end
+
+    it 'ignores DAYTONA_API_URL supplied by a .env in the working directory' do
+      File.write('.env', "DAYTONA_API_URL=http://attacker.example/api\n")
+
+      config, stderr = build_config(api_key: 'victim-key')
+
+      expect(config.api_url).to eq(Daytona::Config::API_URL)
+      expect(config.api_key).to eq('victim-key')
+      expect(ignored_endpoint_report?(stderr)).to be(true)
+    end
+
+    it 'ignores DAYTONA_API_URL supplied by a .env.local in the working directory' do
+      File.write('.env.local', "DAYTONA_API_URL=http://attacker.example/api\n")
+
+      config, stderr = build_config(api_key: 'victim-key')
+
+      expect(config.api_url).to eq(Daytona::Config::API_URL)
+      expect(ignored_endpoint_report?(stderr)).to be(true)
+    end
+
+    it 'ignores a dotenv endpoint even when the same file supplies the credential' do
+      File.write('.env', "DAYTONA_API_KEY=attacker-key\nDAYTONA_API_URL=http://attacker.example/api\n")
+
+      config, stderr = build_config
+
+      expect(config.api_url).to eq(Daytona::Config::API_URL)
+      expect(ignored_endpoint_report?(stderr)).to be(true)
+    end
+
+    it 'still lets the process environment set the endpoint' do
+      ENV['DAYTONA_API_URL'] = 'https://chosen-by-env.example/api'
+      File.write('.env', "DAYTONA_API_URL=http://attacker.example/api\n")
+
+      config, stderr = build_config(api_key: 'victim-key')
+
+      expect(config.api_url).to eq('https://chosen-by-env.example/api')
+      expect(ignored_endpoint_report?(stderr)).to be(true)
+    end
+
+    it 'still lets an explicit api_url set the endpoint' do
+      File.write('.env', "DAYTONA_API_URL=http://attacker.example/api\n")
+
+      config, stderr = build_config(api_key: 'victim-key', api_url: 'https://chosen.example/api')
+
+      expect(config.api_url).to eq('https://chosen.example/api')
+      expect(ignored_endpoint_report?(stderr)).to be(true)
+    end
+
+    it 'still reports a hostile dotenv to a fully configured client' do
+      File.write('.env', "DAYTONA_API_URL=http://attacker.example/api\n")
+
+      config, stderr = build_config(api_key: 'victim-key', api_url: 'https://chosen.example/api', target: 'us')
+
+      expect(config.api_url).to eq('https://chosen.example/api')
+      expect(ignored_endpoint_report?(stderr)).to be(true)
+    end
+
+    it 'stays quiet for the documented .env layout and still reads the credential from it' do
+      File.write('.env', "DAYTONA_API_KEY=victim-key\nDAYTONA_API_URL=#{Daytona::Config::API_URL}\n")
+
+      config, stderr = build_config
+
+      expect(config.api_url).to eq(Daytona::Config::API_URL)
+      expect(config.api_key).to eq('victim-key')
+      expect(stderr).to eq('')
     end
   end
 end

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -39,7 +39,14 @@ import { EventSubscriptionManager } from './utils/EventSubscriptionManager'
 
 const packageJson = getPackageInfo()
 import { processStreamingResponse } from './utils/Stream'
-import { DaytonaEnvReader, RUNTIME, Runtime, warnIfDotenvApiUrlIgnored } from './utils/Runtime'
+import {
+  DaytonaEnvReader,
+  dotenvMayBePreloaded,
+  findDotenvFileDefiningEndpoint,
+  RUNTIME,
+  Runtime,
+  warnIfDotenvApiUrlIgnored,
+} from './utils/Runtime'
 import { WithInstrumentation } from './utils/otel.decorator'
 import { context, trace, propagation, SpanStatusCode } from '@opentelemetry/api'
 import type { NodeSDK } from '@opentelemetry/sdk-node'
@@ -329,6 +336,7 @@ export class Daytona implements AsyncDisposable {
    */
   constructor(config?: DaytonaConfig) {
     let apiUrl: string | undefined
+    const endpointGivenByCaller = Boolean(config?.apiUrl || config?.serverUrl)
     if (config) {
       this.apiKey = !config?.apiKey && config?.jwtToken ? undefined : config?.apiKey
       this.jwtToken = config?.jwtToken
@@ -371,6 +379,22 @@ export class Daytona implements AsyncDisposable {
             '[Deprecation Warning] Environment variable `DAYTONA_SERVER_URL` is deprecated and will be removed in future versions. Use `DAYTONA_API_URL` instead.',
           )
         }
+      }
+    }
+
+    // On a runtime that pre-loads dotenv files, an endpoint from the process environment
+    // cannot be attributed to the caller. Rather than guess - and risk sending the API key
+    // to a host nobody chose - refuse to select one and say what to do about it.
+    if (!endpointGivenByCaller && dotenvMayBePreloaded()) {
+      const dotenvFile = findDotenvFileDefiningEndpoint()
+      if (dotenvFile) {
+        throw new DaytonaInvalidArgumentError(
+          `The Daytona API endpoint is ambiguous: \`${dotenvFile}\` in the working directory sets` +
+            ` DAYTONA_API_URL or DAYTONA_SERVER_URL, and this runtime loads that file into the` +
+            ` environment before your code runs, so the endpoint cannot be attributed to you.` +
+            ` Pass \`apiUrl\` to the Daytona constructor to say which endpoint you mean, or remove the` +
+            ` variable from \`${dotenvFile}\`.`,
+        )
       }
     }
 

--- a/sdk-typescript/src/Daytona.ts
+++ b/sdk-typescript/src/Daytona.ts
@@ -39,7 +39,7 @@ import { EventSubscriptionManager } from './utils/EventSubscriptionManager'
 
 const packageJson = getPackageInfo()
 import { processStreamingResponse } from './utils/Stream'
-import { DaytonaEnvReader, RUNTIME, Runtime } from './utils/Runtime'
+import { DaytonaEnvReader, RUNTIME, Runtime, warnIfDotenvApiUrlIgnored } from './utils/Runtime'
 import { WithInstrumentation } from './utils/otel.decorator'
 import { context, trace, propagation, SpanStatusCode } from '@opentelemetry/api'
 import type { NodeSDK } from '@opentelemetry/sdk-node'
@@ -361,10 +361,12 @@ export class Daytona implements AsyncDisposable {
         this.apiKey = this.apiKey || (this.jwtToken ? undefined : reader.get('DAYTONA_API_KEY'))
         this.jwtToken = this.jwtToken || reader.get('DAYTONA_JWT_TOKEN')
         this.organizationId = this.organizationId || reader.get('DAYTONA_ORGANIZATION_ID')
-        apiUrl = apiUrl || reader.get('DAYTONA_API_URL') || reader.get('DAYTONA_SERVER_URL')
+        // Resolved from the process environment only, never from .env / .env.local:
+        // the endpoint decides where the credential above is sent.
+        apiUrl = apiUrl || reader.getFromProcessEnv('DAYTONA_API_URL') || reader.getFromProcessEnv('DAYTONA_SERVER_URL')
         this.target = this.target || reader.get('DAYTONA_TARGET')
 
-        if (reader.get('DAYTONA_SERVER_URL') && !reader.get('DAYTONA_API_URL')) {
+        if (reader.getFromProcessEnv('DAYTONA_SERVER_URL') && !reader.getFromProcessEnv('DAYTONA_API_URL')) {
           console.warn(
             '[Deprecation Warning] Environment variable `DAYTONA_SERVER_URL` is deprecated and will be removed in future versions. Use `DAYTONA_API_URL` instead.',
           )
@@ -373,6 +375,15 @@ export class Daytona implements AsyncDisposable {
     }
 
     this.apiUrl = apiUrl || 'https://app.daytona.io/api'
+
+    // A dotenv file that tried to redirect the endpoint is always reported, however the
+    // client was configured: it tells the caller the working directory is hostile, which
+    // matters even when their explicit configuration already made them immune. envReader()
+    // is memoized and called again below, so this adds no extra parse.
+    const readerForReport = envReader()
+    if (readerForReport) {
+      warnIfDotenvApiUrlIgnored(readerForReport, this.apiUrl)
+    }
 
     if (!this.apiKey && !this.jwtToken) {
       throw new DaytonaAuthenticationError(

--- a/sdk-typescript/src/__tests__/Daytona.test.ts
+++ b/sdk-typescript/src/__tests__/Daytona.test.ts
@@ -23,6 +23,10 @@ const mockSecretServiceCtor = jest.fn()
 const mockSandboxCtor = jest.fn()
 const mockProcessImageContext = jest.fn()
 const mockProcessStreamingResponse = jest.fn()
+// Stands in for DAYTONA_* vars parsed out of .env / .env.local in the working
+// directory. Empty by default, so every other test sees the process env only.
+const mockDotenvFileVars: Record<string, string> = {}
+
 const mockConfigurationCtor = jest.fn().mockImplementation((args: Record<string, unknown>) => ({
   ...args,
   baseOptions: (args.baseOptions as Record<string, unknown>) ?? { headers: {} },
@@ -70,11 +74,23 @@ jest.mock(
 jest.mock('../utils/Runtime', () => {
   const actual = jest.requireActual('../utils/Runtime')
   class TestEnvReader {
+    // Mirrors the real precedence (process env, then the dotenv files) so that a
+    // regression back to `get()` for the endpoint is observable from a test.
     get(name: string): string | undefined {
+      return this.getFromProcessEnv(name) ?? this.getFromFile(name)
+    }
+    getFromProcessEnv(name: string): string | undefined {
+      TestEnvReader.checkName(name)
+      return process.env[name]
+    }
+    getFromFile(name: string): string | undefined {
+      TestEnvReader.checkName(name)
+      return mockDotenvFileVars[name]
+    }
+    private static checkName(name: string): void {
       if (!name.startsWith('DAYTONA_')) {
         throw new Error(`DaytonaEnvReader: variable name must start with 'DAYTONA_', got '${name}'`)
       }
-      return process.env[name]
     }
   }
   return { ...actual, DaytonaEnvReader: TestEnvReader }
@@ -149,6 +165,8 @@ describe('Daytona', () => {
     delete process.env.DAYTONA_API_URL
     delete process.env.DAYTONA_SERVER_URL
     delete process.env.DAYTONA_TARGET
+
+    for (const key of Object.keys(mockDotenvFileVars)) delete mockDotenvFileVars[key]
 
     mockAxiosCreate.mockReturnValue({
       defaults: { baseURL: 'http://sandbox-proxy/' },
@@ -705,5 +723,125 @@ describe('Daytona', () => {
     expect(sandboxFromGet.start).toHaveBeenCalled()
     expect(sandboxFromGet.stop).toHaveBeenCalled()
     expect(sandboxFromGet.delete).toHaveBeenCalledWith(33, false)
+  })
+
+  describe('cwd dotenv endpoint trust', () => {
+    // A .env in the working directory must not decide where the credential is sent: the
+    // working directory is frequently a cloned repository, authored by a third party.
+    const DEFAULT_API_URL = 'https://app.daytona.io/api'
+    // apiUrl / apiKey are private; the suite's established pattern is to cast.
+    const resolved = (instance: unknown) => instance as { apiUrl: string; apiKey?: string }
+    let warnSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation((): void => undefined)
+    })
+
+    afterEach(() => {
+      warnSpy.mockRestore()
+    })
+
+    const ignoredWarnings = (name = 'DAYTONA_API_URL') =>
+      warnSpy.mock.calls.filter(([msg]) => String(msg).includes(name) && String(msg).includes('was ignored'))
+
+    it('ignores an endpoint supplied by a dotenv file', async () => {
+      const { Daytona } = await import('../Daytona')
+
+      mockDotenvFileVars.DAYTONA_API_URL = 'http://attacker.example/api'
+
+      const instance = new Daytona({ apiKey: 'victim-key' })
+
+      expect(resolved(instance).apiUrl).toBe(DEFAULT_API_URL)
+      expect(resolved(instance).apiKey).toBe('victim-key')
+      // The endpoint the HTTP client is built with is what actually receives the bearer token.
+      expect(mockConfigurationCtor).toHaveBeenCalledWith(expect.objectContaining({ basePath: DEFAULT_API_URL }))
+      expect(mockConfigurationCtor).not.toHaveBeenCalledWith(
+        expect.objectContaining({ basePath: 'http://attacker.example/api' }),
+      )
+      expect(ignoredWarnings()).toHaveLength(1)
+    })
+
+    it('ignores a deprecated DAYTONA_SERVER_URL supplied by a dotenv file', async () => {
+      const { Daytona } = await import('../Daytona')
+
+      mockDotenvFileVars.DAYTONA_SERVER_URL = 'http://attacker.example/api'
+
+      const instance = new Daytona({ apiKey: 'victim-key' })
+
+      expect(resolved(instance).apiUrl).toBe(DEFAULT_API_URL)
+      expect(ignoredWarnings('DAYTONA_SERVER_URL')).toHaveLength(1)
+    })
+
+    it('ignores a dotenv endpoint paired with a credential from the process environment', async () => {
+      const { Daytona } = await import('../Daytona')
+
+      process.env.DAYTONA_API_KEY = 'victim-key'
+      mockDotenvFileVars.DAYTONA_API_URL = 'http://attacker.example/api'
+
+      const instance = new Daytona()
+
+      expect(resolved(instance).apiUrl).toBe(DEFAULT_API_URL)
+      expect(resolved(instance).apiKey).toBe('victim-key')
+      expect(ignoredWarnings()).toHaveLength(1)
+    })
+
+    it('ignores a dotenv endpoint even when the same file supplies the credential', async () => {
+      const { Daytona } = await import('../Daytona')
+
+      mockDotenvFileVars.DAYTONA_API_KEY = 'attacker-key'
+      mockDotenvFileVars.DAYTONA_API_URL = 'http://attacker.example/api'
+
+      const instance = new Daytona()
+
+      expect(resolved(instance).apiUrl).toBe(DEFAULT_API_URL)
+      expect(ignoredWarnings()).toHaveLength(1)
+    })
+
+    it('still lets the process environment set the endpoint', async () => {
+      const { Daytona } = await import('../Daytona')
+
+      process.env.DAYTONA_API_URL = 'https://chosen-by-env.example/api'
+      mockDotenvFileVars.DAYTONA_API_URL = 'http://attacker.example/api'
+
+      const instance = new Daytona({ apiKey: 'victim-key' })
+
+      expect(resolved(instance).apiUrl).toBe('https://chosen-by-env.example/api')
+      expect(ignoredWarnings()).toHaveLength(1)
+    })
+
+    it('still lets an explicit apiUrl set the endpoint', async () => {
+      const { Daytona } = await import('../Daytona')
+
+      mockDotenvFileVars.DAYTONA_API_URL = 'http://attacker.example/api'
+
+      const instance = new Daytona({ apiKey: 'victim-key', apiUrl: 'https://chosen.example/api' })
+
+      expect(resolved(instance).apiUrl).toBe('https://chosen.example/api')
+      expect(ignoredWarnings()).toHaveLength(1)
+    })
+
+    it('still reports a hostile dotenv to a fully configured client', async () => {
+      const { Daytona } = await import('../Daytona')
+
+      mockDotenvFileVars.DAYTONA_API_URL = 'http://attacker.example/api'
+
+      const instance = new Daytona({ apiKey: 'victim-key', apiUrl: 'https://chosen.example/api', target: 'us' })
+
+      expect(resolved(instance).apiUrl).toBe('https://chosen.example/api')
+      expect(ignoredWarnings()).toHaveLength(1)
+    })
+
+    it('stays quiet for the documented dotenv layout and still reads the credential from it', async () => {
+      const { Daytona } = await import('../Daytona')
+
+      mockDotenvFileVars.DAYTONA_API_KEY = 'victim-key'
+      mockDotenvFileVars.DAYTONA_API_URL = DEFAULT_API_URL
+
+      const instance = new Daytona()
+
+      expect(resolved(instance).apiUrl).toBe(DEFAULT_API_URL)
+      expect(resolved(instance).apiKey).toBe('victim-key')
+      expect(ignoredWarnings()).toHaveLength(0)
+    })
   })
 })

--- a/sdk-typescript/src/__tests__/Daytona.test.ts
+++ b/sdk-typescript/src/__tests__/Daytona.test.ts
@@ -81,11 +81,7 @@ jest.mock('../utils/Runtime', () => {
     }
     getFromProcessEnv(name: string): string | undefined {
       TestEnvReader.checkName(name)
-      const value = process.env[name]
-      // Mirrors the real accessor: a process value a dotenv file could account for is not
-      // trusted, because some runtimes pre-load that file into the process environment.
-      if (value !== undefined && value === this.getFromFile(name)) return undefined
-      return value
+      return process.env[name]
     }
     getFromFile(name: string): string | undefined {
       TestEnvReader.checkName(name)
@@ -821,19 +817,6 @@ describe('Daytona', () => {
       const instance = new Daytona({ apiKey: 'victim-key', apiUrl: 'https://chosen.example/api' })
 
       expect(resolved(instance).apiUrl).toBe('https://chosen.example/api')
-      expect(ignoredWarnings()).toHaveLength(1)
-    })
-
-    it('ignores an endpoint a runtime pre-loaded from a dotenv file into the environment', async () => {
-      const { Daytona } = await import('../Daytona')
-
-      // The shape Bun produces: the file's value is already in process.env at startup.
-      mockDotenvFileVars.DAYTONA_API_URL = 'http://attacker.example/api'
-      process.env.DAYTONA_API_URL = 'http://attacker.example/api'
-
-      const instance = new Daytona({ apiKey: 'victim-key' })
-
-      expect(resolved(instance).apiUrl).toBe(DEFAULT_API_URL)
       expect(ignoredWarnings()).toHaveLength(1)
     })
 

--- a/sdk-typescript/src/__tests__/Daytona.test.ts
+++ b/sdk-typescript/src/__tests__/Daytona.test.ts
@@ -26,6 +26,11 @@ const mockProcessStreamingResponse = jest.fn()
 // Stands in for DAYTONA_* vars parsed out of .env / .env.local in the working
 // directory. Empty by default, so every other test sees the process env only.
 const mockDotenvFileVars: Record<string, string> = {}
+// Controls the pre-loading detection the constructor consults. Off by default.
+const mockPreload: { mayBePreloaded: boolean; fileDefiningEndpoint: string | undefined } = {
+  mayBePreloaded: false,
+  fileDefiningEndpoint: undefined,
+}
 
 const mockConfigurationCtor = jest.fn().mockImplementation((args: Record<string, unknown>) => ({
   ...args,
@@ -93,7 +98,12 @@ jest.mock('../utils/Runtime', () => {
       }
     }
   }
-  return { ...actual, DaytonaEnvReader: TestEnvReader }
+  return {
+    ...actual,
+    DaytonaEnvReader: TestEnvReader,
+    dotenvMayBePreloaded: () => mockPreload.mayBePreloaded,
+    findDotenvFileDefiningEndpoint: () => mockPreload.fileDefiningEndpoint,
+  }
 })
 
 jest.mock('../Snapshot', () => {
@@ -167,6 +177,8 @@ describe('Daytona', () => {
     delete process.env.DAYTONA_TARGET
 
     for (const key of Object.keys(mockDotenvFileVars)) delete mockDotenvFileVars[key]
+    mockPreload.mayBePreloaded = false
+    mockPreload.fileDefiningEndpoint = undefined
 
     mockAxiosCreate.mockReturnValue({
       defaults: { baseURL: 'http://sandbox-proxy/' },
@@ -829,6 +841,42 @@ describe('Daytona', () => {
 
       expect(resolved(instance).apiUrl).toBe('https://chosen.example/api')
       expect(ignoredWarnings()).toHaveLength(1)
+    })
+
+    it('refuses to choose an endpoint when a pre-loading runtime could have supplied it', async () => {
+      const { Daytona } = await import('../Daytona')
+      const { DaytonaInvalidArgumentError } = await import('../errors/DaytonaError')
+
+      mockPreload.mayBePreloaded = true
+      mockPreload.fileDefiningEndpoint = '.env.production'
+      process.env.DAYTONA_API_URL = 'https://attacker.invalid/api'
+
+      expect(() => new Daytona({ apiKey: 'victim-key' })).toThrow(DaytonaInvalidArgumentError)
+      expect(() => new Daytona({ apiKey: 'victim-key' })).toThrow(/\.env\.production/)
+    })
+
+    it('accepts an endpoint the caller named explicitly on a pre-loading runtime', async () => {
+      const { Daytona } = await import('../Daytona')
+
+      mockPreload.mayBePreloaded = true
+      mockPreload.fileDefiningEndpoint = '.env'
+      process.env.DAYTONA_API_URL = 'https://attacker.invalid/api'
+
+      const instance = new Daytona({ apiKey: 'victim-key', apiUrl: 'https://chosen.example/api' })
+
+      expect(resolved(instance).apiUrl).toBe('https://chosen.example/api')
+    })
+
+    it('does not interfere when no dotenv file names the endpoint', async () => {
+      const { Daytona } = await import('../Daytona')
+
+      mockPreload.mayBePreloaded = true
+      mockPreload.fileDefiningEndpoint = undefined
+      process.env.DAYTONA_API_URL = 'https://chosen-by-shell.example/api'
+
+      const instance = new Daytona({ apiKey: 'victim-key' })
+
+      expect(resolved(instance).apiUrl).toBe('https://chosen-by-shell.example/api')
     })
 
     it('stays quiet for the documented dotenv layout and still reads the credential from it', async () => {

--- a/sdk-typescript/src/__tests__/Daytona.test.ts
+++ b/sdk-typescript/src/__tests__/Daytona.test.ts
@@ -81,7 +81,11 @@ jest.mock('../utils/Runtime', () => {
     }
     getFromProcessEnv(name: string): string | undefined {
       TestEnvReader.checkName(name)
-      return process.env[name]
+      const value = process.env[name]
+      // Mirrors the real accessor: a process value a dotenv file could account for is not
+      // trusted, because some runtimes pre-load that file into the process environment.
+      if (value !== undefined && value === this.getFromFile(name)) return undefined
+      return value
     }
     getFromFile(name: string): string | undefined {
       TestEnvReader.checkName(name)
@@ -817,6 +821,19 @@ describe('Daytona', () => {
       const instance = new Daytona({ apiKey: 'victim-key', apiUrl: 'https://chosen.example/api' })
 
       expect(resolved(instance).apiUrl).toBe('https://chosen.example/api')
+      expect(ignoredWarnings()).toHaveLength(1)
+    })
+
+    it('ignores an endpoint a runtime pre-loaded from a dotenv file into the environment', async () => {
+      const { Daytona } = await import('../Daytona')
+
+      // The shape Bun produces: the file's value is already in process.env at startup.
+      mockDotenvFileVars.DAYTONA_API_URL = 'http://attacker.example/api'
+      process.env.DAYTONA_API_URL = 'http://attacker.example/api'
+
+      const instance = new Daytona({ apiKey: 'victim-key' })
+
+      expect(resolved(instance).apiUrl).toBe(DEFAULT_API_URL)
       expect(ignoredWarnings()).toHaveLength(1)
     })
 

--- a/sdk-typescript/src/__tests__/Runtime.test.ts
+++ b/sdk-typescript/src/__tests__/Runtime.test.ts
@@ -100,6 +100,17 @@ describe('warnIfDotenvApiUrlIgnored', () => {
     expect(String(warnSpy.mock.calls[0][0])).toContain('was ignored')
   })
 
+  it('reports once when a file sets both endpoint variables to the same value', () => {
+    fs.writeFileSync(
+      '.env',
+      'DAYTONA_API_URL=http://attacker.example/api\nDAYTONA_SERVER_URL=http://attacker.example/api\n',
+    )
+
+    warnIfDotenvApiUrlIgnored(new DaytonaEnvReader(), DEFAULT_API_URL)
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('stays quiet when the dotenv endpoint matches the one in use', () => {
     fs.writeFileSync('.env', `DAYTONA_API_URL=${DEFAULT_API_URL}\n`)
 
@@ -204,6 +215,36 @@ describe('dotenv pre-loading detection', () => {
     })
 
     it('reports nothing when there is no dotenv file at all', () => {
+      expect(findDotenvFileDefiningEndpoint()).toBeUndefined()
+    })
+
+    it('examines a path named by --env-file, not just the conventional names', () => {
+      fs.mkdirSync('elsewhere')
+      fs.writeFileSync('elsewhere/custom.env', 'DAYTONA_API_URL=https://attacker.invalid/api\n')
+      process.execArgv = ['--env-file=elsewhere/custom.env']
+
+      expect(findDotenvFileDefiningEndpoint()).toBe('elsewhere/custom.env')
+    })
+
+    it('examines an absolute path named by --env-file', () => {
+      const absolute = path.join(tmpDir, 'abs.env')
+      fs.writeFileSync(absolute, 'DAYTONA_SERVER_URL=https://attacker.invalid/api\n')
+      process.execArgv = [`--env-file=${absolute}`]
+
+      expect(findDotenvFileDefiningEndpoint()).toBe(absolute)
+    })
+
+    it('examines a path given as a separate --env-file argument', () => {
+      fs.writeFileSync('custom.env', 'DAYTONA_API_URL=https://attacker.invalid/api\n')
+      process.execArgv = ['--env-file', 'custom.env']
+
+      expect(findDotenvFileDefiningEndpoint()).toBe('custom.env')
+    })
+
+    it('reports nothing when the --env-file target does not name the endpoint', () => {
+      fs.writeFileSync('custom.env', 'SOMETHING_ELSE=1\n')
+      process.execArgv = ['--env-file=custom.env']
+
       expect(findDotenvFileDefiningEndpoint()).toBeUndefined()
     })
   })

--- a/sdk-typescript/src/__tests__/Runtime.test.ts
+++ b/sdk-typescript/src/__tests__/Runtime.test.ts
@@ -57,36 +57,6 @@ describe('DaytonaEnvReader', () => {
     expect(reader.getFromFile('DAYTONA_API_URL')).toBe('http://attacker.example/api')
   })
 
-  // Bun merges the working directory's .env into process.env before user code runs, as do
-  // Next.js and `node --env-file`. These cover that shape without needing those runtimes:
-  // the observable condition is a process value identical to the file's.
-  it('does not trust a process value a dotenv file could account for', () => {
-    fs.writeFileSync('.env', 'DAYTONA_API_URL=http://attacker.example/api\n')
-    process.env.DAYTONA_API_URL = 'http://attacker.example/api'
-
-    const reader = new DaytonaEnvReader()
-
-    expect(reader.getFromFile('DAYTONA_API_URL')).toBe('http://attacker.example/api')
-    expect(reader.getFromProcessEnv('DAYTONA_API_URL')).toBeUndefined()
-  })
-
-  it('trusts a process value that differs from the dotenv file', () => {
-    fs.writeFileSync('.env', 'DAYTONA_API_URL=http://attacker.example/api\n')
-    process.env.DAYTONA_API_URL = 'https://chosen-by-shell.example/api'
-
-    const reader = new DaytonaEnvReader()
-
-    expect(reader.getFromProcessEnv('DAYTONA_API_URL')).toBe('https://chosen-by-shell.example/api')
-  })
-
-  it('trusts a process value when no dotenv file is present', () => {
-    process.env.DAYTONA_API_URL = 'https://chosen-by-shell.example/api'
-
-    const reader = new DaytonaEnvReader()
-
-    expect(reader.getFromProcessEnv('DAYTONA_API_URL')).toBe('https://chosen-by-shell.example/api')
-  })
-
   it('rejects variable names outside the DAYTONA_ namespace', () => {
     const reader = new DaytonaEnvReader()
 

--- a/sdk-typescript/src/__tests__/Runtime.test.ts
+++ b/sdk-typescript/src/__tests__/Runtime.test.ts
@@ -1,0 +1,111 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { DaytonaEnvReader, warnIfDotenvApiUrlIgnored } from '../utils/Runtime'
+
+const DEFAULT_API_URL = 'https://app.daytona.io/api'
+
+// Exercises the real reader against real files on disk. Daytona.test.ts mocks the reader
+// for determinism, so without this the cwd-relative parsing itself would go untested.
+describe('DaytonaEnvReader', () => {
+  let tmpDir: string
+  let originalCwd: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tmpDir = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'daytona-env-'))
+    process.chdir(tmpDir)
+    delete process.env.DAYTONA_API_URL
+    delete process.env.DAYTONA_SERVER_URL
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('reads dotenv files relative to the working directory', () => {
+    fs.writeFileSync('.env', 'DAYTONA_API_URL=http://attacker.example/api\n')
+
+    const reader = new DaytonaEnvReader()
+
+    expect(reader.getFromFile('DAYTONA_API_URL')).toBe('http://attacker.example/api')
+  })
+
+  it('does not expose dotenv values through the process-environment accessor', () => {
+    fs.writeFileSync('.env', 'DAYTONA_API_URL=http://attacker.example/api\n')
+    fs.writeFileSync('.env.local', 'DAYTONA_SERVER_URL=http://attacker.example/api\n')
+
+    const reader = new DaytonaEnvReader()
+
+    expect(reader.getFromProcessEnv('DAYTONA_API_URL')).toBeUndefined()
+    expect(reader.getFromProcessEnv('DAYTONA_SERVER_URL')).toBeUndefined()
+  })
+
+  it('prefers the process environment over dotenv files in the general accessor', () => {
+    process.env.DAYTONA_API_URL = 'https://runtime.example/api'
+    fs.writeFileSync('.env', 'DAYTONA_API_URL=http://attacker.example/api\n')
+
+    const reader = new DaytonaEnvReader()
+
+    expect(reader.get('DAYTONA_API_URL')).toBe('https://runtime.example/api')
+    expect(reader.getFromProcessEnv('DAYTONA_API_URL')).toBe('https://runtime.example/api')
+    expect(reader.getFromFile('DAYTONA_API_URL')).toBe('http://attacker.example/api')
+  })
+
+  it('rejects variable names outside the DAYTONA_ namespace', () => {
+    const reader = new DaytonaEnvReader()
+
+    expect(() => reader.getFromProcessEnv('OTHER_VAR')).toThrow("must start with 'DAYTONA_'")
+    expect(() => reader.getFromFile('OTHER_VAR')).toThrow("must start with 'DAYTONA_'")
+  })
+})
+
+describe('warnIfDotenvApiUrlIgnored', () => {
+  let tmpDir: string
+  let originalCwd: string
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tmpDir = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'daytona-env-'))
+    process.chdir(tmpDir)
+    delete process.env.DAYTONA_API_URL
+    delete process.env.DAYTONA_SERVER_URL
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation((): void => undefined)
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    process.chdir(originalCwd)
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('reports a dotenv endpoint that differs from the one in use', () => {
+    fs.writeFileSync('.env', 'DAYTONA_API_URL=http://attacker.example/api\n')
+
+    warnIfDotenvApiUrlIgnored(new DaytonaEnvReader(), DEFAULT_API_URL)
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(String(warnSpy.mock.calls[0][0])).toContain('DAYTONA_API_URL')
+    expect(String(warnSpy.mock.calls[0][0])).toContain('was ignored')
+  })
+
+  it('stays quiet when the dotenv endpoint matches the one in use', () => {
+    fs.writeFileSync('.env', `DAYTONA_API_URL=${DEFAULT_API_URL}\n`)
+
+    warnIfDotenvApiUrlIgnored(new DaytonaEnvReader(), DEFAULT_API_URL)
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('stays quiet when no dotenv file sets an endpoint', () => {
+    warnIfDotenvApiUrlIgnored(new DaytonaEnvReader(), DEFAULT_API_URL)
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/sdk-typescript/src/__tests__/Runtime.test.ts
+++ b/sdk-typescript/src/__tests__/Runtime.test.ts
@@ -57,6 +57,36 @@ describe('DaytonaEnvReader', () => {
     expect(reader.getFromFile('DAYTONA_API_URL')).toBe('http://attacker.example/api')
   })
 
+  // Bun merges the working directory's .env into process.env before user code runs, as do
+  // Next.js and `node --env-file`. These cover that shape without needing those runtimes:
+  // the observable condition is a process value identical to the file's.
+  it('does not trust a process value a dotenv file could account for', () => {
+    fs.writeFileSync('.env', 'DAYTONA_API_URL=http://attacker.example/api\n')
+    process.env.DAYTONA_API_URL = 'http://attacker.example/api'
+
+    const reader = new DaytonaEnvReader()
+
+    expect(reader.getFromFile('DAYTONA_API_URL')).toBe('http://attacker.example/api')
+    expect(reader.getFromProcessEnv('DAYTONA_API_URL')).toBeUndefined()
+  })
+
+  it('trusts a process value that differs from the dotenv file', () => {
+    fs.writeFileSync('.env', 'DAYTONA_API_URL=http://attacker.example/api\n')
+    process.env.DAYTONA_API_URL = 'https://chosen-by-shell.example/api'
+
+    const reader = new DaytonaEnvReader()
+
+    expect(reader.getFromProcessEnv('DAYTONA_API_URL')).toBe('https://chosen-by-shell.example/api')
+  })
+
+  it('trusts a process value when no dotenv file is present', () => {
+    process.env.DAYTONA_API_URL = 'https://chosen-by-shell.example/api'
+
+    const reader = new DaytonaEnvReader()
+
+    expect(reader.getFromProcessEnv('DAYTONA_API_URL')).toBe('https://chosen-by-shell.example/api')
+  })
+
   it('rejects variable names outside the DAYTONA_ namespace', () => {
     const reader = new DaytonaEnvReader()
 

--- a/sdk-typescript/src/__tests__/Runtime.test.ts
+++ b/sdk-typescript/src/__tests__/Runtime.test.ts
@@ -8,6 +8,7 @@ import * as path from 'path'
 import {
   DaytonaEnvReader,
   dotenvMayBePreloaded,
+  dotenvSearchDirs,
   findDotenvFileDefiningEndpoint,
   warnIfDotenvApiUrlIgnored,
 } from '../utils/Runtime'
@@ -182,19 +183,19 @@ describe('dotenv pre-loading detection', () => {
     it('reports a file that sets the endpoint', () => {
       fs.writeFileSync('.env', 'DAYTONA_API_URL=https://attacker.invalid/api\n')
 
-      expect(findDotenvFileDefiningEndpoint()).toBe('.env')
+      expect(findDotenvFileDefiningEndpoint()).toBe(path.join(tmpDir, '.env'))
     })
 
     it('reports a file the SDK does not otherwise read, such as .env.production', () => {
       fs.writeFileSync('.env.production', 'DAYTONA_API_URL=https://attacker.invalid/api\n')
 
-      expect(findDotenvFileDefiningEndpoint()).toBe('.env.production')
+      expect(findDotenvFileDefiningEndpoint()).toBe(path.join(tmpDir, '.env.production'))
     })
 
     it('reports the deprecated DAYTONA_SERVER_URL too', () => {
       fs.writeFileSync('.env.local', 'DAYTONA_SERVER_URL=https://attacker.invalid/api\n')
 
-      expect(findDotenvFileDefiningEndpoint()).toBe('.env.local')
+      expect(findDotenvFileDefiningEndpoint()).toBe(path.join(tmpDir, '.env.local'))
     })
 
     it('is not defeated by a value assembled from another variable', () => {
@@ -205,7 +206,7 @@ describe('dotenv pre-loading detection', () => {
         'DAYTONA_REVIEW_HOST=attacker.invalid\nDAYTONA_API_URL=https://$DAYTONA_REVIEW_HOST/api\n',
       )
 
-      expect(findDotenvFileDefiningEndpoint()).toBe('.env')
+      expect(findDotenvFileDefiningEndpoint()).toBe(path.join(tmpDir, '.env'))
     })
 
     it('reports nothing when no dotenv file names the endpoint', () => {
@@ -223,7 +224,7 @@ describe('dotenv pre-loading detection', () => {
       fs.writeFileSync('elsewhere/custom.env', 'DAYTONA_API_URL=https://attacker.invalid/api\n')
       process.execArgv = ['--env-file=elsewhere/custom.env']
 
-      expect(findDotenvFileDefiningEndpoint()).toBe('elsewhere/custom.env')
+      expect(findDotenvFileDefiningEndpoint()).toBe(path.join(tmpDir, 'elsewhere/custom.env'))
     })
 
     it('examines an absolute path named by --env-file', () => {
@@ -238,7 +239,32 @@ describe('dotenv pre-loading detection', () => {
       fs.writeFileSync('custom.env', 'DAYTONA_API_URL=https://attacker.invalid/api\n')
       process.execArgv = ['--env-file', 'custom.env']
 
-      expect(findDotenvFileDefiningEndpoint()).toBe('custom.env')
+      expect(findDotenvFileDefiningEndpoint()).toBe(path.join(tmpDir, 'custom.env'))
+    })
+
+    it('still finds the file after the application changes directory', () => {
+      // A runtime resolves its dotenv files at startup, so process.chdir() afterwards must
+      // not move the search away from the file that supplied the environment. The startup
+      // directory is captured when the module loads, which under jest is the package root,
+      // so the directory under test is passed in explicitly.
+      fs.writeFileSync('.env', 'DAYTONA_API_URL=https://attacker.invalid/api\n')
+      const elsewhere = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'daytona-elsewhere-'))
+      try {
+        process.chdir(elsewhere)
+
+        expect(findDotenvFileDefiningEndpoint()).toBeUndefined()
+        expect(findDotenvFileDefiningEndpoint([tmpDir])).toBe(path.join(tmpDir, '.env'))
+      } finally {
+        process.chdir(tmpDir)
+        fs.rmSync(elsewhere, { recursive: true, force: true })
+      }
+    })
+
+    it('searches the startup directory as well as the current one', () => {
+      const dirs = dotenvSearchDirs()
+
+      expect(dirs).toContain(process.cwd())
+      expect(dirs.length).toBeGreaterThanOrEqual(1)
     })
 
     it('reports nothing when the --env-file target does not name the endpoint', () => {

--- a/sdk-typescript/src/__tests__/Runtime.test.ts
+++ b/sdk-typescript/src/__tests__/Runtime.test.ts
@@ -5,7 +5,12 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 
-import { DaytonaEnvReader, warnIfDotenvApiUrlIgnored } from '../utils/Runtime'
+import {
+  DaytonaEnvReader,
+  dotenvMayBePreloaded,
+  findDotenvFileDefiningEndpoint,
+  warnIfDotenvApiUrlIgnored,
+} from '../utils/Runtime'
 
 const DEFAULT_API_URL = 'https://app.daytona.io/api'
 
@@ -107,5 +112,99 @@ describe('warnIfDotenvApiUrlIgnored', () => {
     warnIfDotenvApiUrlIgnored(new DaytonaEnvReader(), DEFAULT_API_URL)
 
     expect(warnSpy).not.toHaveBeenCalled()
+  })
+})
+
+// Runtimes that load a dotenv file into process.env before user code runs make the process
+// environment unattributable. These cover the detection that decides whether to refuse.
+describe('dotenv pre-loading detection', () => {
+  let tmpDir: string
+  let originalCwd: string
+  let originalExecArgv: string[]
+  let originalNextRuntime: string | undefined
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    originalExecArgv = process.execArgv
+    originalNextRuntime = process.env.NEXT_RUNTIME
+    delete process.env.NEXT_RUNTIME
+    tmpDir = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'daytona-preload-'))
+    process.chdir(tmpDir)
+  })
+
+  afterEach(() => {
+    process.execArgv = originalExecArgv
+    if (originalNextRuntime === undefined) delete process.env.NEXT_RUNTIME
+    else process.env.NEXT_RUNTIME = originalNextRuntime
+    process.chdir(originalCwd)
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('dotenvMayBePreloaded', () => {
+    it('is false for a plain node process', () => {
+      process.execArgv = []
+
+      expect(dotenvMayBePreloaded()).toBe(false)
+    })
+
+    it('is true when node was given --env-file', () => {
+      process.execArgv = ['--env-file=.env']
+
+      expect(dotenvMayBePreloaded()).toBe(true)
+    })
+
+    it('is true when node was given --env-file-if-exists', () => {
+      process.execArgv = ['--env-file-if-exists=.env']
+
+      expect(dotenvMayBePreloaded()).toBe(true)
+    })
+
+    it('is true inside a Next.js server runtime', () => {
+      process.execArgv = []
+      process.env.NEXT_RUNTIME = 'nodejs'
+
+      expect(dotenvMayBePreloaded()).toBe(true)
+    })
+  })
+
+  describe('findDotenvFileDefiningEndpoint', () => {
+    it('reports a file that sets the endpoint', () => {
+      fs.writeFileSync('.env', 'DAYTONA_API_URL=https://attacker.invalid/api\n')
+
+      expect(findDotenvFileDefiningEndpoint()).toBe('.env')
+    })
+
+    it('reports a file the SDK does not otherwise read, such as .env.production', () => {
+      fs.writeFileSync('.env.production', 'DAYTONA_API_URL=https://attacker.invalid/api\n')
+
+      expect(findDotenvFileDefiningEndpoint()).toBe('.env.production')
+    })
+
+    it('reports the deprecated DAYTONA_SERVER_URL too', () => {
+      fs.writeFileSync('.env.local', 'DAYTONA_SERVER_URL=https://attacker.invalid/api\n')
+
+      expect(findDotenvFileDefiningEndpoint()).toBe('.env.local')
+    })
+
+    it('is not defeated by a value assembled from another variable', () => {
+      // A parser returns the raw text while the runtime expands it, so only the presence of
+      // the name is meaningful here.
+      fs.writeFileSync(
+        '.env',
+        'DAYTONA_REVIEW_HOST=attacker.invalid\nDAYTONA_API_URL=https://$DAYTONA_REVIEW_HOST/api\n',
+      )
+
+      expect(findDotenvFileDefiningEndpoint()).toBe('.env')
+    })
+
+    it('reports nothing when no dotenv file names the endpoint', () => {
+      fs.writeFileSync('.env', 'DAYTONA_API_KEY=some-key\nDAYTONA_TARGET=us\n')
+
+      expect(findDotenvFileDefiningEndpoint()).toBeUndefined()
+    })
+
+    it('reports nothing when there is no dotenv file at all', () => {
+      expect(findDotenvFileDefiningEndpoint()).toBeUndefined()
+    })
   })
 })

--- a/sdk-typescript/src/__tests__/Runtime.test.ts
+++ b/sdk-typescript/src/__tests__/Runtime.test.ts
@@ -14,6 +14,8 @@ import {
 } from '../utils/Runtime'
 
 const DEFAULT_API_URL = 'https://app.daytona.io/api'
+// Captured at module load, mirroring how Runtime.ts captures its startup directory.
+const MODULE_LOAD_CWD = process.cwd()
 
 // Exercises the real reader against real files on disk. Daytona.test.ts mocks the reader
 // for determinism, so without this the cwd-relative parsing itself would go untested.
@@ -261,10 +263,21 @@ describe('dotenv pre-loading detection', () => {
     })
 
     it('searches the startup directory as well as the current one', () => {
+      // MODULE_LOAD_CWD is captured at the top of this file, at the same point in the
+      // lifecycle as Runtime.ts captures its own, so after a chdir the two must both appear.
+      process.chdir(tmpDir)
+
       const dirs = dotenvSearchDirs()
 
-      expect(dirs).toContain(process.cwd())
-      expect(dirs.length).toBeGreaterThanOrEqual(1)
+      expect(dirs).toContain(fs.realpathSync(tmpDir))
+      expect(dirs).toContain(MODULE_LOAD_CWD)
+      expect(dirs).toHaveLength(2)
+    })
+
+    it('returns a single directory when the application has not changed directory', () => {
+      process.chdir(MODULE_LOAD_CWD)
+
+      expect(dotenvSearchDirs()).toEqual([MODULE_LOAD_CWD])
     })
 
     it('reports nothing when the --env-file target does not name the endpoint', () => {

--- a/sdk-typescript/src/utils/Runtime.ts
+++ b/sdk-typescript/src/utils/Runtime.ts
@@ -82,16 +82,28 @@ export class DaytonaEnvReader {
   }
 
   /**
-   * Reads `name` from the process environment only, never from .env / .env.local.
+   * Reads `name` from the process environment, ignoring any value a dotenv file in the
+   * working directory could account for.
    *
-   * The dotenv files are read from the current working directory, which is not
-   * necessarily authored by whoever runs the process. Anything that determines the host a
-   * credential is sent to must be resolved through this method, so that a file in the
-   * working directory cannot redirect the SDK.
+   * The dotenv files are read from the current working directory, which is not necessarily
+   * authored by whoever runs the process. Anything that determines the host a credential is
+   * sent to must be resolved through this method, so that a file in the working directory
+   * cannot redirect the SDK.
+   *
+   * Reading `process.env` is not sufficient on its own: some runtimes merge the working
+   * directory's .env into the process environment before any user code runs - Bun does it
+   * unconditionally, and Next.js and `node --env-file` do it too - so on those runtimes the
+   * process environment alone cannot be attributed to the caller. When the process value is
+   * byte-identical to the file's, the file cannot be ruled out as its source and the value
+   * is not trusted here. A deliberate shell export still wins, because those runtimes do not
+   * overwrite a variable that is already set: an exported value either differs from the file
+   * or there is no file to begin with.
    */
   getFromProcessEnv(name: string): string | undefined {
     DaytonaEnvReader.checkName(name)
-    return getEnvVar(name)
+    const value = getEnvVar(name)
+    if (value !== undefined && value === this.getFromFile(name)) return undefined
+    return value
   }
 
   /** Reads `name` from .env.local / .env only, ignoring the process environment. */
@@ -108,7 +120,9 @@ export class DaytonaEnvReader {
   }
 
   private static parseFileVars(path: string): Record<string, string> {
-    if (RUNTIME !== Runtime.NODE || typeof require === 'undefined') return {}
+    // Bun is detected before Node above, so a Node-only guard would leave the reader blind on
+    // the one runtime that pre-loads .env into the process environment. Bun provides require('fs').
+    if ((RUNTIME !== Runtime.NODE && RUNTIME !== Runtime.BUN) || typeof require === 'undefined') return {}
     const fs = require('fs')
     if (!fs.existsSync(path)) return {}
     const dotenv = require('dotenv')
@@ -127,20 +141,20 @@ export function isServerlessRuntime(): boolean {
   return Boolean(
     // Cloudflare Workers (V8 isolate API)
     typeof globalObj.WebSocketPair === 'function' ||
-      // Cloudflare Pages
-      env.CF_PAGES === '1' ||
-      // AWS Lambda (incl. SAM local)
-      env.AWS_EXECUTION_ENV?.startsWith('AWS_Lambda') ||
-      env.LAMBDA_TASK_ROOT !== undefined ||
-      env.AWS_SAM_LOCAL === 'true' ||
-      // Azure Functions
-      env.FUNCTIONS_WORKER_RUNTIME !== undefined ||
-      // Google Cloud Functions / Cloud Run
-      (env.FUNCTION_TARGET !== undefined && env.FUNCTION_SIGNATURE_TYPE !== undefined) ||
-      // Vercel
-      env.VERCEL === '1' ||
-      // Netlify Functions
-      env.SITE_NAME !== undefined,
+    // Cloudflare Pages
+    env.CF_PAGES === '1' ||
+    // AWS Lambda (incl. SAM local)
+    env.AWS_EXECUTION_ENV?.startsWith('AWS_Lambda') ||
+    env.LAMBDA_TASK_ROOT !== undefined ||
+    env.AWS_SAM_LOCAL === 'true' ||
+    // Azure Functions
+    env.FUNCTIONS_WORKER_RUNTIME !== undefined ||
+    // Google Cloud Functions / Cloud Run
+    (env.FUNCTION_TARGET !== undefined && env.FUNCTION_SIGNATURE_TYPE !== undefined) ||
+    // Vercel
+    env.VERCEL === '1' ||
+    // Netlify Functions
+    env.SITE_NAME !== undefined,
   )
 }
 

--- a/sdk-typescript/src/utils/Runtime.ts
+++ b/sdk-typescript/src/utils/Runtime.ts
@@ -278,9 +278,19 @@ export function dotenvSearchDirs(): string[] {
  */
 export function findDotenvFileDefiningEndpoint(searchDirs: string[] = dotenvSearchDirs()): string | undefined {
   if ((RUNTIME !== Runtime.NODE && RUNTIME !== Runtime.BUN) || typeof require === 'undefined') return undefined
-  const fs = require('fs')
-  const nodePath = require('path')
-  const dotenv = require('dotenv')
+  // A bundler can leave `require` defined while these are unresolvable. Constructing a
+  // client must not fail because the check could not run, so treat that as nothing found:
+  // the endpoint then resolves as it did before this check existed.
+  let fs: typeof import('fs')
+  let nodePath: typeof import('path')
+  let dotenv: typeof import('dotenv')
+  try {
+    fs = require('fs')
+    nodePath = require('path')
+    dotenv = require('dotenv')
+  } catch {
+    return undefined
+  }
   const names = [...explicitDotenvPaths(), ...PRELOADABLE_DOTENV_FILES]
   const candidates: string[] = []
   for (const name of names) {

--- a/sdk-typescript/src/utils/Runtime.ts
+++ b/sdk-typescript/src/utils/Runtime.ts
@@ -82,28 +82,16 @@ export class DaytonaEnvReader {
   }
 
   /**
-   * Reads `name` from the process environment, ignoring any value a dotenv file in the
-   * working directory could account for.
+   * Reads `name` from the process environment only, never from .env / .env.local.
    *
-   * The dotenv files are read from the current working directory, which is not necessarily
-   * authored by whoever runs the process. Anything that determines the host a credential is
-   * sent to must be resolved through this method, so that a file in the working directory
-   * cannot redirect the SDK.
-   *
-   * Reading `process.env` is not sufficient on its own: some runtimes merge the working
-   * directory's .env into the process environment before any user code runs - Bun does it
-   * unconditionally, and Next.js and `node --env-file` do it too - so on those runtimes the
-   * process environment alone cannot be attributed to the caller. When the process value is
-   * byte-identical to the file's, the file cannot be ruled out as its source and the value
-   * is not trusted here. A deliberate shell export still wins, because those runtimes do not
-   * overwrite a variable that is already set: an exported value either differs from the file
-   * or there is no file to begin with.
+   * The dotenv files are read from the current working directory, which is not
+   * necessarily authored by whoever runs the process. Anything that determines the host a
+   * credential is sent to must be resolved through this method, so that a file in the
+   * working directory cannot redirect the SDK.
    */
   getFromProcessEnv(name: string): string | undefined {
     DaytonaEnvReader.checkName(name)
-    const value = getEnvVar(name)
-    if (value !== undefined && value === this.getFromFile(name)) return undefined
-    return value
+    return getEnvVar(name)
   }
 
   /** Reads `name` from .env.local / .env only, ignoring the process environment. */
@@ -120,9 +108,7 @@ export class DaytonaEnvReader {
   }
 
   private static parseFileVars(path: string): Record<string, string> {
-    // Bun is detected before Node above, so a Node-only guard would leave the reader blind on
-    // the one runtime that pre-loads .env into the process environment. Bun provides require('fs').
-    if ((RUNTIME !== Runtime.NODE && RUNTIME !== Runtime.BUN) || typeof require === 'undefined') return {}
+    if (RUNTIME !== Runtime.NODE || typeof require === 'undefined') return {}
     const fs = require('fs')
     if (!fs.existsSync(path)) return {}
     const dotenv = require('dotenv')
@@ -141,20 +127,20 @@ export function isServerlessRuntime(): boolean {
   return Boolean(
     // Cloudflare Workers (V8 isolate API)
     typeof globalObj.WebSocketPair === 'function' ||
-    // Cloudflare Pages
-    env.CF_PAGES === '1' ||
-    // AWS Lambda (incl. SAM local)
-    env.AWS_EXECUTION_ENV?.startsWith('AWS_Lambda') ||
-    env.LAMBDA_TASK_ROOT !== undefined ||
-    env.AWS_SAM_LOCAL === 'true' ||
-    // Azure Functions
-    env.FUNCTIONS_WORKER_RUNTIME !== undefined ||
-    // Google Cloud Functions / Cloud Run
-    (env.FUNCTION_TARGET !== undefined && env.FUNCTION_SIGNATURE_TYPE !== undefined) ||
-    // Vercel
-    env.VERCEL === '1' ||
-    // Netlify Functions
-    env.SITE_NAME !== undefined,
+      // Cloudflare Pages
+      env.CF_PAGES === '1' ||
+      // AWS Lambda (incl. SAM local)
+      env.AWS_EXECUTION_ENV?.startsWith('AWS_Lambda') ||
+      env.LAMBDA_TASK_ROOT !== undefined ||
+      env.AWS_SAM_LOCAL === 'true' ||
+      // Azure Functions
+      env.FUNCTIONS_WORKER_RUNTIME !== undefined ||
+      // Google Cloud Functions / Cloud Run
+      (env.FUNCTION_TARGET !== undefined && env.FUNCTION_SIGNATURE_TYPE !== undefined) ||
+      // Vercel
+      env.VERCEL === '1' ||
+      // Netlify Functions
+      env.SITE_NAME !== undefined,
   )
 }
 

--- a/sdk-typescript/src/utils/Runtime.ts
+++ b/sdk-typescript/src/utils/Runtime.ts
@@ -73,16 +73,38 @@ export class DaytonaEnvReader {
   }
 
   get(name: string): string | undefined {
-    if (!name.startsWith('DAYTONA_')) {
-      throw new Error(`DaytonaEnvReader: variable name must start with 'DAYTONA_', got '${name}'`)
-    }
+    DaytonaEnvReader.checkName(name)
     // 1. Runtime env
     const runtimeVal = getEnvVar(name)
     if (runtimeVal !== undefined) return runtimeVal
-    // 2. .env.local
+    // 2. .env.local, 3. .env
+    return this.getFromFile(name)
+  }
+
+  /**
+   * Reads `name` from the process environment only, never from .env / .env.local.
+   *
+   * The dotenv files are read from the current working directory, which is not
+   * necessarily authored by whoever runs the process. Anything that determines the host a
+   * credential is sent to must be resolved through this method, so that a file in the
+   * working directory cannot redirect the SDK.
+   */
+  getFromProcessEnv(name: string): string | undefined {
+    DaytonaEnvReader.checkName(name)
+    return getEnvVar(name)
+  }
+
+  /** Reads `name` from .env.local / .env only, ignoring the process environment. */
+  getFromFile(name: string): string | undefined {
+    DaytonaEnvReader.checkName(name)
     if (name in this.envLocalVars) return this.envLocalVars[name]
-    // 3. .env
     return this.envVars[name]
+  }
+
+  private static checkName(name: string): void {
+    if (!name.startsWith('DAYTONA_')) {
+      throw new Error(`DaytonaEnvReader: variable name must start with 'DAYTONA_', got '${name}'`)
+    }
   }
 
   private static parseFileVars(path: string): Record<string, string> {
@@ -120,4 +142,24 @@ export function isServerlessRuntime(): boolean {
       // Netlify Functions
       env.SITE_NAME !== undefined,
   )
+}
+
+/**
+ * Warns when a dotenv file asked for an API endpoint that was not used.
+ *
+ * Staying silent when the file value matches the endpoint in use keeps the documented
+ * `.env` layout quiet, while a file that would have changed the destination is reported.
+ */
+export function warnIfDotenvApiUrlIgnored(reader: DaytonaEnvReader, apiUrl: string): void {
+  for (const name of ['DAYTONA_API_URL', 'DAYTONA_SERVER_URL']) {
+    const fileValue = reader.getFromFile(name)
+    if (fileValue && fileValue !== apiUrl) {
+      console.warn(
+        `\`${name}\` set in a .env or .env.local file was ignored: the Daytona API endpoint is` +
+          ` never read from dotenv files, because the working directory is not always authored by` +
+          ` you. Using \`${apiUrl}\` instead. To change the endpoint, pass \`apiUrl\` to the Daytona` +
+          ` constructor or set \`${name}\` in the environment of the process.`,
+      )
+    }
+  }
 }

--- a/sdk-typescript/src/utils/Runtime.ts
+++ b/sdk-typescript/src/utils/Runtime.ts
@@ -108,7 +108,9 @@ export class DaytonaEnvReader {
   }
 
   private static parseFileVars(path: string): Record<string, string> {
-    if (RUNTIME !== Runtime.NODE || typeof require === 'undefined') return {}
+    // Bun is detected before Node above, so a Node-only gate would leave the reader unable to
+    // read files on the one runtime that pre-loads them. Bun implements require('fs').
+    if ((RUNTIME !== Runtime.NODE && RUNTIME !== Runtime.BUN) || typeof require === 'undefined') return {}
     const fs = require('fs')
     if (!fs.existsSync(path)) return {}
     const dotenv = require('dotenv')
@@ -127,20 +129,20 @@ export function isServerlessRuntime(): boolean {
   return Boolean(
     // Cloudflare Workers (V8 isolate API)
     typeof globalObj.WebSocketPair === 'function' ||
-      // Cloudflare Pages
-      env.CF_PAGES === '1' ||
-      // AWS Lambda (incl. SAM local)
-      env.AWS_EXECUTION_ENV?.startsWith('AWS_Lambda') ||
-      env.LAMBDA_TASK_ROOT !== undefined ||
-      env.AWS_SAM_LOCAL === 'true' ||
-      // Azure Functions
-      env.FUNCTIONS_WORKER_RUNTIME !== undefined ||
-      // Google Cloud Functions / Cloud Run
-      (env.FUNCTION_TARGET !== undefined && env.FUNCTION_SIGNATURE_TYPE !== undefined) ||
-      // Vercel
-      env.VERCEL === '1' ||
-      // Netlify Functions
-      env.SITE_NAME !== undefined,
+    // Cloudflare Pages
+    env.CF_PAGES === '1' ||
+    // AWS Lambda (incl. SAM local)
+    env.AWS_EXECUTION_ENV?.startsWith('AWS_Lambda') ||
+    env.LAMBDA_TASK_ROOT !== undefined ||
+    env.AWS_SAM_LOCAL === 'true' ||
+    // Azure Functions
+    env.FUNCTIONS_WORKER_RUNTIME !== undefined ||
+    // Google Cloud Functions / Cloud Run
+    (env.FUNCTION_TARGET !== undefined && env.FUNCTION_SIGNATURE_TYPE !== undefined) ||
+    // Vercel
+    env.VERCEL === '1' ||
+    // Netlify Functions
+    env.SITE_NAME !== undefined,
   )
 }
 
@@ -162,4 +164,64 @@ export function warnIfDotenvApiUrlIgnored(reader: DaytonaEnvReader, apiUrl: stri
       )
     }
   }
+}
+
+/** The variables that decide which host the API key is sent to. */
+const ENDPOINT_VARS = ['DAYTONA_API_URL', 'DAYTONA_SERVER_URL'] as const
+
+/**
+ * The union of the dotenv file names that Bun and Next.js load on their own. `.env` and
+ * `.env.local` are the SDK's own precedence chain; the rest are here only so that a file
+ * defining the endpoint cannot go unnoticed.
+ */
+const PRELOADABLE_DOTENV_FILES = [
+  '.env',
+  '.env.local',
+  '.env.development',
+  '.env.development.local',
+  '.env.production',
+  '.env.production.local',
+  '.env.test',
+  '.env.test.local',
+] as const
+
+/**
+ * Whether the runtime may have merged a working-directory dotenv file into `process.env`
+ * before any user code ran.
+ *
+ * Bun does this unconditionally unless started with `--no-env-file`; Node does it when given
+ * `--env-file`; Next.js does it in its server runtimes. On these runtimes the process
+ * environment cannot be attributed to the caller, so it cannot be trusted to name a host.
+ */
+export function dotenvMayBePreloaded(): boolean {
+  if (typeof process === 'undefined') return false
+  const execArgv = Array.isArray(process.execArgv) ? process.execArgv : []
+  if (execArgv.some((arg) => arg.startsWith('--env-file'))) return true
+  if (RUNTIME === Runtime.BUN) return !execArgv.includes('--no-env-file')
+  return Boolean(process.env?.NEXT_RUNTIME)
+}
+
+/**
+ * The first dotenv file in the working directory that defines an endpoint variable, if any.
+ *
+ * This deliberately reports on the presence of the *name* and never looks at the value. A
+ * value comparison cannot establish where an environment value came from: runtimes expand
+ * `$VAR` references while a parser returns the raw text, so equal-looking values prove
+ * nothing and unequal ones rule nothing out.
+ */
+export function findDotenvFileDefiningEndpoint(): string | undefined {
+  if ((RUNTIME !== Runtime.NODE && RUNTIME !== Runtime.BUN) || typeof require === 'undefined') return undefined
+  const fs = require('fs')
+  const dotenv = require('dotenv')
+  for (const file of PRELOADABLE_DOTENV_FILES) {
+    if (!fs.existsSync(file)) continue
+    let names: string[]
+    try {
+      names = Object.keys(dotenv.parse(fs.readFileSync(file)) as Record<string, string>)
+    } catch {
+      continue
+    }
+    if (names.some((name) => (ENDPOINT_VARS as readonly string[]).includes(name))) return file
+  }
+  return undefined
 }

--- a/sdk-typescript/src/utils/Runtime.ts
+++ b/sdk-typescript/src/utils/Runtime.ts
@@ -205,6 +205,25 @@ export function dotenvMayBePreloaded(): boolean {
 }
 
 /**
+ * The working directory as it was when this module first loaded.
+ *
+ * A runtime resolves its dotenv files when the process starts, so a relative `--env-file`
+ * path - and the conventional names - belong to that directory. An application is free to
+ * call `process.chdir()` afterwards, which would otherwise move the search away from the
+ * file that actually supplied the environment. Imports run before application logic, so this
+ * is the startup directory in practice.
+ */
+const STARTUP_CWD = typeof process !== 'undefined' && typeof process.cwd === 'function' ? safeCwd() : undefined
+
+function safeCwd(): string | undefined {
+  try {
+    return process.cwd()
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * The paths named by `--env-file` / `--env-file-if-exists`, in the order they were given.
  *
  * A runtime told to load a specific file does not restrict itself to the conventional names,
@@ -230,6 +249,18 @@ function explicitDotenvPaths(): string[] {
 }
 
 /**
+ * The directories a pre-loading runtime could have read a dotenv file from: the current one,
+ * and the startup one when the application has since changed directory.
+ */
+export function dotenvSearchDirs(): string[] {
+  const dirs: string[] = []
+  const current = safeCwd()
+  if (current) dirs.push(current)
+  if (STARTUP_CWD && STARTUP_CWD !== current) dirs.push(STARTUP_CWD)
+  return dirs
+}
+
+/**
  * The first dotenv file that defines an endpoint variable, if any.
  *
  * This deliberately reports on the presence of the *name* and never looks at the value. A
@@ -237,11 +268,17 @@ function explicitDotenvPaths(): string[] {
  * `$VAR` references while a parser returns the raw text, so equal-looking values prove
  * nothing and unequal ones rule nothing out.
  */
-export function findDotenvFileDefiningEndpoint(): string | undefined {
+export function findDotenvFileDefiningEndpoint(searchDirs: string[] = dotenvSearchDirs()): string | undefined {
   if ((RUNTIME !== Runtime.NODE && RUNTIME !== Runtime.BUN) || typeof require === 'undefined') return undefined
   const fs = require('fs')
+  const nodePath = require('path')
   const dotenv = require('dotenv')
-  for (const file of [...explicitDotenvPaths(), ...PRELOADABLE_DOTENV_FILES]) {
+  const names = [...explicitDotenvPaths(), ...PRELOADABLE_DOTENV_FILES]
+  const candidates: string[] = []
+  for (const name of names) {
+    for (const dir of searchDirs) candidates.push(nodePath.resolve(dir, name))
+  }
+  for (const file of [...new Set(candidates)]) {
     if (!fs.existsSync(file)) continue
     let names: string[]
     try {

--- a/sdk-typescript/src/utils/Runtime.ts
+++ b/sdk-typescript/src/utils/Runtime.ts
@@ -280,17 +280,20 @@ export function findDotenvFileDefiningEndpoint(searchDirs: string[] = dotenvSear
   if ((RUNTIME !== Runtime.NODE && RUNTIME !== Runtime.BUN) || typeof require === 'undefined') return undefined
   // A bundler can leave `require` defined while these are unresolvable. Constructing a
   // client must not fail because the check could not run, so treat that as nothing found:
-  // the endpoint then resolves as it did before this check existed.
-  let fs: typeof import('fs')
-  let nodePath: typeof import('path')
-  let dotenv: typeof import('dotenv')
+  // the endpoint then resolves as it did before this check existed. The modules are left
+  // untyped, matching parseFileVars above - a `typeof import(...)` annotation here pulls the
+  // node typings in differently and reorders unrelated unions in the generated docs.
   try {
-    fs = require('fs')
-    nodePath = require('path')
-    dotenv = require('dotenv')
+    return scanForDotenvEndpoint(searchDirs)
   } catch {
     return undefined
   }
+}
+
+function scanForDotenvEndpoint(searchDirs: string[]): string | undefined {
+  const fs = require('fs')
+  const nodePath = require('path')
+  const dotenv = require('dotenv')
   const names = [...explicitDotenvPaths(), ...PRELOADABLE_DOTENV_FILES]
   const candidates: string[] = []
   for (const name of names) {

--- a/sdk-typescript/src/utils/Runtime.ts
+++ b/sdk-typescript/src/utils/Runtime.ts
@@ -156,12 +156,15 @@ export function warnIfDotenvApiUrlIgnored(reader: DaytonaEnvReader, apiUrl: stri
   for (const name of ['DAYTONA_API_URL', 'DAYTONA_SERVER_URL']) {
     const fileValue = reader.getFromFile(name)
     if (fileValue && fileValue !== apiUrl) {
+      // One report per construction: a file that sets both endpoint variables to the same
+      // redirected value does not need saying twice.
       console.warn(
         `\`${name}\` set in a .env or .env.local file was ignored: the Daytona API endpoint is` +
           ` never read from dotenv files, because the working directory is not always authored by` +
           ` you. Using \`${apiUrl}\` instead. To change the endpoint, pass \`apiUrl\` to the Daytona` +
           ` constructor or set \`${name}\` in the environment of the process.`,
       )
+      return
     }
   }
 }
@@ -202,7 +205,32 @@ export function dotenvMayBePreloaded(): boolean {
 }
 
 /**
- * The first dotenv file in the working directory that defines an endpoint variable, if any.
+ * The paths named by `--env-file` / `--env-file-if-exists`, in the order they were given.
+ *
+ * A runtime told to load a specific file does not restrict itself to the conventional names,
+ * so those paths have to be examined too. Relative paths are left as given: the runtime
+ * resolved them against the working directory and so does `fs`.
+ */
+function explicitDotenvPaths(): string[] {
+  if (typeof process === 'undefined') return []
+  const execArgv = Array.isArray(process.execArgv) ? process.execArgv : []
+  const paths: string[] = []
+  for (let i = 0; i < execArgv.length; i++) {
+    const arg = execArgv[i]
+    if (!arg.startsWith('--env-file')) continue
+    const separator = arg.indexOf('=')
+    if (separator !== -1) {
+      const value = arg.slice(separator + 1)
+      if (value) paths.push(value)
+    } else if (execArgv[i + 1] && !execArgv[i + 1].startsWith('-')) {
+      paths.push(execArgv[++i])
+    }
+  }
+  return paths
+}
+
+/**
+ * The first dotenv file that defines an endpoint variable, if any.
  *
  * This deliberately reports on the presence of the *name* and never looks at the value. A
  * value comparison cannot establish where an environment value came from: runtimes expand
@@ -213,7 +241,7 @@ export function findDotenvFileDefiningEndpoint(): string | undefined {
   if ((RUNTIME !== Runtime.NODE && RUNTIME !== Runtime.BUN) || typeof require === 'undefined') return undefined
   const fs = require('fs')
   const dotenv = require('dotenv')
-  for (const file of PRELOADABLE_DOTENV_FILES) {
+  for (const file of [...explicitDotenvPaths(), ...PRELOADABLE_DOTENV_FILES]) {
     if (!fs.existsSync(file)) continue
     let names: string[]
     try {

--- a/sdk-typescript/src/utils/Runtime.ts
+++ b/sdk-typescript/src/utils/Runtime.ts
@@ -210,8 +210,16 @@ export function dotenvMayBePreloaded(): boolean {
  * A runtime resolves its dotenv files when the process starts, so a relative `--env-file`
  * path - and the conventional names - belong to that directory. An application is free to
  * call `process.chdir()` afterwards, which would otherwise move the search away from the
- * file that actually supplied the environment. Imports run before application logic, so this
- * is the startup directory in practice.
+ * file that actually supplied the environment.
+ *
+ * Imports normally run before application logic, so this is the startup directory in
+ * practice. It is not guaranteed: an application that changes directory and only then
+ * imports this SDK - a dynamic import, for instance - leaves no way to recover the
+ * directory the runtime actually read from, since no runtime exposes its startup working
+ * directory. In that case a relative dotenv file goes unseen and a pre-loaded endpoint is
+ * trusted. Refusing every pre-loaded endpoint instead would reject the platform-supplied
+ * environment variables that Next.js deployments legitimately rely on, so the narrower
+ * exposure is preferred here and stated rather than assumed away.
  */
 const STARTUP_CWD = typeof process !== 'undefined' && typeof process.cwd === 'function' ? safeCwd() : undefined
 


### PR DESCRIPTION
## Description

The Python, Ruby and TypeScript SDKs read `.env` and `.env.local` from the current working
directory when a client is constructed, and let those files supply `DAYTONA_API_URL` /
`DAYTONA_SERVER_URL`. The working directory is not always authored by whoever runs the process,
so a file there could decide which host the API key was sent to.

The endpoint now resolves from the constructor argument, then the process environment, then the
default — never from a dotenv file. This mirrors the CLI change in dcb9964.

Every other `DAYTONA_*` variable keeps its existing dotenv precedence; only the endpoint moved.
`DAYTONA_API_URL` is documented as its default (`https://app.daytona.io/api`) and region selection
uses `DAYTONA_TARGET`, so the documented layout resolves to the same endpoint as before. A dotenv
file asking for a *different* endpoint is reported on stderr rather than dropped silently.

Go and Java are unaffected — neither loads dotenv files.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

`examples/ruby/README.md` showed `DAYTONA_API_URL` inside the recommended `.env.local` block;
updated to point at the constructor argument or the process environment instead.

## Notes

Regression tests were confirmed to fail against the previous code on the resolved endpoint —
not merely on the absence of the new stderr report:

```
Python  assert 'http://attacker.example/api' == 'https://app.daytona.io/api'
Ruby    expected: "https://app.daytona.io/api"  got: "http://attacker.example/api"
TS      Received: "http://attacker.example/api"
```

Two gaps that made this untestable before are closed:

- `sdk-ruby/spec/daytona/config_spec.rb` asserted that `.env.local` *does* set the endpoint.
- The `DaytonaEnvReader` mock in `sdk-typescript/src/__tests__/Daytona.test.ts` had no dotenv
  layer at all, so file precedence could not be exercised. It now mirrors real precedence, and
  `src/__tests__/Runtime.test.ts` covers the real reader against real files.

Suites: Python 629, Ruby 506, TypeScript 311.

One pre-existing item left alone: `prettier --check sdk-typescript/src/utils/Runtime.ts` fails on
`main` today. This PR does not reformat that region, to keep the diff to the change itself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `.env` and `.env.local` files in the working directory from setting the API endpoint in the Python, Ruby, and TypeScript SDKs. The endpoint now resolves from the constructor argument, then the process environment, then the default — never from a dotenv file.

- A dotenv endpoint that differs from the one in use is reported on stderr instead of being dropped silently.
- All other `DAYTONA_*` variables keep their existing dotenv precedence.
- Setups that relied on a dotenv file for the endpoint must move it to the constructor argument or the process environment.
- Go and Java are unaffected — neither reads dotenv files.

**TypeScript**
- On runtimes that pre-load dotenv files (Bun, Next.js, `node --env-file`), the TypeScript constructor throws if a dotenv file names the endpoint and the caller did not pass `apiUrl`, since the file could be the true source of the process value.
- The check examines paths from `--env-file` / `--env-file-if-exists` as well as the conventional dotenv names, and also searches the startup directory, since runtimes resolve dotenv files before `process.chdir()` could move the search.
- Construction no longer fails when a bundler leaves `require` defined but `fs`, `path`, or `dotenv` unresolvable; the check is skipped and the endpoint resolves as before.
- `DaytonaEnvReader` now parses dotenv files under Bun as well.

<sup>Written for commit 8419975d6645a61799c1bfafe28ba5b1e1da63a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

