### PR TITLE
fix(sdk-ruby): parse .env files without shell command substitution

### DIFF
--- a/sdk-ruby/lib/daytona/config.rb
+++ b/sdk-ruby/lib/daytona/config.rb
@@ -6,6 +6,24 @@
 require 'dotenv'
 
 module Daytona
+  # Dotenv runs `$(...)` in a value through the shell while parsing, and the working
+  # directory is frequently a cloned repository, so parsing `.env` there would execute
+  # whatever its author put in it. Dotenv::Parser picks its substitutions up from
+  # `self.class.substitutions`, and Ruby does not inherit class-level instance variables,
+  # so declaring the list here drops command substitution while leaving Dotenv::Parser
+  # alone — a host application's own Dotenv.load keeps the behaviour its author chose.
+  # `${VAR}` is kept: it reads only keys already parsed or the process environment.
+  class DotenvParser < Dotenv::Parser
+    @substitutions = [Dotenv::Substitutions::Variable].freeze
+
+    # This reaches into dotenv's internals rather than a public API, and dotenv has already
+    # reorganised them once inside the range the gemspec allows. Prove the suppression holds
+    # in the process that will rely on it, rather than trusting the version we pin in CI.
+    probe = call('DAYTONA_PROBE=$(echo substituted)')['DAYTONA_PROBE']
+    raise "dotenv command substitution is not suppressed (got #{probe.inspect})" unless
+      probe == '$(echo substituted)'
+  end
+
   class Config
     API_URL = 'https://app.daytona.io/api'
 
@@ -131,10 +149,18 @@ module Daytona
     def parse_dotenv_files
       file_vars = {}
       env_file = File.join(Dir.pwd, '.env')
-      file_vars.merge!(daytona_filter(Dotenv.parse(env_file))) if File.exist?(env_file)
+      file_vars.merge!(daytona_filter(parse_env_file(env_file))) if File.exist?(env_file)
       env_local_file = File.join(Dir.pwd, '.env.local')
-      file_vars.merge!(daytona_filter(Dotenv.parse(env_local_file))) if File.exist?(env_local_file)
+      file_vars.merge!(daytona_filter(parse_env_file(env_local_file))) if File.exist?(env_local_file)
       file_vars
+    end
+
+    # Read with the mode dotenv itself uses, so the accepted format does not narrow: `bom`
+    # skips a byte-order mark an editor on Windows may have written, and pinning `utf-8`
+    # keeps the file readable under a POSIX locale, where the default external encoding
+    # would make one accented byte anywhere — a comment included — raise while it is scanned.
+    def parse_env_file(path)
+      DotenvParser.call(File.read(path, mode: 'rb:bom|utf-8'))
     end
 
     # Returns a lambda that looks up DAYTONA_-prefixed env vars without writing to ENV.

--- a/sdk-ruby/lib/daytona/config.rb
+++ b/sdk-ruby/lib/daytona/config.rb
@@ -8,20 +8,41 @@ require 'dotenv'
 module Daytona
   # Dotenv runs `$(...)` in a value through the shell while parsing, and the working
   # directory is frequently a cloned repository, so parsing `.env` there would execute
-  # whatever its author put in it. Dotenv::Parser picks its substitutions up from
-  # `self.class.substitutions`, and Ruby does not inherit class-level instance variables,
-  # so declaring the list here drops command substitution while leaving Dotenv::Parser
-  # alone — a host application's own Dotenv.load keeps the behaviour its author chose.
-  # `${VAR}` is kept: it reads only keys already parsed or the process environment.
-  class DotenvParser < Dotenv::Parser
-    @substitutions = [Dotenv::Substitutions::Variable].freeze
+  # whatever its author put in it.
+  module EnvFile
+    # Dotenv::Parser picks its substitutions up from `self.class.substitutions`, and Ruby
+    # does not inherit class-level instance variables, so declaring the list here drops
+    # command substitution while leaving Dotenv::Parser alone — a host application's own
+    # Dotenv.load keeps the behaviour its author chose. `${VAR}` is kept: it reads only
+    # keys already parsed or the process environment.
+    class Parser < Dotenv::Parser
+      @substitutions = [Dotenv::Substitutions::Variable].freeze
+    end
 
