### PR TITLE
docs: fix broken Slack and DCO guideline links in contributor guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ participating, you are expected to uphold it. Please report unacceptable behavio
 Found a bug or have an idea for the SDKs, clients, or CLI? Please
 [open an issue](https://github.com/daytona/clients/issues/new) — but first check that a
 matching issue doesn't already exist. For questions and discussion, join the
-[Daytona Community Slack](https://github.com/daytona/clients/slack).
+[Daytona Community Slack](https://go.daytona.io/slack).
 
 ## What you can contribute
 

--- a/PREPARING_YOUR_CHANGES.md
+++ b/PREPARING_YOUR_CHANGES.md
@@ -2,7 +2,7 @@
 
 This document contains information related to preparing changes for a pull request. Here's a quick checklist for a good PR, more details below:
 
-1. A discussion around the change on [Slack](https://github.com/daytona/clients/slack) or in an issue.
+1. A discussion around the change on [Slack](https://go.daytona.io/slack) or in an issue.
 1. A GitHub Issue with a good description associated with the PR
 1. One feature/change per PR
 1. One commit per PR
@@ -19,7 +19,7 @@ For example, if a descriptive title covers what the commit does in practice, the
 However, if the commit has an out-sized impact relative to other commits, its description will need to reflect that.
 
 Reviewers may ask you to amend your commits if they are not descriptive enough.
-Since the descriptiveness of a commit is subjective, please feel free to talk to us on [Slack](https://github.com/daytona/clients/slack) if you have any questions.
+Since the descriptiveness of a commit is subjective, please feel free to talk to us on [Slack](https://go.daytona.io/slack) if you have any questions.
 
 ### Optional Commit Template
 
@@ -49,7 +49,7 @@ This option adds a `Signed-off-by` trailer at the end of the commit log message.
 
 ## DCO Policy on Real Names
 
-The DCO is a representation by someone stating they have the right to contribute the code they have proposed and is important for legal purposes. We have adopted the CNCF DCO Guidelines (https://github.com/cncf/foundation/blob/main/dco-guidelines.md). Which for simplicity we will include here in full:
+The DCO is a representation by someone stating they have the right to contribute the code they have proposed and is important for legal purposes. We have adopted the CNCF DCO Guidelines (https://github.com/cncf/foundation/blob/main/policies-guidance/dco-guidelines.md). Which for simplicity we will include here in full:
 
 ### DCO Guidelines v1.1
 


### PR DESCRIPTION
## Description

`CONTRIBUTING.md` and `PREPARING_YOUR_CHANGES.md` send contributors to `https://github.com/daytona/clients/slack`, which is not a real page (HTTP 404). This replaces the three occurrences with `https://go.daytona.io/slack`, the community invite link used on daytona.io, which resolves to the Daytona Community Slack join page.

`PREPARING_YOUR_CHANGES.md` also links the CNCF DCO guidelines at `cncf/foundation/blob/main/dco-guidelines.md`, which has since moved (HTTP 404). Updated to the current `policies-guidance/dco-guidelines.md` path.

Docs-only: four link changes across two files, no code changes.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

N/A: this PR is itself a docs-only change to the contributor guides.

## Related Issue(s)

No issue filed; the fix is small and self-describing (dead links confirmed with `curl`).

## Screenshots

N/A

## Notes

- `markdownlint-cli2` (repo config) reports 0 issues on both files.
- Every external link in both files now returns 2xx/3xx. The Slack short link redirects to the `daytonacommunity.slack.com` join page, which answers 403 to non-browser clients but loads normally in a browser.
- Single commit, DCO signed-off, rebased on current `main`.
