### PR TITLE
fix(sdk-python,sdk-typescript): parse Dockerfile COPY instructions correctly in from_dockerfile

### DIFF
--- a/sdk-python/src/daytona/common/image.py
+++ b/sdk-python/src/daytona/common/image.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import glob
+import json
 import os
 import re
 import shlex
@@ -509,8 +510,7 @@ class Image(BaseModel):
             list[tuple[str, str]]: The list of the actual file path and its corresponding COPY-command source path.
         """
         sources: list[tuple[str, str]] = []
-        # Split the Dockerfile into lines
-        lines = dockerfile_content.split("\n")
+        lines = Image.__dockerfile_logical_lines(dockerfile_content)
 
         for line in lines:
             # Skip empty lines and comments
@@ -549,6 +549,36 @@ class Image(BaseModel):
         return sources
 
     @staticmethod
+    def __dockerfile_logical_lines(dockerfile_content: str) -> list[str]:
+        """Joins backslash-continued physical lines into logical Dockerfile instruction lines.
+
+        Args:
+            dockerfile_content: str: The content of the Dockerfile.
+
+        Returns:
+            list[str]: The logical instruction lines.
+        """
+        logical_lines: list[str] = []
+        current: str | None = None
+
+        for physical_line in dockerfile_content.splitlines():
+            if current is not None and (not physical_line.strip() or physical_line.lstrip().startswith("#")):
+                # Docker drops empty and comment lines that appear inside a continued instruction
+                continue
+            stripped = physical_line.rstrip()
+            continued = stripped.endswith("\\")
+            segment = stripped[:-1] if continued else physical_line
+            current = segment if current is None else current + segment
+            if not continued:
+                logical_lines.append(current)
+                current = None
+
+        if current is not None:
+            logical_lines.append(current)
+
+        return logical_lines
+
+    @staticmethod
     def __parse_copy_command(line: str) -> dict[str, list[str] | str] | None:
         """Parses a COPY command to extract sources and destination.
 
@@ -561,38 +591,38 @@ class Image(BaseModel):
         # Remove initial "COPY" and strip whitespace
         parts = line.strip()[4:].strip()
 
+        # Skip leading flags such as --chown=..., --chmod=... or --link. Docker only accepts
+        # the --flag=value form, so a flag never consumes the token that follows it.
+        while parts.startswith("--"):
+            flag_and_rest = parts.split(maxsplit=1)
+            parts = flag_and_rest[1] if len(flag_and_rest) > 1 else ""
+
         # Handle JSON array format: COPY ["src1", "src2", "dest"]
         if parts.startswith("["):
             try:
-                # Parse the JSON-like array format
-                elements = shlex.split(parts.replace("[", "").replace("]", ""))
-                if len(elements) < 2:
-                    return None
-
-                return {"sources": elements[:-1], "dest": elements[-1]}
-            except:
+                decoded = cast(object, json.loads(parts))
+            except json.JSONDecodeError:
+                return None
+            if not isinstance(decoded, list):
+                return None
+            raw_elements = cast(list[object], decoded)
+            elements = [element for element in raw_elements if isinstance(element, str)]
+            if len(elements) < 2 or len(elements) != len(raw_elements):
                 return None
 
-        # Handle regular format with possible flags
-        parts = shlex.split(parts)
+            return {"sources": elements[:-1], "dest": elements[-1]}
 
-        # Extract flags like --chown, --chmod, --from
-        sources_start_idx = 0
-        for i, part in enumerate(parts):
-            if part.startswith("--"):
-                # Skip the flag and its value if it has one
-                if "=" not in part and i + 1 < len(parts) and not parts[i + 1].startswith("--"):
-                    sources_start_idx = i + 2
-                else:
-                    sources_start_idx = i + 1
-            else:
-                break
-
-        # After skipping flags, we need at least one source and one destination
-        if len(parts) - sources_start_idx < 2:
+        # Handle the whitespace-separated format
+        try:
+            elements = shlex.split(parts)
+        except ValueError:
             return None
 
