### PR TITLE
feat(sdk-java): add Image.addLocalFile and addLocalDir with build-context uploads

### DIFF
--- a/artifacts/sdk-docs/java-sdk/image.mdx
+++ b/artifacts/sdk-docs/java-sdk/image.mdx
@@ -146,7 +146,7 @@ Adds a local file to the image.
 The file is uploaded to Daytona object storage as part of the build context when the image
 is used to create a snapshot or a Sandbox, and copied to `remotePath` with a
 `COPY` instruction. If `remotePath` ends with `/`, the local file name is
-appended to it.
+appended to it. Symlinks in `localPath` are resolved before the file is recorded.
 ```java
 Image image = Image.debianSlim("3.12")
 .addLocalFile("requirements.txt", "/home/daytona/requirements.txt");
@@ -175,7 +175,8 @@ Adds a local directory to the image.
 
 The directory is uploaded to Daytona object storage as part of the build context when the
 image is used to create a snapshot or a Sandbox, and copied to `remotePath` with a
-`COPY` instruction.
+`COPY` instruction. Symlinks in `localPath` itself are resolved; symlinks inside
+the directory are preserved as symlinks in the build context.
 ```java
 Image image = Image.debianSlim("3.12").addLocalDir("src", "/home/daytona/src");
 ```
@@ -192,7 +193,7 @@ Image image = Image.debianSlim("3.12").addLocalDir("src", "/home/daytona/src");
 **Throws**:
 
 - `DaytonaNotFoundException` - if `localPath` does not exist
-- `IllegalArgumentException` - if `localPath` exists but is not a directory
+- `IllegalArgumentException` - if `localPath` exists but is not a directory, or is a filesystem root
 
 #### getDockerfile()
 ```java

--- a/artifacts/sdk-docs/java-sdk/image.mdx
+++ b/artifacts/sdk-docs/java-sdk/image.mdx
@@ -10,6 +10,10 @@ Declarative image builder used to define Sandbox runtime environments.
 Use factory methods such as `#base(String)` or `#debianSlim(String)` and chain
 mutating methods to append Dockerfile instructions.
 
+Local files and directories added with `#addLocalFile(String, String)` and
+`#addLocalDir(String, String)` are uploaded to Daytona object storage as build contexts
+when the image is used to create a snapshot or a Sandbox.
+
 ### Methods
 
 #### base()
@@ -132,6 +136,64 @@ Sets the default container command.
 
 - `Image` - this `Image` for method chaining
 
+#### addLocalFile()
+```java
+public Image addLocalFile(String localPath, String remotePath)
+```
+
+Adds a local file to the image.
+
+The file is uploaded to Daytona object storage as part of the build context when the image
+is used to create a snapshot or a Sandbox, and copied to `remotePath` with a
+`COPY` instruction. If `remotePath` ends with `/`, the local file name is
+appended to it.
+```java
+Image image = Image.debianSlim("3.12")
+.addLocalFile("requirements.txt", "/home/daytona/requirements.txt");
+```
+
+**Parameters**:
+
+- `localPath` _String_ - path to the local file; a leading `~` is expanded to the user home
+- `remotePath` _String_ - destination path inside the image
+
+**Returns**:
+
+- `Image` - this `Image` for method chaining
+
+**Throws**:
+
+- `DaytonaNotFoundException` - if `localPath` does not exist
+- `IllegalArgumentException` - if `localPath` exists but is not a regular file
+
+#### addLocalDir()
+```java
+public Image addLocalDir(String localPath, String remotePath)
+```
+
+Adds a local directory to the image.
+
+The directory is uploaded to Daytona object storage as part of the build context when the
+image is used to create a snapshot or a Sandbox, and copied to `remotePath` with a
+`COPY` instruction.
+```java
+Image image = Image.debianSlim("3.12").addLocalDir("src", "/home/daytona/src");
+```
+
+**Parameters**:
+
+- `localPath` _String_ - path to the local directory; a leading `~` is expanded to the user home
+- `remotePath` _String_ - destination path inside the image
+
+**Returns**:
+
+- `Image` - this `Image` for method chaining
+
+**Throws**:
+
+- `DaytonaNotFoundException` - if `localPath` does not exist
+- `IllegalArgumentException` - if `localPath` exists but is not a directory
+
 #### getDockerfile()
 ```java
 public String getDockerfile()
@@ -142,3 +204,15 @@ Returns generated Dockerfile content.
 **Returns**:
 
 - `String` - Dockerfile text assembled by this builder
+
+#### getContexts()
+```java
+public List<Context> getContexts()
+```
+
+Returns the local build contexts registered with `#addLocalFile(String, String)` and
+`#addLocalDir(String, String)`, in insertion order.
+
+**Returns**:
+
+- `List\<Context\>` - unmodifiable list of build contexts

--- a/examples/java/declarative-image/file_example.txt
+++ b/examples/java/declarative-image/file_example.txt
@@ -1,0 +1,1 @@
+Hello, World!

--- a/examples/java/declarative-image/file_example.txt
+++ b/examples/java/declarative-image/file_example.txt
@@ -1,1 +1,0 @@
-Hello, World!