-    # This reaches into dotenv's internals rather than a public API, and dotenv has already
-    # reorganised them once inside the range the gemspec allows. Prove the suppression holds
-    # in the process that will rely on it, rather than trusting the version we pin in CI.
-    probe = call('DAYTONA_PROBE=$(echo substituted)')['DAYTONA_PROBE']
-    raise "dotenv command substitution is not suppressed (got #{probe.inspect})" unless
-      probe == '$(echo substituted)'
+    # Read with the mode dotenv itself uses, so the accepted format does not narrow: `bom`
+    # skips a byte-order mark an editor on Windows may have written, and pinning `utf-8`
+    # keeps the file readable under a POSIX locale, where the default external encoding
+    # would make one accented byte anywhere — a comment included — raise while it is scanned.
+    def self.parse(path)
+      verify_suppression!
+      Parser.call(File.read(path, mode: 'rb:bom|utf-8'))
+    end
+
+    # The subclass reaches into dotenv's internals rather than a public API, and dotenv has
+    # already reorganised them once inside the range the gemspec allows, so confirm the
+    # suppression actually holds in the process that relies on it rather than trusting the
+    # version pinned in CI. Checked here rather than on load: this is the operation the
+    # guard protects, so a lapse stops it, and a gem that never reads a .env still loads.
+    # A failure is not memoised, so it is raised again on the next attempt.
+    def self.verify_suppression!
+      return if @verified
+
+      probe = Parser.call('DAYTONA_PROBE=$(echo substituted)')['DAYTONA_PROBE']
+      raise "dotenv command substitution is not suppressed (got #{probe.inspect})" unless
+        probe == '$(echo substituted)'
+
+      @verified = true
+    end
   end
 
   class Config
@@ -149,18 +170,10 @@ module Daytona
     def parse_dotenv_files
       file_vars = {}
       env_file = File.join(Dir.pwd, '.env')
-      file_vars.merge!(daytona_filter(parse_env_file(env_file))) if File.exist?(env_file)
+      file_vars.merge!(daytona_filter(EnvFile.parse(env_file))) if File.exist?(env_file)
       env_local_file = File.join(Dir.pwd, '.env.local')
-      file_vars.merge!(daytona_filter(parse_env_file(env_local_file))) if File.exist?(env_local_file)
+      file_vars.merge!(daytona_filter(EnvFile.parse(env_local_file))) if File.exist?(env_local_file)
       file_vars
-    end
-
-    # Read with the mode dotenv itself uses, so the accepted format does not narrow: `bom`
-    # skips a byte-order mark an editor on Windows may have written, and pinning `utf-8`
-    # keeps the file readable under a POSIX locale, where the default external encoding
-    # would make one accented byte anywhere — a comment included — raise while it is scanned.
-    def parse_env_file(path)
-      DotenvParser.call(File.read(path, mode: 'rb:bom|utf-8'))
     end
 
     # Returns a lambda that looks up DAYTONA_-prefixed env vars without writing to ENV.

--- a/sdk-ruby/spec/daytona/config_spec.rb
+++ b/sdk-ruby/spec/daytona/config_spec.rb
@@ -242,4 +242,36 @@ RSpec.describe Daytona::Config do
       expect(stderr).to eq('')
     end
   end
+  # Separate from endpoint trust: pinning where the credential goes does nothing about a
+  # file whose contents run while being read.
+  describe 'dotenv files are not executed', :real_dotenv do
+    around do |example|
+      Dir.mktmpdir { |dir| Dir.chdir(dir) { example.run } }
+    end
+
+    # A client configured entirely in code needs nothing from the file, and still parses it.
+    it 'does not execute a hostile .env' do
+      File.write('.env', "DAYTONA_UNUSED=$(touch marker-ran)\n")
+
+      described_class.new(api_key: 'k', api_url: 'https://chosen.example/api', target: 'us')
+
+      expect(File.exist?('marker-ran')).to be(false)
+    end
+
+    it 'does not execute a hostile .env.local' do
+      File.write('.env.local', "DAYTONA_UNUSED=$(touch marker-ran)\n")
+
+      described_class.new(api_key: 'k', api_url: 'https://chosen.example/api', target: 'us')
+
+      expect(File.exist?('marker-ran')).to be(false)
+    end
+
+    # Guards the read mode: without it a byte-order mark swallows the first key, so a .env
+    # written on Windows would silently lose the credential.
+    it 'reads a file that starts with a byte-order mark' do
+      File.binwrite('.env', "\xEF\xBB\xBFDAYTONA_API_KEY=bom-key\n")
+
+      expect(described_class.new.api_key).to eq('bom-key')
+    end
+  end
 end