-        return {"sources": parts[sources_start_idx:-1], "dest": parts[-1]}
+        # We need at least one source and one destination
+        if len(elements) < 2:
+            return None
+
+        return {"sources": elements[:-1], "dest": elements[-1]}
 
     @staticmethod
     def __flatten_str_args(args: Sequence[str | Sequence[str]]) -> list[str]:

--- a/sdk-python/tests/test_image.py
+++ b/sdk-python/tests/test_image.py
@@ -192,6 +192,71 @@ class TestImageFromDockerfile:
         with pytest.raises(DaytonaError, match="does not exist"):
             Image.from_dockerfile("/nonexistent/Dockerfile")
 
+    def test_from_dockerfile_parses_json_array_copy(self, tmp_path):
+        (tmp_path / "a.txt").write_text("a")
+        (tmp_path / "dir with space").mkdir()
+        (tmp_path / "dir with space" / "b.txt").write_text("b")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text('FROM python:3.12\nCOPY ["a.txt", "dir with space/b.txt", "/app/"]\n')
+
+        img = Image.from_dockerfile(dockerfile)
+
+        assert [c.archive_path for c in img._context_list] == ["a.txt", "dir with space/b.txt"]
+
+    def test_from_dockerfile_joins_backslash_continued_copy(self, tmp_path):
+        (tmp_path / "a.txt").write_text("a")
+        (tmp_path / "b.txt").write_text("b")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text("FROM python:3.12\nCOPY a.txt \\\n    b.txt \\\n    /app/\n")
+
+        img = Image.from_dockerfile(dockerfile)
+
+        assert [c.archive_path for c in img._context_list] == ["a.txt", "b.txt"]
+
+    def test_from_dockerfile_skips_copy_it_cannot_parse(self, tmp_path):
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text('FROM python:3.12\nCOPY "unterminated /app/\n')
+
+        img = Image.from_dockerfile(dockerfile)
+
+        assert img._context_list == []
+
+    def test_from_dockerfile_ignores_comment_lines_inside_continued_copy(self, tmp_path):
+        (tmp_path / "a.txt").write_text("a")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text("FROM python:3.12\nCOPY a.txt \\\n    # a comment inside the instruction\n    /app/\n")
+
+        img = Image.from_dockerfile(dockerfile)
+
+        assert [c.archive_path for c in img._context_list] == ["a.txt"]
+
+    def test_from_dockerfile_ignores_blank_lines_inside_continued_copy(self, tmp_path):
+        (tmp_path / "a.txt").write_text("a")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text("FROM python:3.12\nCOPY a.txt \\\n\n    /app/\n")
+
+        img = Image.from_dockerfile(dockerfile)
+
+        assert [c.archive_path for c in img._context_list] == ["a.txt"]
+
+    def test_from_dockerfile_keeps_sources_after_boolean_copy_flag(self, tmp_path):
+        (tmp_path / "a.txt").write_text("a")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text("FROM python:3.12\nCOPY --link a.txt /app/\n")
+
+        img = Image.from_dockerfile(dockerfile)
+
+        assert [c.archive_path for c in img._context_list] == ["a.txt"]
+
+    def test_from_dockerfile_parses_json_array_copy_after_flags(self, tmp_path):
+        (tmp_path / "a.txt").write_text("a")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text('FROM python:3.12\nCOPY --chown=1000:1000 --link ["a.txt", "/app/"]\n')
+
+        img = Image.from_dockerfile(dockerfile)
+
+        assert [c.archive_path for c in img._context_list] == ["a.txt"]
+
 
 class TestImageDockerfileCommands:
     def test_add_dockerfile_commands(self):