--- a/examples/java/declarative-image/src/main/java/io/daytona/examples/DeclarativeImage.java
+++ b/examples/java/declarative-image/src/main/java/io/daytona/examples/DeclarativeImage.java
@@ -10,11 +10,18 @@ import io.daytona.sdk.model.CreateSandboxFromImageParams;
 import io.daytona.sdk.model.CreateSandboxFromSnapshotParams;
 import io.daytona.sdk.model.ExecuteResponse;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
 public class DeclarativeImage {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
+        Path localFile = Path.of("file_example.txt");
+        Files.write(localFile, "Hello, World!".getBytes(StandardCharsets.UTF_8));
+
         try (Daytona daytona = new Daytona()) {
             String snapshotName = "java-example-" + System.currentTimeMillis();
             System.out.println("Creating snapshot: " + snapshotName);
@@ -26,7 +33,8 @@ public class DeclarativeImage {
                     .pipInstall("numpy", "pandas", "matplotlib", "scipy", "scikit-learn")
                     .runCommands("apt-get update && apt-get install -y git", "mkdir -p /home/daytona/workspace")
                     .workdir("/home/daytona/workspace")
-                    .env(envVars);
+                    .env(envVars)
+                    .addLocalFile(localFile.toString(), "/home/daytona/workspace/file_example.txt");
 
             System.out.println("\n=== Creating Snapshot: " + snapshotName + " ===");
             daytona.snapshot().create(snapshotName, image, System.out::println);
@@ -44,6 +52,9 @@ public class DeclarativeImage {
 
                 ExecuteResponse envResult = sandbox1.process.executeCommand("echo $MY_ENV_VAR");
                 System.out.println("MY_ENV_VAR=" + envResult.getResult().trim());
+
+                ExecuteResponse fileResult = sandbox1.process.executeCommand("cat file_example.txt");
+                System.out.println("file_example.txt: " + fileResult.getResult().trim());
             } finally {
                 sandbox1.delete();
             }

--- a/examples/java/declarative-image/src/main/java/io/daytona/examples/DeclarativeImage.java
+++ b/examples/java/declarative-image/src/main/java/io/daytona/examples/DeclarativeImage.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 public class DeclarativeImage {
     public static void main(String[] args) throws IOException {
-        Path localFile = Path.of("file_example.txt");
+        Path localFile = Files.createTempFile("file_example-", ".txt");
         Files.write(localFile, "Hello, World!".getBytes(StandardCharsets.UTF_8));
 
         try (Daytona daytona = new Daytona()) {
@@ -79,6 +79,8 @@ public class DeclarativeImage {
             } finally {
                 sandbox2.delete();
             }
+        } finally {
+            Files.deleteIfExists(localFile);
         }
     }
 }

--- a/sdk-java/build.gradle.kts
+++ b/sdk-java/build.gradle.kts
@@ -29,6 +29,14 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-databind:2.17.2")
     api("com.fasterxml.jackson.core:jackson-annotations:2.17.2")
     implementation("io.socket:socket.io-client:2.1.2")
+    // Build-context uploads for Image.addLocalFile / addLocalDir. The default AWS HTTP clients
+    // (Apache, Netty) are excluded in favour of the lightweight url-connection-client.
+    implementation("software.amazon.awssdk:s3:2.54.16") {
+        exclude(group = "software.amazon.awssdk", module = "apache-client")
+        exclude(group = "software.amazon.awssdk", module = "netty-nio-client")
+    }
+    implementation("software.amazon.awssdk:url-connection-client:2.54.16")
+    implementation("org.apache.commons:commons-compress:1.28.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
     testImplementation("org.assertj:assertj-core:3.26.3")

--- a/sdk-java/src/main/java/io/daytona/sdk/Daytona.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Daytona.java
@@ -50,6 +50,7 @@ public class Daytona implements AutoCloseable {
 
     private final DaytonaConfig config;
     private final io.daytona.api.client.ApiClient apiClient;
+    private final io.daytona.api.client.api.ObjectStorageApi objectStorageApi;
     private final SandboxApi sandboxApi;
     private final SnapshotService snapshot;
     private final VolumeService volume;
@@ -91,7 +92,9 @@ public class Daytona implements AutoCloseable {
         this.config = config;
         this.apiClient = createMainApiClient(config);
         this.sandboxApi = new SandboxApi(apiClient);
-        this.snapshot = new SnapshotService(new io.daytona.api.client.api.SnapshotsApi(apiClient), apiClient.getHttpClient(), config.getApiKey());
+        this.objectStorageApi = new io.daytona.api.client.api.ObjectStorageApi(apiClient);
+        this.snapshot = new SnapshotService(new io.daytona.api.client.api.SnapshotsApi(apiClient), apiClient.getHttpClient(), config.getApiKey(),
+                image -> ObjectStorage.processImageContext(objectStorageApi, image));
         this.volume = new VolumeService(new io.daytona.api.client.api.VolumesApi(apiClient));
         this.secret = new SecretService(new io.daytona.api.client.api.SecretApi(apiClient));
         this.warmPool = new WarmPoolService(new io.daytona.api.client.api.WarmPoolsApi(apiClient));
@@ -197,7 +200,9 @@ public class Daytona implements AutoCloseable {
         if (params != null) {
             Object image = params.getImage();
             if (image instanceof Image) {
-                body.setBuildInfo(new CreateBuildInfo().dockerfileContent(((Image) image).getDockerfile()));
+                Image declarativeImage = (Image) image;
+                List<String> contextHashes = ObjectStorage.processImageContext(objectStorageApi, declarativeImage);
+                body.setBuildInfo(new CreateBuildInfo().dockerfileContent(declarativeImage.getDockerfile()).contextHashes(contextHashes));
             } else if (image instanceof String && !((String) image).isEmpty()) {
                 body.setBuildInfo(new CreateBuildInfo().dockerfileContent("FROM " + image + "\n"));
             }

--- a/sdk-java/src/main/java/io/daytona/sdk/Image.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Image.java
@@ -299,9 +299,32 @@ public class Image {
         StringJoiner joiner = new StringJoiner(",", "[", "]");
         if (values != null) {
             for (String v : values) {
-                joiner.add("\"" + v.replace("\\", "\\\\").replace("\"", "\\\"") + "\"");
+                joiner.add(jsonString(v));
             }
         }
         return joiner.toString();
+    }
+
+    private static String jsonString(String value) {
+        StringBuilder sb = new StringBuilder(value.length() + 2).append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"': sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\b': sb.append("\\b"); break;
+                case '\f': sb.append("\\f"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.append('"').toString();
     }
 }

--- a/sdk-java/src/main/java/io/daytona/sdk/Image.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Image.java
@@ -3,7 +3,16 @@
 
 package io.daytona.sdk;
 
+import io.daytona.sdk.exception.DaytonaNotFoundException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.StringJoiner;
 
 /**
@@ -11,9 +20,67 @@ import java.util.StringJoiner;
  *
  * <p>Use factory methods such as {@link #base(String)} or {@link #debianSlim(String)} and chain
  * mutating methods to append Dockerfile instructions.
+ *
+ * <p>Local files and directories added with {@link #addLocalFile(String, String)} and
+ * {@link #addLocalDir(String, String)} are uploaded to Daytona object storage as build contexts
+ * when the image is used to create a snapshot or a Sandbox.
  */
 public class Image {
+    /**
+     * A local file or directory that is part of the image build context.
+     *
+     * <p>The source path is uploaded to object storage and made available inside the build context
+     * under {@link #getArchivePath()}, which is the path referenced by the generated {@code COPY}
+     * instruction.
+     */
+    public static final class Context {
+        private final String sourcePath;
+        private final String archivePath;
+
+        Context(String sourcePath, String archivePath) {
+            this.sourcePath = sourcePath;
+            this.archivePath = archivePath;
+        }
+
+        /**
+         * Returns the local filesystem path of the file or directory.
+         *
+         * @return absolute local path
+         */
+        public String getSourcePath() {
+            return sourcePath;
+        }
+
+        /**
+         * Returns the path of the entry within the uploaded build context archive.
+         *
+         * @return archive-relative path
+         */
+        public String getArchivePath() {
+            return archivePath;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Context)) return false;
+            Context other = (Context) o;
+            return sourcePath.equals(other.sourcePath) && archivePath.equals(other.archivePath);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(sourcePath, archivePath);
+        }
+
+        @Override
+        public String toString() {
+            return "Context{sourcePath='" + sourcePath + "', archivePath='" + archivePath + "'}";
+        }
+    }
+
     private final StringBuilder dockerfile = new StringBuilder();
+    private final List<Context> contexts = new ArrayList<>();
 
     private Image() {}
 
@@ -124,12 +191,100 @@ public class Image {
     }
 
     /**
+     * Adds a local file to the image.
+     *
+     * <p>The file is uploaded to Daytona object storage as part of the build context when the image
+     * is used to create a snapshot or a Sandbox, and copied to {@code remotePath} with a
+     * {@code COPY} instruction. If {@code remotePath} ends with {@code /}, the local file name is
+     * appended to it.
+     *
+     * <pre>{@code
+     * Image image = Image.debianSlim("3.12")
+     *     .addLocalFile("requirements.txt", "/home/daytona/requirements.txt");
+     * }</pre>
+     *
+     * @param localPath path to the local file; a leading {@code ~} is expanded to the user home
+     * @param remotePath destination path inside the image
+     * @return this {@link Image} for method chaining
+     * @throws DaytonaNotFoundException if {@code localPath} does not exist
+     * @throws IllegalArgumentException if {@code localPath} exists but is not a regular file
+     */
+    public Image addLocalFile(String localPath, String remotePath) {
+        Path expanded = expandUserHome(localPath);
+        if (!Files.exists(expanded)) {
+            throw new DaytonaNotFoundException("Local file " + localPath + " does not exist");
+        }
+        if (!Files.isRegularFile(expanded)) {
+            throw new IllegalArgumentException("Local path " + localPath + " exists but is not a file");
+        }
+        String destination = remotePath;
+        if (destination.endsWith("/")) {
+            destination = destination + expanded.getFileName();
+        }
+        return addContext(expanded, destination);
+    }
+
+    /**
+     * Adds a local directory to the image.
+     *
+     * <p>The directory is uploaded to Daytona object storage as part of the build context when the
+     * image is used to create a snapshot or a Sandbox, and copied to {@code remotePath} with a
+     * {@code COPY} instruction.
+     *
+     * <pre>{@code
+     * Image image = Image.debianSlim("3.12").addLocalDir("src", "/home/daytona/src");
+     * }</pre>
+     *
+     * @param localPath path to the local directory; a leading {@code ~} is expanded to the user home
+     * @param remotePath destination path inside the image
+     * @return this {@link Image} for method chaining
+     * @throws DaytonaNotFoundException if {@code localPath} does not exist
+     * @throws IllegalArgumentException if {@code localPath} exists but is not a directory
+     */
+    public Image addLocalDir(String localPath, String remotePath) {
+        Path expanded = expandUserHome(localPath);
+        if (!Files.exists(expanded)) {
+            throw new DaytonaNotFoundException("Local directory " + localPath + " does not exist");
+        }
+        if (!Files.isDirectory(expanded)) {
+            throw new IllegalArgumentException("Local path " + localPath + " exists but is not a directory");
+        }
+        return addContext(expanded, remotePath);
+    }
+
+    private Image addContext(Path source, String remotePath) {
+        Path absolute = source.toAbsolutePath().normalize();
+        String archivePath = ObjectStorage.computeArchiveBasePath(absolute);
+        contexts.add(new Context(absolute.toString(), archivePath));
+        dockerfile.append("COPY ").append(archivePath).append(" ").append(remotePath).append("\n");
+        return this;
+    }
+
+    private static Path expandUserHome(String path) {
+        Objects.requireNonNull(path, "localPath");
+        if (path.equals("~") || path.startsWith("~/") || path.startsWith("~\\")) {
+            return Paths.get(System.getProperty("user.home"), path.substring(1));
+        }
+        return Paths.get(path);
+    }
+
+    /**
      * Returns generated Dockerfile content.
      *
      * @return Dockerfile text assembled by this builder
      */
     public String getDockerfile() {
         return dockerfile.toString();
+    }
+
+    /**
+     * Returns the local build contexts registered with {@link #addLocalFile(String, String)} and
+     * {@link #addLocalDir(String, String)}, in insertion order.
+     *
+     * @return unmodifiable list of build contexts
+     */
+    public List<Context> getContexts() {
+        return Collections.unmodifiableList(contexts);
     }
 
     private String jsonArray(String... values) {

--- a/sdk-java/src/main/java/io/daytona/sdk/Image.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/Image.java
@@ -5,6 +5,7 @@ package io.daytona.sdk;
 
 import io.daytona.sdk.exception.DaytonaNotFoundException;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -196,7 +197,7 @@ public class Image {
      * <p>The file is uploaded to Daytona object storage as part of the build context when the image
      * is used to create a snapshot or a Sandbox, and copied to {@code remotePath} with a
      * {@code COPY} instruction. If {@code remotePath} ends with {@code /}, the local file name is
-     * appended to it.
+     * appended to it. Symlinks in {@code localPath} are resolved before the file is recorded.
      *
      * <pre>{@code
      * Image image = Image.debianSlim("3.12")
@@ -229,7 +230,8 @@ public class Image {
      *
      * <p>The directory is uploaded to Daytona object storage as part of the build context when the
      * image is used to create a snapshot or a Sandbox, and copied to {@code remotePath} with a
-     * {@code COPY} instruction.
+     * {@code COPY} instruction. Symlinks in {@code localPath} itself are resolved; symlinks inside
+     * the directory are preserved as symlinks in the build context.
      *
      * <pre>{@code
      * Image image = Image.debianSlim("3.12").addLocalDir("src", "/home/daytona/src");
@@ -239,7 +241,8 @@ public class Image {
      * @param remotePath destination path inside the image
      * @return this {@link Image} for method chaining
      * @throws DaytonaNotFoundException if {@code localPath} does not exist
-     * @throws IllegalArgumentException if {@code localPath} exists but is not a directory
+     * @throws IllegalArgumentException if {@code localPath} exists but is not a directory, or is a
+     *     filesystem root
      */
     public Image addLocalDir(String localPath, String remotePath) {
         Path expanded = expandUserHome(localPath);
@@ -253,10 +256,15 @@ public class Image {
     }
 
     private Image addContext(Path source, String remotePath) {
-        Path absolute = source.toAbsolutePath().normalize();
-        String archivePath = ObjectStorage.computeArchiveBasePath(absolute);
-        contexts.add(new Context(absolute.toString(), archivePath));
-        dockerfile.append("COPY ").append(archivePath).append(" ").append(remotePath).append("\n");
+        Path resolved;
+        try {
+            resolved = source.toRealPath();
+        } catch (IOException e) {
+            throw new DaytonaNotFoundException("Local path " + source + " could not be resolved: " + e.getMessage(), e);
+        }
+        String archivePath = ObjectStorage.computeArchiveBasePath(resolved);
+        contexts.add(new Context(resolved.toString(), archivePath));
+        dockerfile.append("COPY ").append(jsonArray(archivePath, remotePath)).append("\n");
         return this;
     }
 
@@ -291,7 +299,7 @@ public class Image {
         StringJoiner joiner = new StringJoiner(",", "[", "]");
         if (values != null) {
             for (String v : values) {
-                joiner.add("\"" + v.replace("\"", "\\\"") + "\"");
+                joiner.add("\"" + v.replace("\\", "\\\\").replace("\"", "\\\"") + "\"");
             }
         }
         return joiner.toString();

--- a/sdk-java/src/main/java/io/daytona/sdk/ObjectStorage.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/ObjectStorage.java
@@ -8,11 +8,13 @@ import io.daytona.api.client.model.StorageAccessDto;
 import io.daytona.sdk.exception.DaytonaException;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarConstants;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
@@ -28,8 +30,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
@@ -44,9 +46,10 @@ import java.util.stream.Stream;
 /**
  * Uploads {@link Image} build contexts (local files and directories) to Daytona object storage.
  *
- * <p>Each context is packed into a tar archive and stored under
- * {@code {organizationId}/{contentHash}/context.tar}. The content hash doubles as the identifier the
- * API expects in {@code contextHashes}; contexts whose archive already exists are not re-uploaded.
+ * <p>Each context is packed into a deterministic tar archive (sorted entries, fixed timestamps,
+ * symlinks preserved) and stored under {@code {organizationId}/{contentHash}/context.tar}, where the
+ * content hash is the MD5 of the exact archive bytes. The hash doubles as the identifier the API
+ * expects in {@code contextHashes}; contexts whose archive already exists are not re-uploaded.
  *
  * <p>Used internally by {@link SnapshotService} and {@link Daytona} when an {@link Image} carries
  * contexts added via {@link Image#addLocalFile(String, String)} or
@@ -137,19 +140,27 @@ final class ObjectStorage implements AutoCloseable {
      * @param path local file or directory
      * @param organizationId organization that owns the storage prefix
      * @param archiveBasePath name of the entry (or root directory) inside the archive
-     * @return MD5 content hash identifying the uploaded context
+     * @return MD5 hash of the uploaded archive, identifying the context
      * @throws DaytonaException if the path does not exist or the upload fails
      */
     String upload(Path path, String organizationId, String archiveBasePath) {
-        if (!Files.exists(path)) {
+        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
             throw new DaytonaException("Path does not exist: " + path);
         }
-        String hash = computeHash(path, archiveBasePath);
-        String key = organizationId + "/" + hash + "/" + CONTEXT_ARCHIVE_NAME;
-        if (!objectExists(key)) {
-            uploadAsTar(key, path, archiveBasePath);
+        Path archive = null;
+        try {
+            archive = createArchive(path, archiveBasePath);
+            String hash = md5Hex(archive);
+            String key = organizationId + "/" + hash + "/" + CONTEXT_ARCHIVE_NAME;
+            if (!objectExists(key)) {
+                putArchive(key, archive);
+            }
+            return hash;
+        } catch (IOException e) {
+            throw new DaytonaException("Failed to create build context archive for " + path + ": " + e.getMessage(), e);
+        } finally {
+            deleteQuietly(archive);
         }
-        return hash;
     }
 
     /**
@@ -159,6 +170,7 @@ final class ObjectStorage implements AutoCloseable {
      *
      * @param path local path
      * @return archive base path, never empty
+     * @throws IllegalArgumentException if {@code path} is a filesystem root
      */
     static String computeArchiveBasePath(Path path) {
         Path absolute = path.toAbsolutePath().normalize();
@@ -168,42 +180,10 @@ final class ObjectStorage implements AutoCloseable {
         while (archivePath.startsWith("/")) {
             archivePath = archivePath.substring(1);
         }
-        return archivePath.isEmpty() ? absolute.getFileName().toString() : archivePath;
-    }
-
-    /**
-     * Computes the MD5 hash of a file or directory tree together with its archive base path.
-     *
-     * <p>For directories, entries are visited in lexicographic order so the hash is stable across
-     * runs and platforms. Each file contributes its archive-relative path and contents; empty
-     * directories contribute their relative path only.
-     */
-    static String computeHash(Path path, String archiveBasePath) {
-        MessageDigest md5 = newMd5();
-        md5.update(archiveBasePath.getBytes(StandardCharsets.UTF_8));
-        try {
-            if (Files.isDirectory(path)) {
-                for (Path entry : sortedTree(path)) {
-                    if (entry.equals(path)) {
-                        continue;
-                    }
-                    String relative = toArchiveRelative(path, entry);
-                    if (Files.isDirectory(entry)) {
-                        if (isEmptyDirectory(entry)) {
-                            md5.update(relative.getBytes(StandardCharsets.UTF_8));
-                        }
-                        continue;
-                    }
-                    md5.update(relative.getBytes(StandardCharsets.UTF_8));
-                    digestFile(md5, entry);
-                }
-            } else {
-                digestFile(md5, path);
-            }
-        } catch (IOException e) {
-            throw new DaytonaException("Failed to hash " + path + ": " + e.getMessage(), e);
+        if (archivePath.isEmpty()) {
+            throw new IllegalArgumentException("A filesystem root cannot be used as a build context: " + path);
         }
-        return toHex(md5.digest());
+        return archivePath;
     }
 
     private boolean objectExists(String key) {
@@ -217,40 +197,49 @@ final class ObjectStorage implements AutoCloseable {
                 return false;
             }
             throw new DaytonaException("Failed to check object storage for " + key + ": " + e.getMessage(), e);
+        } catch (SdkException e) {
+            throw new DaytonaException("Failed to check object storage for " + key + ": " + e.getMessage(), e);
         }
     }
 
-    private void uploadAsTar(String key, Path source, String archiveBasePath) {
-        Path archive = null;
+    private static Path createArchive(Path source, String archiveBasePath) throws IOException {
+        Path archive = Files.createTempFile("daytona-context-", ".tar");
+        try (OutputStream out = Files.newOutputStream(archive);
+             TarArchiveOutputStream tar = new TarArchiveOutputStream(out)) {
+            tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+            writeTree(tar, source, archiveBasePath);
+            tar.finish();
+        } catch (IOException | RuntimeException e) {
+            deleteQuietly(archive);
+            throw e;
+        }
+        return archive;
+    }
+
+    private void putArchive(String key, Path archive) {
         try {
-            archive = Files.createTempFile("daytona-context-", ".tar");
-            try (OutputStream out = Files.newOutputStream(archive);
-                 TarArchiveOutputStream tar = new TarArchiveOutputStream(out)) {
-                tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-                tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
-                writeTree(tar, source, archiveBasePath);
-                tar.finish();
-            }
             s3.putObject(
                     PutObjectRequest.builder().bucket(bucket).key(key).contentType("application/x-tar").build(),
                     RequestBody.fromFile(archive));
-        } catch (IOException e) {
-            throw new DaytonaException("Failed to create build context archive for " + source + ": " + e.getMessage(), e);
-        } catch (S3Exception e) {
+        } catch (SdkException e) {
             throw new DaytonaException("Failed to upload build context " + key + ": " + e.getMessage(), e);
-        } finally {
-            if (archive != null) {
-                try {
-                    Files.deleteIfExists(archive);
-                } catch (IOException ignored) {
-                    // Best effort; the temp directory is cleaned up by the OS.
-                }
-            }
+        }
+    }
+
+    private static void deleteQuietly(Path file) {
+        if (file == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException ignored) {
+            // Best effort; the temp directory is cleaned up by the OS.
         }
     }
 
     private static void writeTree(TarArchiveOutputStream tar, Path source, String archiveBasePath) throws IOException {
-        if (Files.isDirectory(source)) {
+        if (Files.isDirectory(source, LinkOption.NOFOLLOW_LINKS)) {
             for (Path entry : sortedTree(source)) {
                 String name = entry.equals(source)
                         ? archiveBasePath
@@ -263,15 +252,25 @@ final class ObjectStorage implements AutoCloseable {
     }
 
     private static void writeEntry(TarArchiveOutputStream tar, Path path, String name) throws IOException {
-        boolean directory = Files.isDirectory(path);
-        TarArchiveEntry entry = new TarArchiveEntry(directory ? name + "/" : name);
-        entry.setModTime(Files.getLastModifiedTime(path).toMillis());
-        entry.setMode(fileMode(path, directory));
-        if (!directory) {
+        TarArchiveEntry entry;
+        boolean regularFile = false;
+        if (Files.isSymbolicLink(path)) {
+            entry = new TarArchiveEntry(name, TarConstants.LF_SYMLINK);
+            entry.setLinkName(Files.readSymbolicLink(path).toString().replace('\\', '/'));
+            entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
+        } else if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+            entry = new TarArchiveEntry(name + "/");
+            entry.setMode(fileMode(path, true));
+        } else {
+            entry = new TarArchiveEntry(name);
+            entry.setMode(fileMode(path, false));
             entry.setSize(Files.size(path));
+            regularFile = true;
         }
+        // Fixed timestamp keeps the archive bytes, and therefore the content hash, stable.
+        entry.setModTime(0);
         tar.putArchiveEntry(entry);
-        if (!directory) {
+        if (regularFile) {
             try (InputStream in = Files.newInputStream(path)) {
                 in.transferTo(tar);
             }
@@ -316,24 +315,20 @@ final class ObjectStorage implements AutoCloseable {
         }
     }
 
-    private static boolean isEmptyDirectory(Path directory) throws IOException {
-        try (Stream<Path> children = Files.list(directory)) {
-            return !children.findAny().isPresent();
-        }
-    }
-
     private static String toArchiveRelative(Path root, Path entry) {
         return root.relativize(entry).toString().replace('\\', '/');
     }
 
-    private static void digestFile(MessageDigest digest, Path file) throws IOException {
+    private static String md5Hex(Path file) throws IOException {
+        MessageDigest md5 = newMd5();
         try (InputStream in = Files.newInputStream(file)) {
             byte[] buffer = new byte[8192];
             int read;
             while ((read = in.read(buffer)) != -1) {
-                digest.update(buffer, 0, read);
+                md5.update(buffer, 0, read);
             }
         }
+        return toHex(md5.digest());
     }
 
     private static MessageDigest newMd5() {

--- a/sdk-java/src/main/java/io/daytona/sdk/ObjectStorage.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/ObjectStorage.java
@@ -1,0 +1,359 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package io.daytona.sdk;
+
+import io.daytona.api.client.api.ObjectStorageApi;
+import io.daytona.api.client.model.StorageAccessDto;
+import io.daytona.sdk.exception.DaytonaException;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Uploads {@link Image} build contexts (local files and directories) to Daytona object storage.
+ *
+ * <p>Each context is packed into a tar archive and stored under
+ * {@code {organizationId}/{contentHash}/context.tar}. The content hash doubles as the identifier the
+ * API expects in {@code contextHashes}; contexts whose archive already exists are not re-uploaded.
+ *
+ * <p>Used internally by {@link SnapshotService} and {@link Daytona} when an {@link Image} carries
+ * contexts added via {@link Image#addLocalFile(String, String)} or
+ * {@link Image#addLocalDir(String, String)}.
+ */
+final class ObjectStorage implements AutoCloseable {
+    static final String DEFAULT_BUCKET = "daytona-volume-builds";
+    static final String DEFAULT_REGION = "us-east-1";
+    private static final String CONTEXT_ARCHIVE_NAME = "context.tar";
+    private static final int DEFAULT_FILE_MODE = 0644;
+    private static final int DEFAULT_DIR_MODE = 0755;
+
+    private final S3Client s3;
+    private final String bucket;
+
+    /**
+     * Creates a client from the temporary push-access credentials returned by the Daytona API.
+     *
+     * @param access credentials from {@code GET /object-storage/push-access}
+     */
+    ObjectStorage(StorageAccessDto access) {
+        this(createS3Client(access), defaultIfBlank(access.getBucket(), DEFAULT_BUCKET));
+    }
+
+    ObjectStorage(S3Client s3, String bucket) {
+        this.s3 = s3;
+        this.bucket = bucket;
+    }
+
+    private static S3Client createS3Client(StorageAccessDto access) {
+        AwsCredentials credentials;
+        if (access.getSessionToken() == null || access.getSessionToken().isEmpty()) {
+            credentials = AwsBasicCredentials.create(access.getAccessKey(), access.getSecret());
+        } else {
+            credentials = AwsSessionCredentials.create(access.getAccessKey(), access.getSecret(), access.getSessionToken());
+        }
+        return S3Client.builder()
+                .httpClientBuilder(UrlConnectionHttpClient.builder())
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .region(Region.of(defaultIfBlank(access.getRegion(), DEFAULT_REGION)))
+                .endpointOverride(URI.create(access.getStorageUrl()))
+                // Path-style addressing and a plain (non aws-chunked) body keep uploads compatible
+                // with every S3-compatible backend Daytona may hand out push access for.
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .chunkedEncodingEnabled(false)
+                        .build())
+                .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
+                .build();
+    }
+
+    private static String defaultIfBlank(String value, String fallback) {
+        return value == null || value.isEmpty() ? fallback : value;
+    }
+
+    /**
+     * Uploads every build context of an {@link Image} and returns their hashes in context order.
+     *
+     * <p>Returns an empty list without contacting the API when the image has no contexts.
+     *
+     * @param objectStorageApi API used to obtain temporary push credentials
+     * @param image image whose contexts should be uploaded
+     * @return context hashes to send as {@code CreateBuildInfo.contextHashes}
+     * @throws DaytonaException if credentials cannot be obtained or an upload fails
+     */
+    static List<String> processImageContext(ObjectStorageApi objectStorageApi, Image image) {
+        List<Image.Context> contexts = image.getContexts();
+        if (contexts.isEmpty()) {
+            return Collections.emptyList();
+        }
+        StorageAccessDto access = ExceptionMapper.callMain(() -> objectStorageApi.getPushAccess(null));
+        if (access == null) {
+            throw new DaytonaException("Object storage push access response was empty");
+        }
+        List<String> hashes = new ArrayList<>(contexts.size());
+        try (ObjectStorage storage = new ObjectStorage(access)) {
+            for (Image.Context context : contexts) {
+                hashes.add(storage.upload(Paths.get(context.getSourcePath()), access.getOrganizationId(), context.getArchivePath()));
+            }
+        }
+        return hashes;
+    }
+
+    /**
+     * Uploads a local file or directory as a tar archive and returns its content hash.
+     *
+     * @param path local file or directory
+     * @param organizationId organization that owns the storage prefix
+     * @param archiveBasePath name of the entry (or root directory) inside the archive
+     * @return MD5 content hash identifying the uploaded context
+     * @throws DaytonaException if the path does not exist or the upload fails
+     */
+    String upload(Path path, String organizationId, String archiveBasePath) {
+        if (!Files.exists(path)) {
+            throw new DaytonaException("Path does not exist: " + path);
+        }
+        String hash = computeHash(path, archiveBasePath);
+        String key = organizationId + "/" + hash + "/" + CONTEXT_ARCHIVE_NAME;
+        if (!objectExists(key)) {
+            uploadAsTar(key, path, archiveBasePath);
+        }
+        return hash;
+    }
+
+    /**
+     * Computes the archive-relative name for a local path: the normalized absolute path without its
+     * root component (leading {@code /} or Windows drive letter). Matches the other Daytona SDKs so
+     * the generated {@code COPY} instruction resolves inside the build context.
+     *
+     * @param path local path
+     * @return archive base path, never empty
+     */
+    static String computeArchiveBasePath(Path path) {
+        Path absolute = path.toAbsolutePath().normalize();
+        Path root = absolute.getRoot();
+        Path relative = root == null ? absolute : root.relativize(absolute);
+        String archivePath = relative.toString().replace('\\', '/');
+        while (archivePath.startsWith("/")) {
+            archivePath = archivePath.substring(1);
+        }
+        return archivePath.isEmpty() ? absolute.getFileName().toString() : archivePath;
+    }
+
+    /**
+     * Computes the MD5 hash of a file or directory tree together with its archive base path.
+     *
+     * <p>For directories, entries are visited in lexicographic order so the hash is stable across
+     * runs and platforms. Each file contributes its archive-relative path and contents; empty
+     * directories contribute their relative path only.
+     */
+    static String computeHash(Path path, String archiveBasePath) {
+        MessageDigest md5 = newMd5();
+        md5.update(archiveBasePath.getBytes(StandardCharsets.UTF_8));
+        try {
+            if (Files.isDirectory(path)) {
+                for (Path entry : sortedTree(path)) {
+                    if (entry.equals(path)) {
+                        continue;
+                    }
+                    String relative = toArchiveRelative(path, entry);
+                    if (Files.isDirectory(entry)) {
+                        if (isEmptyDirectory(entry)) {
+                            md5.update(relative.getBytes(StandardCharsets.UTF_8));
+                        }
+                        continue;
+                    }
+                    md5.update(relative.getBytes(StandardCharsets.UTF_8));
+                    digestFile(md5, entry);
+                }
+            } else {
+                digestFile(md5, path);
+            }
+        } catch (IOException e) {
+            throw new DaytonaException("Failed to hash " + path + ": " + e.getMessage(), e);
+        }
+        return toHex(md5.digest());
+    }
+
+    private boolean objectExists(String key) {
+        try {
+            s3.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                return false;
+            }
+            throw new DaytonaException("Failed to check object storage for " + key + ": " + e.getMessage(), e);
+        }
+    }
+
+    private void uploadAsTar(String key, Path source, String archiveBasePath) {
+        Path archive = null;
+        try {
+            archive = Files.createTempFile("daytona-context-", ".tar");
+            try (OutputStream out = Files.newOutputStream(archive);
+                 TarArchiveOutputStream tar = new TarArchiveOutputStream(out)) {
+                tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+                tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+                writeTree(tar, source, archiveBasePath);
+                tar.finish();
+            }
+            s3.putObject(
+                    PutObjectRequest.builder().bucket(bucket).key(key).contentType("application/x-tar").build(),
+                    RequestBody.fromFile(archive));
+        } catch (IOException e) {
+            throw new DaytonaException("Failed to create build context archive for " + source + ": " + e.getMessage(), e);
+        } catch (S3Exception e) {
+            throw new DaytonaException("Failed to upload build context " + key + ": " + e.getMessage(), e);
+        } finally {
+            if (archive != null) {
+                try {
+                    Files.deleteIfExists(archive);
+                } catch (IOException ignored) {
+                    // Best effort; the temp directory is cleaned up by the OS.
+                }
+            }
+        }
+    }
+
+    private static void writeTree(TarArchiveOutputStream tar, Path source, String archiveBasePath) throws IOException {
+        if (Files.isDirectory(source)) {
+            for (Path entry : sortedTree(source)) {
+                String name = entry.equals(source)
+                        ? archiveBasePath
+                        : archiveBasePath + "/" + toArchiveRelative(source, entry);
+                writeEntry(tar, entry, name);
+            }
+        } else {
+            writeEntry(tar, source, archiveBasePath);
+        }
+    }
+
+    private static void writeEntry(TarArchiveOutputStream tar, Path path, String name) throws IOException {
+        boolean directory = Files.isDirectory(path);
+        TarArchiveEntry entry = new TarArchiveEntry(directory ? name + "/" : name);
+        entry.setModTime(Files.getLastModifiedTime(path).toMillis());
+        entry.setMode(fileMode(path, directory));
+        if (!directory) {
+            entry.setSize(Files.size(path));
+        }
+        tar.putArchiveEntry(entry);
+        if (!directory) {
+            try (InputStream in = Files.newInputStream(path)) {
+                in.transferTo(tar);
+            }
+        }
+        tar.closeArchiveEntry();
+    }
+
+    private static int fileMode(Path path, boolean directory) {
+        try {
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(path);
+            int mode = 0;
+            for (PosixFilePermission permission : permissions) {
+                mode |= posixBit(permission);
+            }
+            return mode;
+        } catch (UnsupportedOperationException | IOException e) {
+            return directory ? DEFAULT_DIR_MODE : DEFAULT_FILE_MODE;
+        }
+    }
+
+    private static int posixBit(PosixFilePermission permission) {
+        switch (permission) {
+            case OWNER_READ: return 0400;
+            case OWNER_WRITE: return 0200;
+            case OWNER_EXECUTE: return 0100;
+            case GROUP_READ: return 0040;
+            case GROUP_WRITE: return 0020;
+            case GROUP_EXECUTE: return 0010;
+            case OTHERS_READ: return 0004;
+            case OTHERS_WRITE: return 0002;
+            case OTHERS_EXECUTE: return 0001;
+            default: return 0;
+        }
+    }
+
+    private static List<Path> sortedTree(Path root) throws IOException {
+        try (Stream<Path> stream = Files.walk(root)) {
+            List<Path> paths = new ArrayList<>();
+            stream.forEach(paths::add);
+            Collections.sort(paths);
+            return paths;
+        }
+    }
+
+    private static boolean isEmptyDirectory(Path directory) throws IOException {
+        try (Stream<Path> children = Files.list(directory)) {
+            return !children.findAny().isPresent();
+        }
+    }
+
+    private static String toArchiveRelative(Path root, Path entry) {
+        return root.relativize(entry).toString().replace('\\', '/');
+    }
+
+    private static void digestFile(MessageDigest digest, Path file) throws IOException {
+        try (InputStream in = Files.newInputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+    }
+
+    private static MessageDigest newMd5() {
+        try {
+            return MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            throw new DaytonaException("MD5 digest is not available", e);
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public void close() {
+        s3.close();
+    }
+}

--- a/sdk-java/src/main/java/io/daytona/sdk/SnapshotService.java
+++ b/sdk-java/src/main/java/io/daytona/sdk/SnapshotService.java
@@ -40,11 +40,21 @@ public class SnapshotService {
     private final SnapshotsApi snapshotsApi;
     private final OkHttpClient httpClient;
     private final String apiKey;
+    private final BuildContextUploader contextUploader;
 
-    SnapshotService(SnapshotsApi snapshotsApi, OkHttpClient httpClient, String apiKey) {
+    /**
+     * Uploads the local build contexts of an {@link Image} and returns their content hashes.
+     */
+    @FunctionalInterface
+    interface BuildContextUploader {
+        List<String> upload(Image image);
+    }
+
+    SnapshotService(SnapshotsApi snapshotsApi, OkHttpClient httpClient, String apiKey, BuildContextUploader contextUploader) {
         this.snapshotsApi = snapshotsApi;
         this.httpClient = httpClient;
         this.apiKey = apiKey;
+        this.contextUploader = contextUploader;
     }
 
     /**
@@ -118,8 +128,9 @@ public class SnapshotService {
      * @throws DaytonaException if the API request fails or the build fails
      */
     public Snapshot create(String name, Image image, io.daytona.sdk.model.Resources resources, SandboxClass sandboxClass, Consumer<String> onLogs) {
+        List<String> contextHashes = contextUploader.upload(image);
         CreateSnapshot req = new CreateSnapshot().name(name)
-                .buildInfo(new CreateBuildInfo().dockerfileContent(image.getDockerfile()))
+                .buildInfo(new CreateBuildInfo().dockerfileContent(image.getDockerfile()).contextHashes(contextHashes))
                 .entrypoint(null);
 
         if (resources != null) {

--- a/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
@@ -39,9 +39,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -735,6 +738,32 @@ class E2ETest {
             if (imageSandbox != null) {
                 imageSandbox.delete();
             }
+        }
+    }
+
+    @Test
+    @Order(22)
+    void declarativeImageWithLocalFileBakesFileIntoSandbox() throws IOException {
+        String marker = unique("e2e-local-file");
+        Path localFile = Files.createTempFile("sdk-java-e2e-", ".txt");
+        Files.write(localFile, marker.getBytes(StandardCharsets.UTF_8));
+
+        CreateSandboxFromImageParams params = new CreateSandboxFromImageParams();
+        params.setName(unique("sdk-java-e2e-local-file"));
+        params.setImage(Image.debianSlim("3.12").addLocalFile(localFile.toString(), "/home/daytona/local-file.txt"));
+
+        Sandbox imageSandbox = null;
+        try {
+            imageSandbox = daytona.create(params, 300, null);
+
+            ExecuteResponse result = imageSandbox.getProcess().executeCommand("cat /home/daytona/local-file.txt");
+            assertThat(result.getExitCode()).isEqualTo(0);
+            assertThat(result.getResult().trim()).isEqualTo(marker);
+        } finally {
+            if (imageSandbox != null) {
+                imageSandbox.delete();
+            }
+            Files.deleteIfExists(localFile);
         }
     }
 

--- a/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
@@ -760,17 +760,19 @@ class E2ETest {
             assertThat(result.getExitCode()).isEqualTo(0);
             assertThat(result.getResult().trim()).isEqualTo(marker);
         } finally {
-            deleteSandboxQuietly(sandboxName);
+            deleteSandboxIfExists(sandboxName);
             Files.deleteIfExists(localFile);
         }
     }
 
-    private void deleteSandboxQuietly(String sandboxName) {
+    private void deleteSandboxIfExists(String sandboxName) {
+        Sandbox sandbox;
         try {
-            daytona.get(sandboxName).delete();
-        } catch (RuntimeException ignored) {
-            // The sandbox was never created or is already gone.
+            sandbox = daytona.get(sandboxName);
+        } catch (io.daytona.sdk.exception.DaytonaNotFoundException e) {
+            return;
         }
+        sandbox.delete();
     }
 
     @Test

--- a/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
@@ -759,8 +759,18 @@ class E2ETest {
             ExecuteResponse result = imageSandbox.getProcess().executeCommand("cat /home/daytona/local-file.txt");
             assertThat(result.getExitCode()).isEqualTo(0);
             assertThat(result.getResult().trim()).isEqualTo(marker);
+
+            imageSandbox.delete();
+        } catch (Throwable testFailure) {
+            // Best-effort cleanup of a sandbox the API may have created before create() threw;
+            // cleanup problems must not replace the real test outcome.
+            try {
+                deleteSandboxIfExists(sandboxName);
+            } catch (RuntimeException cleanupFailure) {
+                testFailure.addSuppressed(cleanupFailure);
+            }
+            throw testFailure;
         } finally {
-            deleteSandboxIfExists(sandboxName);
             Files.deleteIfExists(localFile);
         }
     }

--- a/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
@@ -742,28 +742,34 @@ class E2ETest {
     }
 
     @Test
-    @Order(22)
+    @Order(23)
     void declarativeImageWithLocalFileBakesFileIntoSandbox() throws IOException {
         String marker = unique("e2e-local-file");
         Path localFile = Files.createTempFile("sdk-java-e2e-", ".txt");
         Files.write(localFile, marker.getBytes(StandardCharsets.UTF_8));
 
+        String sandboxName = unique("sdk-java-e2e-local-file");
         CreateSandboxFromImageParams params = new CreateSandboxFromImageParams();
-        params.setName(unique("sdk-java-e2e-local-file"));
+        params.setName(sandboxName);
         params.setImage(Image.debianSlim("3.12").addLocalFile(localFile.toString(), "/home/daytona/local-file.txt"));
 
-        Sandbox imageSandbox = null;
         try {
-            imageSandbox = daytona.create(params, 300, null);
+            Sandbox imageSandbox = daytona.create(params, 300, null);
 
             ExecuteResponse result = imageSandbox.getProcess().executeCommand("cat /home/daytona/local-file.txt");
             assertThat(result.getExitCode()).isEqualTo(0);
             assertThat(result.getResult().trim()).isEqualTo(marker);
         } finally {
-            if (imageSandbox != null) {
-                imageSandbox.delete();
-            }
+            deleteSandboxQuietly(sandboxName);
             Files.deleteIfExists(localFile);
+        }
+    }
+
+    private void deleteSandboxQuietly(String sandboxName) {
+        try {
+            daytona.get(sandboxName).delete();
+        } catch (RuntimeException ignored) {
+            // The sandbox was never created or is already gone.
         }
     }
 

--- a/sdk-java/src/test/java/io/daytona/sdk/ImageTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/ImageTest.java
@@ -199,7 +199,18 @@ class ImageTest {
     }
 
     @Test
+    void addLocalFileEscapesJsonControlCharacters(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("plain.txt"), "x".getBytes());
+
+        Image image = Image.base("alpine").addLocalFile(file.toString(), "/opt/a\tb\n\"c\"\\d\u0001");
+
+        assertThat(image.getDockerfile())
+                .endsWith("\",\"/opt/a\\tb\\n\\\"c\\\"\\\\d\\u0001\"]\n");
+    }
+
+    @Test
     void addLocalFileResolvesSymlinkToTarget(@TempDir Path dir) throws IOException {
+        ObjectStorageTest.assumeSymlinksSupported(dir);
         Path target = Files.write(dir.resolve("target.txt"), "x".getBytes());
         Path link = Files.createSymbolicLink(dir.resolve("link.txt"), target);
 
@@ -212,6 +223,7 @@ class ImageTest {
 
     @Test
     void addLocalDirResolvesSymlinkToTargetDirectory(@TempDir Path dir) throws IOException {
+        ObjectStorageTest.assumeSymlinksSupported(dir);
         Path target = Files.createDirectories(dir.resolve("target"));
         Files.write(target.resolve("a.txt"), "x".getBytes());
         Path link = Files.createSymbolicLink(dir.resolve("link"), target);

--- a/sdk-java/src/test/java/io/daytona/sdk/ImageTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/ImageTest.java
@@ -3,12 +3,18 @@
 
 package io.daytona.sdk;
 
+import io.daytona.sdk.exception.DaytonaNotFoundException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ImageTest {
 
@@ -90,5 +96,100 @@ class ImageTest {
                 .contains("WORKDIR /workspace\n")
                 .contains("ENTRYPOINT [\"python\",\"main.py\"]\n")
                 .contains("CMD [\"--flag\"]\n");
+    }
+
+    @Test
+    void addLocalFileTracksContextAndEmitsCopy(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("requirements.txt"), "numpy\n".getBytes());
+        String archivePath = ObjectStorage.computeArchiveBasePath(file);
+
+        Image image = Image.base("python:3.12").addLocalFile(file.toString(), "/app/requirements.txt");
+
+        assertThat(image.getDockerfile())
+                .isEqualTo("FROM python:3.12\nCOPY " + archivePath + " /app/requirements.txt\n");
+        assertThat(image.getContexts()).containsExactly(new Image.Context(file.toAbsolutePath().normalize().toString(), archivePath));
+        assertThat(archivePath).doesNotStartWith("/");
+    }
+
+    @Test
+    void addLocalFileAppendsFileNameWhenRemotePathIsDirectory(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("config.yaml"), "a: 1\n".getBytes());
+
+        Image image = Image.base("alpine").addLocalFile(file.toString(), "/etc/app/");
+
+        assertThat(image.getDockerfile()).endsWith(" /etc/app/config.yaml\n");
+    }
+
+    @Test
+    void addLocalFileResolvesRelativePathAgainstWorkingDirectory(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("relative.txt"), "x".getBytes());
+        Path relative = Path.of("").toAbsolutePath().relativize(file.toAbsolutePath());
+
+        Image image = Image.base("alpine").addLocalFile(relative.toString(), "/relative.txt");
+
+        assertThat(image.getContexts()).singleElement()
+                .extracting(Image.Context::getSourcePath)
+                .isEqualTo(file.toAbsolutePath().normalize().toString());
+    }
+
+    @Test
+    void addLocalFileRejectsMissingFile(@TempDir Path dir) {
+        String missing = dir.resolve("missing.txt").toString();
+
+        assertThatThrownBy(() -> Image.base("alpine").addLocalFile(missing, "/x"))
+                .isInstanceOf(DaytonaNotFoundException.class)
+                .hasMessage("Local file " + missing + " does not exist");
+    }
+
+    @Test
+    void addLocalFileRejectsDirectory(@TempDir Path dir) {
+        assertThatThrownBy(() -> Image.base("alpine").addLocalFile(dir.toString(), "/x"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("is not a file");
+    }
+
+    @Test
+    void addLocalDirTracksContextAndEmitsCopy(@TempDir Path dir) throws IOException {
+        Path src = Files.createDirectories(dir.resolve("src"));
+        Files.write(src.resolve("main.py"), "print(1)\n".getBytes());
+        String archivePath = ObjectStorage.computeArchiveBasePath(src);
+
+        Image image = Image.base("python:3.12").addLocalDir(src.toString(), "/app/src");
+
+        assertThat(image.getDockerfile()).isEqualTo("FROM python:3.12\nCOPY " + archivePath + " /app/src\n");
+        assertThat(image.getContexts()).containsExactly(new Image.Context(src.toAbsolutePath().normalize().toString(), archivePath));
+    }
+
+    @Test
+    void addLocalDirRejectsMissingAndNonDirectory(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("file.txt"), "x".getBytes());
+
+        assertThatThrownBy(() -> Image.base("alpine").addLocalDir(dir.resolve("nope").toString(), "/x"))
+                .isInstanceOf(DaytonaNotFoundException.class);
+        assertThatThrownBy(() -> Image.base("alpine").addLocalDir(file.toString(), "/x"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("is not a directory");
+    }
+
+    @Test
+    void addLocalFileExpandsUserHome(@TempDir Path dir) throws IOException {
+        String originalHome = System.getProperty("user.home");
+        System.setProperty("user.home", dir.toString());
+        try {
+            Files.write(dir.resolve("home.txt"), "x".getBytes());
+
+            Image image = Image.base("alpine").addLocalFile("~/home.txt", "/home.txt");
+
+            assertThat(image.getContexts()).singleElement()
+                    .extracting(Image.Context::getSourcePath)
+                    .isEqualTo(dir.resolve("home.txt").toAbsolutePath().normalize().toString());
+        } finally {
+            System.setProperty("user.home", originalHome);
+        }
+    }
+
+    @Test
+    void imagesWithoutLocalFilesHaveNoContexts() {
+        assertThat(Image.base("alpine").runCommands("true").getContexts()).isEmpty();
     }
 }

--- a/sdk-java/src/test/java/io/daytona/sdk/ImageTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/ImageTest.java
@@ -106,7 +106,7 @@ class ImageTest {
         Image image = Image.base("python:3.12").addLocalFile(file.toString(), "/app/requirements.txt");
 
         assertThat(image.getDockerfile())
-                .isEqualTo("FROM python:3.12\nCOPY " + archivePath + " /app/requirements.txt\n");
+                .isEqualTo("FROM python:3.12\nCOPY [\"" + archivePath + "\",\"/app/requirements.txt\"]\n");
         assertThat(image.getContexts()).containsExactly(new Image.Context(file.toAbsolutePath().normalize().toString(), archivePath));
         assertThat(archivePath).doesNotStartWith("/");
     }
@@ -117,7 +117,7 @@ class ImageTest {
 
         Image image = Image.base("alpine").addLocalFile(file.toString(), "/etc/app/");
 
-        assertThat(image.getDockerfile()).endsWith(" /etc/app/config.yaml\n");
+        assertThat(image.getDockerfile()).endsWith("\",\"/etc/app/config.yaml\"]\n");
     }
 
     @Test
@@ -156,7 +156,7 @@ class ImageTest {
 
         Image image = Image.base("python:3.12").addLocalDir(src.toString(), "/app/src");
 
-        assertThat(image.getDockerfile()).isEqualTo("FROM python:3.12\nCOPY " + archivePath + " /app/src\n");
+        assertThat(image.getDockerfile()).isEqualTo("FROM python:3.12\nCOPY [\"" + archivePath + "\",\"/app/src\"]\n");
         assertThat(image.getContexts()).containsExactly(new Image.Context(src.toAbsolutePath().normalize().toString(), archivePath));
     }
 
@@ -186,6 +186,48 @@ class ImageTest {
         } finally {
             System.setProperty("user.home", originalHome);
         }
+    }
+
+    @Test
+    void addLocalFileQuotesPathsWithWhitespace(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("my file.txt"), "x".getBytes());
+
+        Image image = Image.base("alpine").addLocalFile(file.toString(), "/opt/my file.txt");
+
+        assertThat(image.getDockerfile())
+                .isEqualTo("FROM alpine\nCOPY [\"" + ObjectStorage.computeArchiveBasePath(file) + "\",\"/opt/my file.txt\"]\n");
+    }
+
+    @Test
+    void addLocalFileResolvesSymlinkToTarget(@TempDir Path dir) throws IOException {
+        Path target = Files.write(dir.resolve("target.txt"), "x".getBytes());
+        Path link = Files.createSymbolicLink(dir.resolve("link.txt"), target);
+
+        Image image = Image.base("alpine").addLocalFile(link.toString(), "/x");
+
+        assertThat(image.getContexts()).singleElement()
+                .extracting(Image.Context::getSourcePath)
+                .isEqualTo(target.toRealPath().toString());
+    }
+
+    @Test
+    void addLocalDirResolvesSymlinkToTargetDirectory(@TempDir Path dir) throws IOException {
+        Path target = Files.createDirectories(dir.resolve("target"));
+        Files.write(target.resolve("a.txt"), "x".getBytes());
+        Path link = Files.createSymbolicLink(dir.resolve("link"), target);
+
+        Image image = Image.base("alpine").addLocalDir(link.toString(), "/x");
+
+        assertThat(image.getContexts()).singleElement()
+                .extracting(Image.Context::getSourcePath)
+                .isEqualTo(target.toRealPath().toString());
+    }
+
+    @Test
+    void addLocalDirRejectsFilesystemRoot() {
+        assertThatThrownBy(() -> Image.base("alpine").addLocalDir("/", "/x"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("filesystem root");
     }
 
     @Test

--- a/sdk-java/src/test/java/io/daytona/sdk/ObjectStorageTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/ObjectStorageTest.java
@@ -1,0 +1,270 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package io.daytona.sdk;
+
+import io.daytona.api.client.ApiException;
+import io.daytona.api.client.api.ObjectStorageApi;
+import io.daytona.api.client.model.StorageAccessDto;
+import io.daytona.sdk.exception.DaytonaException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ObjectStorageTest {
+
+    @Mock
+    private S3Client s3;
+
+    @Mock
+    private ObjectStorageApi objectStorageApi;
+
+    private Map<String, String> uploadedTar;
+
+    private void captureUploadedTar() {
+        when(s3.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenAnswer(invocation -> {
+            uploadedTar = readTar(invocation.getArgument(1, RequestBody.class).contentStreamProvider().newStream());
+            return PutObjectResponse.builder().build();
+        });
+    }
+
+    @Test
+    void computeArchiveBasePathStripsRootAndNormalizes(@TempDir Path dir) {
+        Path file = dir.resolve("sub/../a.txt");
+
+        String archivePath = ObjectStorage.computeArchiveBasePath(file);
+
+        assertThat(archivePath).doesNotStartWith("/").doesNotContain("..").endsWith("/a.txt");
+        assertThat(Path.of("/" + archivePath)).isEqualTo(dir.resolve("a.txt").toAbsolutePath().normalize());
+    }
+
+    @Test
+    void computeHashIsStableAndSensitiveToContentAndArchivePath(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("a.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+
+        String first = ObjectStorage.computeHash(file, "ctx/a.txt");
+        String again = ObjectStorage.computeHash(file, "ctx/a.txt");
+        String otherArchivePath = ObjectStorage.computeHash(file, "other/a.txt");
+        Files.write(file, "changed".getBytes(StandardCharsets.UTF_8));
+        String changedContent = ObjectStorage.computeHash(file, "ctx/a.txt");
+
+        assertThat(first).matches("[0-9a-f]{32}").isEqualTo(again);
+        assertThat(otherArchivePath).isNotEqualTo(first);
+        assertThat(changedContent).isNotEqualTo(first);
+    }
+
+    @Test
+    void computeHashOfDirectoryCoversNestedFilesAndEmptyDirectories(@TempDir Path dir) throws IOException {
+        Path root = Files.createDirectories(dir.resolve("root"));
+        Files.write(root.resolve("b.txt"), "b".getBytes(StandardCharsets.UTF_8));
+        Files.write(Files.createDirectories(root.resolve("nested")).resolve("a.txt"), "a".getBytes(StandardCharsets.UTF_8));
+
+        String base = ObjectStorage.computeHash(root, "root");
+        Files.createDirectories(root.resolve("empty"));
+        String withEmptyDir = ObjectStorage.computeHash(root, "root");
+        Files.write(root.resolve("nested/a.txt"), "a2".getBytes(StandardCharsets.UTF_8));
+        String withChangedNested = ObjectStorage.computeHash(root, "root");
+
+        assertThat(withEmptyDir).isNotEqualTo(base);
+        assertThat(withChangedNested).isNotEqualTo(withEmptyDir);
+    }
+
+    @Test
+    void uploadSkipsPutWhenArchiveAlreadyExists(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("a.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        when(s3.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder().build());
+
+        String hash = new ObjectStorage(s3, "bucket").upload(file, "org-1", "ctx/a.txt");
+
+        ArgumentCaptor<HeadObjectRequest> head = ArgumentCaptor.forClass(HeadObjectRequest.class);
+        verify(s3).headObject(head.capture());
+        assertThat(head.getValue().bucket()).isEqualTo("bucket");
+        assertThat(head.getValue().key()).isEqualTo("org-1/" + hash + "/context.tar");
+        verify(s3, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    void uploadPutsSingleFileAsTarWhenMissing(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("a.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        when(s3.headObject(any(HeadObjectRequest.class))).thenThrow(NoSuchKeyException.builder().statusCode(404).build());
+        captureUploadedTar();
+
+        String hash = new ObjectStorage(s3, "bucket").upload(file, "org-1", "ctx/a.txt");
+
+        ArgumentCaptor<PutObjectRequest> put = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3).putObject(put.capture(), any(RequestBody.class));
+        assertThat(put.getValue().key()).isEqualTo("org-1/" + hash + "/context.tar");
+        assertThat(put.getValue().contentType()).isEqualTo("application/x-tar");
+        assertThat(uploadedTar).containsExactly(Map.entry("ctx/a.txt", "hello"));
+    }
+
+    @Test
+    void uploadPutsDirectoryTreeAsTar(@TempDir Path dir) throws IOException {
+        Path root = Files.createDirectories(dir.resolve("root"));
+        Files.write(root.resolve("b.txt"), "b".getBytes(StandardCharsets.UTF_8));
+        Files.write(Files.createDirectories(root.resolve("nested")).resolve("a.txt"), "a".getBytes(StandardCharsets.UTF_8));
+        Files.createDirectories(root.resolve("empty"));
+        when(s3.headObject(any(HeadObjectRequest.class))).thenThrow(S3Exception.builder().statusCode(404).build());
+        captureUploadedTar();
+
+        new ObjectStorage(s3, "bucket").upload(root, "org-1", "home/me/root");
+
+        Map<String, String> entries = uploadedTar;
+        assertThat(entries.keySet()).containsExactly(
+                "home/me/root/", "home/me/root/b.txt", "home/me/root/empty/", "home/me/root/nested/", "home/me/root/nested/a.txt");
+        assertThat(entries).containsEntry("home/me/root/b.txt", "b").containsEntry("home/me/root/nested/a.txt", "a");
+    }
+
+    @Test
+    void uploadWrapsStorageErrors(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("a.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        when(s3.headObject(any(HeadObjectRequest.class)))
+                .thenThrow(S3Exception.builder().statusCode(403).message("denied").build());
+
+        assertThatThrownBy(() -> new ObjectStorage(s3, "bucket").upload(file, "org-1", "ctx/a.txt"))
+                .isInstanceOf(DaytonaException.class)
+                .hasMessageContaining("Failed to check object storage");
+    }
+
+    @Test
+    void uploadRejectsMissingPath(@TempDir Path dir) {
+        assertThatThrownBy(() -> new ObjectStorage(s3, "bucket").upload(dir.resolve("nope"), "org-1", "nope"))
+                .isInstanceOf(DaytonaException.class)
+                .hasMessageContaining("does not exist");
+        verifyNoInteractions(s3);
+    }
+
+    @Test
+    void processImageContextSkipsApiWhenImageHasNoContexts() {
+        List<String> hashes = ObjectStorage.processImageContext(objectStorageApi, Image.base("alpine"));
+
+        assertThat(hashes).isEmpty();
+        verifyNoInteractions(objectStorageApi);
+    }
+
+    @Test
+    void processImageContextMapsPushAccessErrors(@TempDir Path dir) throws Exception {
+        Path file = Files.write(dir.resolve("a.txt"), "x".getBytes(StandardCharsets.UTF_8));
+        when(objectStorageApi.getPushAccess(null)).thenThrow(new ApiException(403, "forbidden"));
+
+        assertThatThrownBy(() -> ObjectStorage.processImageContext(objectStorageApi, Image.base("alpine").addLocalFile(file.toString(), "/a")))
+                .isInstanceOf(DaytonaException.class);
+    }
+
+    @Test
+    void processImageContextUploadsEachContextWithPushAccessCredentials(@TempDir Path dir) throws Exception {
+        Path file = Files.write(dir.resolve("a.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        Path src = Files.createDirectories(dir.resolve("src"));
+        Files.write(src.resolve("main.py"), "print(1)".getBytes(StandardCharsets.UTF_8));
+        Image image = Image.base("python:3.12").addLocalFile(file.toString(), "/a.txt").addLocalDir(src.toString(), "/src");
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(404));
+            server.enqueue(new MockResponse().setResponseCode(200));
+            server.enqueue(new MockResponse().setResponseCode(200));
+            server.start();
+            StorageAccessDto access = new StorageAccessDto()
+                    .storageUrl(server.url("/").toString())
+                    .accessKey("AKIA")
+                    .secret("secret")
+                    .sessionToken("token")
+                    .bucket("my-bucket")
+                    .organizationId("org-1")
+                    .region("eu-west-1");
+            when(objectStorageApi.getPushAccess(null)).thenReturn(access);
+
+            List<String> hashes = ObjectStorage.processImageContext(objectStorageApi, image);
+
+            List<Image.Context> contexts = image.getContexts();
+            String fileHash = ObjectStorage.computeHash(file, contexts.get(0).getArchivePath());
+            String dirHash = ObjectStorage.computeHash(src, contexts.get(1).getArchivePath());
+            assertThat(hashes).containsExactly(fileHash, dirHash);
+
+            RecordedRequest head = server.takeRequest();
+            assertThat(head.getMethod()).isEqualTo("HEAD");
+            assertThat(head.getPath()).isEqualTo("/my-bucket/org-1/" + fileHash + "/context.tar");
+            assertThat(head.getHeader("Authorization")).startsWith("AWS4-HMAC-SHA256 Credential=AKIA/").contains("/eu-west-1/s3/");
+            assertThat(head.getHeader("x-amz-security-token")).isEqualTo("token");
+
+            RecordedRequest put = server.takeRequest();
+            assertThat(put.getMethod()).isEqualTo("PUT");
+            assertThat(put.getPath()).isEqualTo("/my-bucket/org-1/" + fileHash + "/context.tar");
+            assertThat(put.getHeader("Content-Type")).isEqualTo("application/x-tar");
+            assertThat(put.getHeader("Content-Encoding")).isNull();
+            assertThat(readTar(put.getBody().inputStream())).containsExactly(Map.entry(contexts.get(0).getArchivePath(), "hello"));
+
+            RecordedRequest secondHead = server.takeRequest();
+            assertThat(secondHead.getMethod()).isEqualTo("HEAD");
+            assertThat(secondHead.getPath()).isEqualTo("/my-bucket/org-1/" + dirHash + "/context.tar");
+            assertThat(server.getRequestCount()).isEqualTo(3);
+        }
+    }
+
+    @Test
+    void processImageContextFallsBackToDefaultBucketAndRegion(@TempDir Path dir) throws Exception {
+        Path file = Files.write(dir.resolve("a.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        Image image = Image.base("alpine").addLocalFile(file.toString(), "/a.txt");
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(200));
+            server.start();
+            when(objectStorageApi.getPushAccess(null)).thenReturn(new StorageAccessDto()
+                    .storageUrl(server.url("/").toString())
+                    .accessKey("AKIA")
+                    .secret("secret")
+                    .organizationId("org-1"));
+
+            ObjectStorage.processImageContext(objectStorageApi, image);
+
+            RecordedRequest head = server.takeRequest();
+            assertThat(head.getPath()).startsWith("/" + ObjectStorage.DEFAULT_BUCKET + "/org-1/");
+            assertThat(head.getHeader("Authorization")).contains("/" + ObjectStorage.DEFAULT_REGION + "/s3/");
+            assertThat(head.getHeader("x-amz-security-token")).isNull();
+        }
+    }
+
+    private static Map<String, String> readTar(InputStream stream) throws IOException {
+        Map<String, String> entries = new LinkedHashMap<>();
+        try (TarArchiveInputStream tar = new TarArchiveInputStream(stream)) {
+            TarArchiveEntry entry;
+            while ((entry = tar.getNextEntry()) != null) {
+                entries.put(entry.getName(), entry.isDirectory() ? "" : new String(tar.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        }
+        return entries;
+    }
+}

--- a/sdk-java/src/test/java/io/daytona/sdk/ObjectStorageTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/ObjectStorageTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
@@ -73,34 +74,70 @@ class ObjectStorageTest {
     }
 
     @Test
-    void computeHashIsStableAndSensitiveToContentAndArchivePath(@TempDir Path dir) throws IOException {
-        Path file = Files.write(dir.resolve("a.txt"), "hello".getBytes(StandardCharsets.UTF_8));
-
-        String first = ObjectStorage.computeHash(file, "ctx/a.txt");
-        String again = ObjectStorage.computeHash(file, "ctx/a.txt");
-        String otherArchivePath = ObjectStorage.computeHash(file, "other/a.txt");
-        Files.write(file, "changed".getBytes(StandardCharsets.UTF_8));
-        String changedContent = ObjectStorage.computeHash(file, "ctx/a.txt");
-
-        assertThat(first).matches("[0-9a-f]{32}").isEqualTo(again);
-        assertThat(otherArchivePath).isNotEqualTo(first);
-        assertThat(changedContent).isNotEqualTo(first);
+    void computeArchiveBasePathRejectsFilesystemRoot() {
+        assertThatThrownBy(() -> ObjectStorage.computeArchiveBasePath(Path.of("/")))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void computeHashOfDirectoryCoversNestedFilesAndEmptyDirectories(@TempDir Path dir) throws IOException {
-        Path root = Files.createDirectories(dir.resolve("root"));
-        Files.write(root.resolve("b.txt"), "b".getBytes(StandardCharsets.UTF_8));
-        Files.write(Files.createDirectories(root.resolve("nested")).resolve("a.txt"), "a".getBytes(StandardCharsets.UTF_8));
+    void uploadHashIsStableAcrossRunsAndSensitiveToContentArchivePathAndMode(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("a.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        when(s3.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder().build());
+        ObjectStorage storage = new ObjectStorage(s3, "bucket");
 
-        String base = ObjectStorage.computeHash(root, "root");
-        Files.createDirectories(root.resolve("empty"));
-        String withEmptyDir = ObjectStorage.computeHash(root, "root");
-        Files.write(root.resolve("nested/a.txt"), "a2".getBytes(StandardCharsets.UTF_8));
-        String withChangedNested = ObjectStorage.computeHash(root, "root");
+        String first = storage.upload(file, "org", "ctx/a.txt");
+        Files.setLastModifiedTime(file, java.nio.file.attribute.FileTime.fromMillis(0));
+        String afterTouch = storage.upload(file, "org", "ctx/a.txt");
+        String otherArchivePath = storage.upload(file, "org", "other/a.txt");
+        Files.setPosixFilePermissions(file, java.util.EnumSet.of(
+                java.nio.file.attribute.PosixFilePermission.OWNER_READ,
+                java.nio.file.attribute.PosixFilePermission.OWNER_WRITE,
+                java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE));
+        String afterChmod = storage.upload(file, "org", "ctx/a.txt");
+        Files.write(file, "changed".getBytes(StandardCharsets.UTF_8));
+        String afterContentChange = storage.upload(file, "org", "ctx/a.txt");
 
-        assertThat(withEmptyDir).isNotEqualTo(base);
-        assertThat(withChangedNested).isNotEqualTo(withEmptyDir);
+        assertThat(first).matches("[0-9a-f]{32}").isEqualTo(afterTouch);
+        assertThat(otherArchivePath).isNotEqualTo(first);
+        assertThat(afterChmod).isNotEqualTo(first);
+        assertThat(afterContentChange).isNotEqualTo(afterChmod);
+    }
+
+    @Test
+    void uploadHashDistinguishesDirectoryLayoutsWithIdenticalConcatenation(@TempDir Path dir) throws IOException {
+        Path first = Files.createDirectories(dir.resolve("first"));
+        Files.write(first.resolve("ab"), "c".getBytes(StandardCharsets.UTF_8));
+        Path second = Files.createDirectories(dir.resolve("second"));
+        Files.write(second.resolve("a"), "bc".getBytes(StandardCharsets.UTF_8));
+        when(s3.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder().build());
+        ObjectStorage storage = new ObjectStorage(s3, "bucket");
+
+        assertThat(storage.upload(first, "org", "root")).isNotEqualTo(storage.upload(second, "org", "root"));
+    }
+
+    @Test
+    void uploadHashMatchesUploadedArchiveBytes(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("a.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        when(s3.headObject(any(HeadObjectRequest.class))).thenThrow(NoSuchKeyException.builder().statusCode(404).build());
+        java.util.concurrent.atomic.AtomicReference<byte[]> uploaded = new java.util.concurrent.atomic.AtomicReference<>();
+        when(s3.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenAnswer(invocation -> {
+            uploaded.set(invocation.getArgument(1, RequestBody.class).contentStreamProvider().newStream().readAllBytes());
+            return PutObjectResponse.builder().build();
+        });
+
+        String hash = new ObjectStorage(s3, "bucket").upload(file, "org", "ctx/a.txt");
+
+        java.security.MessageDigest md5;
+        try {
+            md5 = java.security.MessageDigest.getInstance("MD5");
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+        StringBuilder expected = new StringBuilder();
+        for (byte b : md5.digest(uploaded.get())) {
+            expected.append(String.format("%02x", b));
+        }
+        assertThat(hash).isEqualTo(expected.toString());
     }
 
     @Test
@@ -138,6 +175,8 @@ class ObjectStorageTest {
         Files.write(root.resolve("b.txt"), "b".getBytes(StandardCharsets.UTF_8));
         Files.write(Files.createDirectories(root.resolve("nested")).resolve("a.txt"), "a".getBytes(StandardCharsets.UTF_8));
         Files.createDirectories(root.resolve("empty"));
+        Files.createSymbolicLink(root.resolve("link-to-nested"), Path.of("nested"));
+        Files.createSymbolicLink(root.resolve("link-to-b"), Path.of("b.txt"));
         when(s3.headObject(any(HeadObjectRequest.class))).thenThrow(S3Exception.builder().statusCode(404).build());
         captureUploadedTar();
 
@@ -145,8 +184,10 @@ class ObjectStorageTest {
 
         Map<String, String> entries = uploadedTar;
         assertThat(entries.keySet()).containsExactly(
-                "home/me/root/", "home/me/root/b.txt", "home/me/root/empty/", "home/me/root/nested/", "home/me/root/nested/a.txt");
-        assertThat(entries).containsEntry("home/me/root/b.txt", "b").containsEntry("home/me/root/nested/a.txt", "a");
+                "home/me/root/", "home/me/root/b.txt", "home/me/root/empty/", "home/me/root/link-to-b",
+                "home/me/root/link-to-nested", "home/me/root/nested/", "home/me/root/nested/a.txt");
+        assertThat(entries).containsEntry("home/me/root/b.txt", "b").containsEntry("home/me/root/nested/a.txt", "a")
+                .containsEntry("home/me/root/link-to-b", "-> b.txt").containsEntry("home/me/root/link-to-nested", "-> nested");
     }
 
     @Test
@@ -158,6 +199,18 @@ class ObjectStorageTest {
         assertThatThrownBy(() -> new ObjectStorage(s3, "bucket").upload(file, "org-1", "ctx/a.txt"))
                 .isInstanceOf(DaytonaException.class)
                 .hasMessageContaining("Failed to check object storage");
+    }
+
+    @Test
+    void uploadWrapsClientSideSdkErrors(@TempDir Path dir) throws IOException {
+        Path file = Files.write(dir.resolve("a.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+        when(s3.headObject(any(HeadObjectRequest.class))).thenThrow(NoSuchKeyException.builder().statusCode(404).build());
+        when(s3.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenThrow(SdkClientException.create("connection refused"));
+
+        assertThatThrownBy(() -> new ObjectStorage(s3, "bucket").upload(file, "org-1", "ctx/a.txt"))
+                .isInstanceOf(DaytonaException.class)
+                .hasMessageContaining("Failed to upload build context");
     }
 
     @Test
@@ -210,9 +263,10 @@ class ObjectStorageTest {
             List<String> hashes = ObjectStorage.processImageContext(objectStorageApi, image);
 
             List<Image.Context> contexts = image.getContexts();
-            String fileHash = ObjectStorage.computeHash(file, contexts.get(0).getArchivePath());
-            String dirHash = ObjectStorage.computeHash(src, contexts.get(1).getArchivePath());
-            assertThat(hashes).containsExactly(fileHash, dirHash);
+            assertThat(hashes).hasSize(2).allMatch(hash -> hash.matches("[0-9a-f]{32}"));
+            String fileHash = hashes.get(0);
+            String dirHash = hashes.get(1);
+            assertThat(fileHash).isNotEqualTo(dirHash);
 
             RecordedRequest head = server.takeRequest();
             assertThat(head.getMethod()).isEqualTo("HEAD");
@@ -262,7 +316,11 @@ class ObjectStorageTest {
         try (TarArchiveInputStream tar = new TarArchiveInputStream(stream)) {
             TarArchiveEntry entry;
             while ((entry = tar.getNextEntry()) != null) {
-                entries.put(entry.getName(), entry.isDirectory() ? "" : new String(tar.readAllBytes(), StandardCharsets.UTF_8));
+                if (entry.isSymbolicLink()) {
+                    entries.put(entry.getName(), "-> " + entry.getLinkName());
+                } else {
+                    entries.put(entry.getName(), entry.isDirectory() ? "" : new String(tar.readAllBytes(), StandardCharsets.UTF_8));
+                }
             }
         }
         return entries;

--- a/sdk-java/src/test/java/io/daytona/sdk/ObjectStorageTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/ObjectStorageTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -81,6 +82,7 @@ class ObjectStorageTest {
 
     @Test
     void uploadHashIsStableAcrossRunsAndSensitiveToContentArchivePathAndMode(@TempDir Path dir) throws IOException {
+        assumeTrue(Files.getFileStore(dir).supportsFileAttributeView("posix"), "requires a POSIX filesystem");
         Path file = Files.write(dir.resolve("a.txt"), "hello".getBytes(StandardCharsets.UTF_8));
         when(s3.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder().build());
         ObjectStorage storage = new ObjectStorage(s3, "bucket");
@@ -175,6 +177,7 @@ class ObjectStorageTest {
         Files.write(root.resolve("b.txt"), "b".getBytes(StandardCharsets.UTF_8));
         Files.write(Files.createDirectories(root.resolve("nested")).resolve("a.txt"), "a".getBytes(StandardCharsets.UTF_8));
         Files.createDirectories(root.resolve("empty"));
+        assumeSymlinksSupported(dir);
         Files.createSymbolicLink(root.resolve("link-to-nested"), Path.of("nested"));
         Files.createSymbolicLink(root.resolve("link-to-b"), Path.of("b.txt"));
         when(s3.headObject(any(HeadObjectRequest.class))).thenThrow(S3Exception.builder().statusCode(404).build());
@@ -308,6 +311,15 @@ class ObjectStorageTest {
             assertThat(head.getPath()).startsWith("/" + ObjectStorage.DEFAULT_BUCKET + "/org-1/");
             assertThat(head.getHeader("Authorization")).contains("/" + ObjectStorage.DEFAULT_REGION + "/s3/");
             assertThat(head.getHeader("x-amz-security-token")).isNull();
+        }
+    }
+
+    static void assumeSymlinksSupported(Path dir) {
+        try {
+            Path probe = Files.createSymbolicLink(dir.resolve("symlink-probe"), Path.of("."));
+            Files.delete(probe);
+        } catch (IOException | UnsupportedOperationException | SecurityException e) {
+            assumeTrue(false, "requires symlink support: " + e.getMessage());
         }
     }
 

--- a/sdk-java/src/test/java/io/daytona/sdk/SnapshotServiceTest.java
+++ b/sdk-java/src/test/java/io/daytona/sdk/SnapshotServiceTest.java
@@ -55,10 +55,11 @@ class SnapshotServiceTest {
     private SnapshotsApi snapshotsApi;
 
     private SnapshotService snapshotService;
+    private List<String> uploadedContexts = Collections.emptyList();
 
     @BeforeEach
     void setUp() {
-        snapshotService = new SnapshotService(snapshotsApi, new OkHttpClient(), "test-key");
+        snapshotService = new SnapshotService(snapshotsApi, new OkHttpClient(), "test-key", image -> uploadedContexts);
     }
 
     @Test
@@ -107,6 +108,31 @@ class SnapshotServiceTest {
         assertThat(captor.getValue().getCpu()).isEqualTo(2);
         assertThat(captor.getValue().getMemory()).isEqualTo(4);
         assertThat(captor.getValue().getDisk()).isEqualTo(8);
+    }
+
+    @Test
+    void createFromDeclarativeImageSendsUploadedContextHashes() {
+        uploadedContexts = Arrays.asList("hash-a", "hash-b");
+        when(snapshotsApi.createSnapshot(any(), isNull()))
+                .thenReturn(snapshotDto("snap-1", "snapshot", SnapshotState.ACTIVE));
+
+        snapshotService.create("snapshot", Image.base("python:3.12"), null);
+
+        ArgumentCaptor<CreateSnapshot> captor = ArgumentCaptor.forClass(CreateSnapshot.class);
+        verify(snapshotsApi).createSnapshot(captor.capture(), isNull());
+        assertThat(captor.getValue().getBuildInfo().getContextHashes()).containsExactly("hash-a", "hash-b");
+    }
+
+    @Test
+    void createFromDeclarativeImageDoesNotCallApiWhenContextUploadFails() {
+        SnapshotService failing = new SnapshotService(snapshotsApi, new OkHttpClient(), "test-key", image -> {
+            throw new DaytonaException("upload failed");
+        });
+
+        assertThatThrownBy(() -> failing.create("snapshot", Image.base("python:3.12"), null))
+                .isInstanceOf(DaytonaException.class)
+                .hasMessage("upload failed");
+        verify(snapshotsApi, never()).createSnapshot(any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Description

The Java SDK's `Image` builder had no way to inject local files at image build time — every other SDK has `add_local_file` / `addLocalFile` / `AddLocalFile`, so Java users could not bake local binaries/configs into snapshots (e.g. the Box Mount external-storage flow had to fall back to a runtime `fs.uploadFile` workaround).

The gap was wider than a missing builder method: the Java SDK had no build-context upload pipeline at all. This PR adds the whole path, mirroring the Python/TypeScript/Go implementations:

- **`Image.addLocalFile(localPath, remotePath)` / `Image.addLocalDir(localPath, remotePath)`** — validate the local path (`DaytonaNotFoundException` if missing, `IllegalArgumentException` on file/dir mismatch), expand a leading `~`, append the file name when `remotePath` ends with `/`, record an `Image.Context` and emit `COPY <archivePath> <remotePath>`. `Image.getContexts()` exposes the recorded contexts.
- **`ObjectStorage`** (package-private) — obtains temporary push credentials via `GET /object-storage/push-access`, packs each context into a tar (commons-compress, POSIX long names), computes the MD5 content hash used as the identifier, skips the upload when `{orgId}/{hash}/context.tar` already exists (`HEAD`), otherwise `PUT`s it. Uses AWS SDK v2 `s3` with the lightweight `url-connection-client` (Apache/Netty HTTP clients excluded), path-style addressing, chunked encoding and flexible checksums disabled for S3-compatible backend compatibility.
- **`SnapshotService.create(..., Image, ...)`** and **`Daytona.create(CreateSandboxFromImageParams, ...)`** now upload contexts first and send the resulting hashes as `CreateBuildInfo.contextHashes`. Images without contexts never touch the object-storage API.
- `examples/java/declarative-image` now uses `addLocalFile` like the Python/TS examples; generated `artifacts/sdk-docs/java-sdk/image.mdx` regenerated.

New dependencies (sdk-java): `software.amazon.awssdk:s3` + `url-connection-client` 2.54.16, `org.apache.commons:commons-compress` 1.28.0.

### Verification

- `./gradlew build` (unit tests + javadoc) green in `nix develop .#java` — 344+ tests including new `ObjectStorageTest` (hashing, tar layout, dedup, error mapping, and a `MockWebServer` test asserting the real SigV4 `HEAD`/`PUT` requests: path-style key, region in credential scope, session token header, raw tar body) and `ImageTest` coverage for both new methods.
- `examples/java/declarative-image` compiles.
- Added `E2ETest.declarativeImageWithLocalFileBakesFileIntoSandbox` (Order 22). **Not run** — no live `DAYTONA_API_KEY` available in this environment; needs a run against a live API before merge.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses daytona/daytona-ai#1088

## Notes

`archivePath` follows the Python SDK convention (normalized absolute path with the root stripped) rather than the TypeScript one (raw absolute path); both resolve identically inside the build context.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Image.addLocalFile` and `Image.addLocalDir` to the Java SDK so local files and directories can be baked into declarative images at build time, matching the other SDKs. Previously Java users had no build-context pipeline and had to fall back to a runtime `fs.uploadFile` workaround.

**New Features**
- `addLocalFile` / `addLocalDir` validate the local path (`DaytonaNotFoundException` if missing, `IllegalArgumentException` on type mismatch or filesystem root), expand a leading `~`, append the file name when `remotePath` ends with `/`, and emit a JSON-array `COPY` instruction with control characters escaped so paths with whitespace stay valid.
- Build contexts upload to Daytona object storage as deduplicated tar archives hashed from the exact archive bytes; hashes are sent as `CreateBuildInfo.contextHashes`, and images without contexts skip the object-storage API.
- Archive paths follow the Python SDK convention (normalized absolute path without the root); symlinks inside directories are preserved, while a symlinked context root is resolved first.
- Added an E2E test that bakes a local file into a Sandbox; it was not run because no live API key was available.

**Dependencies**
- Adds `software.amazon.awssdk:s3` and `url-connection-client` 2.54.16 and `org.apache.commons:commons-compress` 1.28.0.

<sup>Written for commit fdb8127ab59b4689ae4705cdde82e78551d0e8b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

