### PR TITLE
fix(cli): default `ssh --expires` to the API default of 60 minutes

### DIFF
--- a/cli/cmd/sandbox/ssh.go
+++ b/cli/cmd/sandbox/ssh.go
@@ -62,5 +62,5 @@ var SSHCmd = &cobra.Command{
 var sshExpiresInMinutes int
 
 func init() {
-	SSHCmd.Flags().IntVar(&sshExpiresInMinutes, "expires", 1440, "SSH access token expiration time in minutes (defaults to 24 hours)")
+	SSHCmd.Flags().IntVar(&sshExpiresInMinutes, "expires", 60, "SSH access token expiration time in minutes")
 }

--- a/cli/docs/daytona_ssh.md
+++ b/cli/docs/daytona_ssh.md
@@ -13,7 +13,7 @@ daytona ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 ### Options
 
 ```
-      --expires int   SSH access token expiration time in minutes (defaults to 24 hours) (default 1440)
+      --expires int   SSH access token expiration time in minutes (default 60)
 ```
 
 ### Options inherited from parent commands

--- a/cli/hack/docs/daytona_ssh.yaml
+++ b/cli/hack/docs/daytona_ssh.yaml
@@ -4,9 +4,9 @@ description: Establish an SSH connection to a running sandbox
 usage: daytona ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 options:
   - name: expires
-    default_value: '1440'
+    default_value: '60'
     usage: |
-      SSH access token expiration time in minutes (defaults to 24 hours)
+      SSH access token expiration time in minutes
 inherited_options:
   - name: help
     default_value: 'false'


### PR DESCRIPTION
`daytona ssh` always sent `expiresInMinutes`, because the flag defaulted to 1440 — so the CLI overrode the API's own 60-minute default with a 24-hour one on every invocation. Nothing about the CLI path needs a longer-lived token than the dashboard path.

Aligns the flag default with the API. `--expires 1440` restores the previous behaviour.

Generated CLI docs updated for the changed default only; the rest of `cli/docs` has unrelated formatting drift against the current generator, left alone here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the default for `daytona ssh --expires` from 1440 minutes to 60 minutes, matching the API's default. Previously every invocation overrode the API's 60-minute default with a 24-hour token; now the CLI uses the API default unless `--expires` is explicitly set. To keep the old behavior, pass `--expires 1440`.

<sup>Written for commit 7b650346577e272fde36fe68bd4fe96e77be19a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