--- a/sdk-typescript/src/Image.ts
+++ b/sdk-typescript/src/Image.ts
@@ -602,6 +602,38 @@ export class Image {
   }
 
   /**
+   * Joins backslash-continued physical lines into logical Dockerfile instruction lines.
+   *
+   * @param {string} dockerfileContent - The content of the Dockerfile.
+   * @returns {string[]} The logical instruction lines.
+   */
+  private static dockerfileLogicalLines(dockerfileContent: string): string[] {
+    const logicalLines: string[] = []
+    let current: string | null = null
+
+    for (const physicalLine of dockerfileContent.split(/\r?\n/)) {
+      if (current !== null && (!physicalLine.trim() || physicalLine.trimStart().startsWith('#'))) {
+        // Docker drops empty and comment lines that appear inside a continued instruction
+        continue
+      }
+      const stripped = physicalLine.trimEnd()
+      const continued = stripped.endsWith('\\')
+      const segment = continued ? stripped.slice(0, -1) : physicalLine
+      current = current === null ? segment : current + segment
+      if (!continued) {
+        logicalLines.push(current)
+        current = null
+      }
+    }
+
+    if (current !== null) {
+      logicalLines.push(current)
+    }
+
+    return logicalLines
+  }
+
+  /**
    * Extracts source files from COPY commands in a Dockerfile.
    *
    * @param {string} dockerfileContent - The content of the Dockerfile.
@@ -610,7 +642,7 @@ export class Image {
    */
   private static extractCopySources(dockerfileContent: string, pathPrefix = ''): Array<[string, string]> {
     const sources: Array<[string, string]> = []
-    const lines = dockerfileContent.split('\n')
+    const lines = Image.dockerfileLogicalLines(dockerfileContent)
 
     for (const line of lines) {
       // Skip empty lines and comments
@@ -659,56 +691,48 @@ export class Image {
    */
   private static parseCopyCommand(line: string): { sources: string[]; dest: string } | null {
     // Remove initial "COPY" and strip whitespace
-    const parts = line.trim().substring(4).trim()
+    let parts = line.trim().substring(4).trim()
+
+    // Skip leading flags such as --chown=..., --chmod=... or --link. Docker only accepts
+    // the --flag=value form, so a flag never consumes the token that follows it.
+    while (parts.startsWith('--')) {
+      parts = parts.replace(/^\S+\s*/, '')
+    }
 
     // Handle JSON array format: COPY ["src1", "src2", "dest"]
     if (parts.startsWith('[')) {
+      let decoded: unknown
       try {
-        // Parse the JSON-like array format
-        const elements = parseShellQuote(parts.replace('[', '').replace(']', '')).filter(
-          (x): x is string => typeof x === 'string',
-        )
-
-        if (elements.length < 2) {
-          return null
-        }
-
-        return {
-          sources: elements.slice(0, -1),
-          dest: elements[elements.length - 1],
-        }
+        decoded = JSON.parse(parts)
       } catch {
         return null
       }
-    }
 
-    // Handle regular format with possible flags
-    const splitParts = parseShellQuote(parts).filter((x): x is string => typeof x === 'string')
+      if (!Array.isArray(decoded) || !decoded.every((element): element is string => typeof element === 'string')) {
+        return null
+      }
 
-    // Extract flags like --chown, --chmod, --from
-    let sourcesStartIdx = 0
-    for (let i = 0; i < splitParts.length; i++) {
-      const part = splitParts[i]
-      if (part.startsWith('--')) {
-        // Skip the flag and its value if it has one
-        if (!part.includes('=') && i + 1 < splitParts.length && !splitParts[i + 1].startsWith('--')) {
-          sourcesStartIdx = i + 2
-        } else {
-          sourcesStartIdx = i + 1
-        }
-      } else {
-        break
+      if (decoded.length < 2) {
+        return null
+      }
+
+      return {
+        sources: decoded.slice(0, -1),
+        dest: decoded[decoded.length - 1],
       }
     }
 
-    // After skipping flags, we need at least one source and one destination
-    if (splitParts.length - sourcesStartIdx < 2) {
+    // Handle the whitespace-separated format
+    const elements = parseShellQuote(parts).filter((x): x is string => typeof x === 'string')
+
+    // We need at least one source and one destination
+    if (elements.length < 2) {
       return null
     }
 
     return {
-      sources: splitParts.slice(sourcesStartIdx, -1),
-      dest: splitParts[splitParts.length - 1],
+      sources: elements.slice(0, -1),
+      dest: elements[elements.length - 1],
     }
   }
 }

--- a/sdk-typescript/src/__tests__/Image.test.ts
+++ b/sdk-typescript/src/__tests__/Image.test.ts
@@ -341,7 +341,60 @@ describe('Image', () => {
       dest: string
     }
 
-    expect(parsed).toEqual({ sources: ['./a.txt,', './b.txt,'], dest: '/app/' })
+    expect(parsed).toEqual({ sources: ['./a.txt', './b.txt'], dest: '/app/' })
+  })
+
+  it('extractCopySources joins backslash-continued COPY instructions', async () => {
+    const { Image } = await import('../Image')
+    const fastGlob = { sync: jest.fn((patterns: string[]) => patterns) }
+    mockDynamicRequire.mockImplementation((moduleName: string) => {
+      if (moduleName === 'fast-glob') return fastGlob
+      return {}
+    })
+
+    const imageRuntime = Image as unknown as Record<string, (...args: unknown[]) => unknown>
+    const sources = imageRuntime.extractCopySources(
+      ['COPY a.txt \\', '    b.txt \\', '    /app/'].join('\n'),
+      '/repo',
+    ) as Array<[string, string]>
+
+    expect(sources).toEqual([
+      ['/repo/a.txt', 'a.txt'],
+      ['/repo/b.txt', 'b.txt'],
+    ])
+  })
+
+  it('extractCopySources ignores comment lines inside a continued COPY instruction', async () => {
+    const { Image } = await import('../Image')
+    const fastGlob = { sync: jest.fn((patterns: string[]) => patterns) }
+    mockDynamicRequire.mockImplementation((moduleName: string) => {
+      if (moduleName === 'fast-glob') return fastGlob
+      return {}
+    })
+
+    const imageRuntime = Image as unknown as Record<string, (...args: unknown[]) => unknown>
+    const sources = imageRuntime.extractCopySources(
+      ['COPY a.txt \\', '    # a comment inside the instruction', '    /app/'].join('\n'),
+      '/repo',
+    ) as Array<[string, string]>
+
+    expect(sources).toEqual([['/repo/a.txt', 'a.txt']])
+  })
+
+  it('extractCopySources ignores blank lines inside a continued COPY instruction', async () => {
+    const { Image } = await import('../Image')
+    const fastGlob = { sync: jest.fn((patterns: string[]) => patterns) }
+    mockDynamicRequire.mockImplementation((moduleName: string) => {
+      if (moduleName === 'fast-glob') return fastGlob
+      return {}
+    })
+
+    const imageRuntime = Image as unknown as Record<string, (...args: unknown[]) => unknown>
+    const sources = imageRuntime.extractCopySources(['COPY a.txt \\', '', '    /app/'].join('\n'), '/repo') as Array<
+      [string, string]
+    >
+
+    expect(sources).toEqual([['/repo/a.txt', 'a.txt']])
   })
 
   it('extractCopySources ignores heredoc and stage copy commands', async () => {
@@ -359,5 +412,23 @@ describe('Image', () => {
     ) as Array<[string, string]>
 
     expect(sources).toEqual([['/repo/a.txt', './b.txt']])
+  })
+
+  it('parseCopyCommand keeps the sources after a boolean flag such as --link', async () => {
+    const { Image } = await import('../Image')
+    const imageRuntime = Image as unknown as Record<string, (...args: unknown[]) => unknown>
+
+    const parsed = imageRuntime.parseCopyCommand('COPY --link a.txt /app/')
+
+    expect(parsed).toEqual({ sources: ['a.txt'], dest: '/app/' })
+  })
+
+  it('parseCopyCommand handles flags before a json array copy command', async () => {
+    const { Image } = await import('../Image')
+    const imageRuntime = Image as unknown as Record<string, (...args: unknown[]) => unknown>
+
+    const parsed = imageRuntime.parseCopyCommand('COPY --chown=1000:1000 --link ["a.txt", "/app/"]')
+
+    expect(parsed).toEqual({ sources: ['a.txt'], dest: '/app/' })
   })
 })


### PR DESCRIPTION
## Description

`Image.from_dockerfile` (Python) and `Image.fromDockerfile` (TypeScript) scan the Dockerfile for `COPY` instructions to find the local files that must be uploaded as build context. That scan mis-handled several valid Dockerfile forms:

- **JSON-array form** (`COPY ["src", "dest"]`) was split with a shell tokenizer after stripping the brackets, so every source but the last kept a trailing comma (`src,`) and never matched a real file, and a compact `COPY ["a","b"]` was dropped entirely.
- **Backslash line continuations** were not joined. A `COPY` wrapped across lines crashed the Python SDK with an uncaught `ValueError: No escaped character` from `shlex` (reported in daytonaio/daytona#5148 with a real-world traceback) and silently lost the continued sources in the TypeScript SDK.
- A line that `shlex` could not tokenize (for example an unterminated quote) raised the same uncaught `ValueError` instead of being skipped, which is what the JSON branch already did.
- A **boolean flag** such as `--link` consumed the following source path, and flags placed before a JSON array made the array fall through to the shell tokenizer.

The fix parses the JSON form with a real JSON parser, joins continued lines (dropping empty and comment lines inside a continuation, as Docker does), treats every leading `--flag` token as a flag on its own (Docker only accepts the `--flag=value` form), and skips lines that cannot be tokenized. Only context discovery changes; the Dockerfile content is still passed through to the build unchanged.

Both SDKs get the same behavior and the same set of tests. The existing TypeScript test `parseCopyCommand handles json array copy commands` asserted the comma-suffixed sources (`'./a.txt,'`); its expectation is corrected.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

No public signatures or docstrings change; only private helpers.

## Related Issue(s)

Reported in daytonaio/daytona#5148 (that repository is no longer maintained). No issue filed here.

## Screenshots

N/A

## Notes

Verified locally:

- Python: `sdk-python/tests/test_image.py` 42 passed (7 new); full `sdk-python` unit suite 640 passed, 0 skipped; `basedpyright` 0 errors / 0 warnings; `pylint`, `black`, `isort` clean.
- TypeScript: `sdk-typescript` jest suite 412 passed across 20 suites, 0 skipped (5 new tests plus the corrected one); `eslint`, `prettier`, and the CI `tsc --verbatimModuleSyntax` check clean.
- Each behavior was added as a failing test first and then made to pass.

Not covered: the Ruby SDK has the same `parse_copy_command` / `extract_copy_sources` pair and the same defects; I could not run its test suite locally (no modern Ruby toolchain), so it is left for a follow-up rather than shipped unverified. `# escape=` parser directives are not interpreted (the backslash is always the continuation character).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Dockerfile `COPY` instruction parsing in `Image.from_dockerfile` (Python) and `Image.fromDockerfile` (TypeScript) so valid Dockerfiles no longer lose build context files or crash.

- JSON-array `COPY` commands previously left trailing commas on sources; they are now parsed as JSON.
- Backslash-continued `COPY` lines previously crashed the Python SDK and silently lost sources in TypeScript; continued lines are now joined as Docker does.
- Lines that cannot be tokenized (e.g., unterminated quotes) are skipped instead of raising a `ValueError`.
- Boolean flags like `--link` no longer consume the following source path, and flags before a JSON array are handled.
- Only context discovery changes; the Dockerfile content passed to the build is unchanged.
- The Ruby SDK has the same parsing defects but is left for a follow-up.

<sup>Written for commit 4dd51331d8fb5fb9975013a9a2a801f7be9eb02f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytona/clients/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