--- a/sdk-ruby/spec/spec_helper.rb
+++ b/sdk-ruby/spec/spec_helper.rb
@@ -45,7 +45,7 @@ RSpec.configure do |config|
   ].freeze
 
   config.before do |example|
-    allow(Daytona::DotenvParser).to receive(:call).and_return({}) unless example.metadata[:real_dotenv]
+    allow(Daytona::EnvFile).to receive(:parse).and_return({}) unless example.metadata[:real_dotenv]
   end
 
   config.around do |example|

--- a/sdk-ruby/spec/spec_helper.rb
+++ b/sdk-ruby/spec/spec_helper.rb
@@ -28,7 +28,7 @@ RSpec.configure do |config|
   end
 
   # Auth/url resolution must be deterministic in tests, so:
-  #   1. Stub Dotenv.parse so .env / .env.local files are never consulted.
+  #   1. Stub the dotenv read so .env / .env.local files are never consulted.
   #   2. Snapshot and clear DAYTONA_* ENV vars around each example, so the
   #      developer's shell or local-service env can't leak into a unit test
   #      that asserts on the absence of credentials.
@@ -45,7 +45,7 @@ RSpec.configure do |config|
   ].freeze
 
   config.before do |example|
-    allow(Dotenv).to receive(:parse).and_return({}) unless example.metadata[:real_dotenv]
+    allow(Daytona::DotenvParser).to receive(:call).and_return({}) unless example.metadata[:real_dotenv]
   end
 
   config.around do |example|


### PR DESCRIPTION
`Daytona::Config#initialize` reads `.env` and `.env.local` from `Dir.pwd` on every construction. `Dotenv.parse` expands `$(...)` in a value by running it through the shell, so a value in a file the caller did not author took effect while the file was being read.

Both reads now go through `Daytona::DotenvParser`, a `Dotenv::Parser` subclass that declares its own substitution list and omits the command substitution. Ruby does not inherit class-level instance variables, so `Dotenv::Parser` itself is untouched — a host application's own `Dotenv.load` keeps the behaviour its author chose.

The rest of the format is inherited unchanged: quoting, escapes, newline expansion, the `export` prefix, comments, and `${VAR}`, which reads only keys already parsed from the same file or the process environment. The file is read with the same `rb:bom|utf-8` mode dotenv uses, so a byte-order mark still parses and a non-ASCII byte does not raise under a POSIX locale.

The subclass depends on parser internals rather than a public API, and dotenv has already reorganised that area within the range the gemspec allows (`>= 2.0, < 4`). It therefore asserts on load that the suppression actually holds, so the check runs in the process that depends on it rather than only against the version pinned here. Mechanism verified against dotenv 2.0.0, 2.7.6, 2.8.1, 3.0.0, 3.1.8 and 3.2.0.

Three specs cover it: a `.env` and a `.env.local` whose value would run, and a file beginning with a byte-order mark. Each fails without the change.

Note for review: this changes how a value resolves — `DAYTONA_TARGET=$(cat .region)` was previously the command's output and is now the literal string. I have not marked the commit as breaking, on the grounds that the prior behaviour was a defect rather than an interface, but that is worth agreeing before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sdk-ruby's `.env`/`.env.local` parsing so values are no longer passed to the shell. Previously, `$(...)` in a value was executed; now it's treated as a literal string.

- Parsing goes through a `Dotenv::Parser` subclass that omits command substitution while preserving the rest of dotenv's format (quoting, escapes, `${VAR}`, etc.).
- Files are read with the same `rb:bom|utf-8` mode as dotenv, so BOM and non-ASCII behavior are unchanged.
- A runtime check on the parse path raises if command substitution is ever suppressed, stopping only the `.env` feature rather than gem load.

**Review note:** This changes how a value resolves (e.g., `DAYTONA_TARGET=$(cat .region)` becomes the literal string). It's not marked as breaking because it fixes a defect, but that decision should be confirmed before merge.

<sup>Written for commit febbdf3a6f62dd73cde1d338c46ceddc23d8734d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

